### PR TITLE
Bug fix in cdr_solver which reset weights from data on wrong level. 

### DIFF
--- a/src/cdr_solver/cdr_solver.cpp
+++ b/src/cdr_solver/cdr_solver.cpp
@@ -1025,7 +1025,7 @@ void cdr_solver::reset_redist_weights(const EBAMRCellData& a_state){
 
       if(has_coar){
 	EBFineToCoarRedist& fine2coar = *m_amr->get_fine_to_coar_redist(m_realm, m_phase)[lvl];
-	fine2coar.resetWeights(*a_state[lvl], comp);
+	fine2coar.resetWeights(*a_state[lvl-1], comp);
       }
       if(has_fine){
 	EBCoarToCoarRedist& coar2coar = *m_amr->get_coar_to_coar_redist(m_realm, m_phase)[lvl];


### PR DESCRIPTION
This broke code that had EBCF crossings and used mass-weighted redistribution. 