### PR TITLE
Time step computation for advection-diffusion code

### DIFF
--- a/physics/advection_diffusion/advection_diffusion_stepper.cpp
+++ b/physics/advection_diffusion/advection_diffusion_stepper.cpp
@@ -195,7 +195,7 @@ void advection_diffusion_stepper::compute_dt(Real& a_dt, time_code& a_timecode){
     
   // CFL on diffusion, if explicit diffusion
   if(m_solver->is_diffusive() && m_integrator == 0){
-    diff_dt = m_solver->compute_diffusive_dt();
+    diff_dt = m_solver->compute_diffusion_dt();
 
     if(m_solver->is_mobile()){
       a_dt = m_cfl*1./(1./cfl_dt + 1./diff_dt);

--- a/physics/cdr_plasma/cdr_plasma_stepper.H
+++ b/physics/cdr_plasma/cdr_plasma_stepper.H
@@ -287,7 +287,7 @@ namespace physics {
       /*!
 	@brief Compute the time step and how it was restricted
       */
-      virtual void compute_dt(Real& a_dt, time_code& a_timecode);
+      virtual void compute_dt(Real& a_dt, time_code& a_timecode) = 0;
 
       /*!
 	@brief Compute the cell-centered electric field on both phases

--- a/physics/cdr_plasma/cdr_plasma_stepper.cpp
+++ b/physics/cdr_plasma/cdr_plasma_stepper.cpp
@@ -2552,52 +2552,6 @@ void cdr_plasma_stepper::compute_cdr_diffusion(const EBAMRCellData& a_E_cell, co
   }
 }
 
-void cdr_plasma_stepper::compute_dt(Real& a_dt, time_code& a_timecode){
-  CH_TIME("cdr_plasma_stepper::compute_dt");
-  if(m_verbosity > 5){
-    pout() << "cdr_plasma_stepper::compute_dt" << endl;
-  }
-
-  Real dt = 1.E99;
-
-  m_dt_cfl          = m_cdr->compute_cfl_dt();
-  const Real dt_cfl = m_cfl*m_dt_cfl;
-  if(dt_cfl < dt){
-    dt = dt_cfl;
-    a_timecode = time_code::cfl;
-  }
-  
-  const Real dt_dif = m_cfl*m_cdr->compute_diffusive_dt();
-  if(dt_dif < dt){
-    dt = dt_dif;
-    a_timecode = time_code::diffusion;
-  }
-
-  const Real dt_relax = m_relax_time*this->compute_relaxation_time();
-  if(dt_relax < dt){
-    dt = dt_relax;
-    a_timecode = time_code::relaxation_time;
-  }
-
-  const Real dt_restrict = this->restrict_dt();
-  if(dt_restrict < dt){
-    dt = dt_restrict;
-    a_timecode = time_code::restricted;
-  }
-
-  if(dt < m_min_dt){
-    dt = m_min_dt;
-    a_timecode = time_code::hardcap;
-  }
-
-  if(dt > m_max_dt){
-    dt = m_max_dt;
-    a_timecode = time_code::hardcap;
-  }
-
-  a_dt = dt;
-}
-
 void cdr_plasma_stepper::compute_E(MFAMRCellData& a_E, const MFAMRCellData& a_potential){
   CH_TIME("cdr_plasma_stepper::compute_E(mfamrcell, mfamrcell)");
   if(m_verbosity > 5){
@@ -4379,29 +4333,29 @@ void cdr_plasma_stepper::print_step_report(){
   const Real cfl_dt = this->get_cfl_dt();
 
   std::string str;
-  if(m_timecode == time_code::cfl){
-    str = " (Restricted by CFL)";
+  if(m_timecode == time_code::advection){
+    str = " (Restricted by advection)";
   }
-  if(m_timecode == time_code::adv_diffusion){
+  else if(m_timecode == time_code::advection_diffusion){
     str = " (Restricted by advection-diffusion)";
-    }
-  if(m_timecode == time_code::error){
+  }
+  else if(m_timecode == time_code::error){
     str = " (Restricted by error)";
   }
-  if(m_timecode == time_code::diffusion){
+  else if(m_timecode == time_code::diffusion){
     str = " (Restricted by diffusion)";
   }
-  if(m_timecode == time_code::source){
+  else if(m_timecode == time_code::source){
     MayDay::Abort("driver::step_report - shouldn't happen, source term has been taken out of the design");
     str = " (Restricted by source term)";
   }
-  if(m_timecode == time_code::relaxation_time){
+  else if(m_timecode == time_code::relaxation_time){
     str = " (Restricted by relaxation time)";
   }
-  if(m_timecode == time_code::restricted){
+  else if(m_timecode == time_code::restricted){
     str = " (Restricted by time stepper)";
   }
-  if(m_timecode == time_code::hardcap){
+  else if(m_timecode == time_code::hardcap){
     str = " (Restricted by a hardcap)";
   }
   pout() << "                                   mode  = " << str << endl

--- a/physics/cdr_plasma/time_steppers/imex_sdc/imex_sdc.cpp
+++ b/physics/cdr_plasma/time_steppers/imex_sdc/imex_sdc.cpp
@@ -1208,7 +1208,7 @@ void imex_sdc::compute_dt(Real& a_dt, time_code& a_timecode){
     Nref = Nref*m_amr->get_ref_rat()[lvl];
   }
   const Real max_gl_dist = imex_sdc::get_max_node_distance();
-  m_dt_cfl = m_cdr->compute_cfl_dt();
+  m_dt_cfl = m_cdr->compute_advection_dt();
 
   Real dt_cfl = 2.0*m_dt_cfl/max_gl_dist;
   
@@ -1216,7 +1216,7 @@ void imex_sdc::compute_dt(Real& a_dt, time_code& a_timecode){
   if(!m_adaptive_dt){
     if(dt_cfl < dt){
       dt = m_cfl*dt_cfl;
-      a_timecode = time_code::cfl;
+      a_timecode = time_code::advection;
     }
   }
   else{

--- a/src/cdr_solver/cdr_layout.H
+++ b/src/cdr_solver/cdr_layout.H
@@ -181,12 +181,17 @@ public:
   /*!
     @brief Get largest possible time step for advection part
   */
-  virtual Real compute_cfl_dt();
+  virtual Real compute_advection_dt();
 
   /*!
     @brief Get largest possible time step for diffusion part
   */
-  virtual Real compute_diffusive_dt();
+  virtual Real compute_diffusion_dt();
+
+  /*!
+    @brief Get largest possible time step for diffusion part
+  */
+  virtual Real compute_advection_diffusion_dt();
 
   /*!
     @brief Get largest possible time step for source term

--- a/src/cdr_solver/cdr_layoutI.H
+++ b/src/cdr_solver/cdr_layoutI.H
@@ -373,17 +373,17 @@ void cdr_layout<T>::write_plot_file(){
 }
 
 template <class T>
-Real cdr_layout<T>::compute_cfl_dt(){
-  CH_TIME("cdr_layout<T>::compute_cfl_dt");
+Real cdr_layout<T>::compute_advection_dt(){
+  CH_TIME("cdr_layout<T>::compute_advection_dt");
   if(m_verbosity > 5){
-    pout() << "cdr_layout<T>::compute_cfl_dt" << endl;
+    pout() << "cdr_layout<T>::compute_advection_dt" << endl;
   }
 
   Real dt = 1.E99;
   
   for (cdr_iterator<T> solver_it = this->iterator(); solver_it.ok(); ++solver_it){
     RefCountedPtr<cdr_solver>& solver = solver_it();
-    const Real this_dt = solver->compute_cfl_dt();
+    const Real this_dt = solver->compute_advection_dt();
 
     dt = Min(dt, this_dt);
   }
@@ -392,17 +392,36 @@ Real cdr_layout<T>::compute_cfl_dt(){
 }
 
 template <class T>
-Real cdr_layout<T>::compute_diffusive_dt(){
-  CH_TIME("cdr_layout<T>::compute_diffusive_dt");
+Real cdr_layout<T>::compute_diffusion_dt(){
+  CH_TIME("cdr_layout<T>::compute_diffusion_dt");
   if(m_verbosity > 5){
-    pout() << "cdr_layout<T>::compute_diffusive_dt" << endl;
+    pout() << "cdr_layout<T>::compute_diffusion_dt" << endl;
   }
 
   Real dt = 1.E99;
   
   for (cdr_iterator<T> solver_it = this->iterator(); solver_it.ok(); ++solver_it){
     RefCountedPtr<cdr_solver>& solver = solver_it();
-    const Real this_dt = solver->compute_diffusive_dt();
+    const Real this_dt = solver->compute_diffusion_dt();
+
+    dt = Min(dt, this_dt);
+  }
+
+  return dt;
+}
+
+template <class T>
+Real cdr_layout<T>::compute_advection_diffusion_dt(){
+  CH_TIME("cdr_layout<T>::compute_advection_diffusion_dt");
+  if(m_verbosity > 5){
+    pout() << "cdr_layout<T>::compute_advection_diffusion_dt" << endl;
+  }
+
+  Real dt = 1.E99;
+  
+  for (cdr_iterator<T> solver_it = this->iterator(); solver_it.ok(); ++solver_it){
+    RefCountedPtr<cdr_solver>& solver = solver_it();
+    const Real this_dt = solver->compute_advection_diffusion_dt();
 
     dt = Min(dt, this_dt);
   }

--- a/src/cdr_solver/cdr_solver.H
+++ b/src/cdr_solver/cdr_solver.H
@@ -334,11 +334,6 @@ public:
   virtual int get_num_plotvars() const;
 
   /*!
-    @brief Compute the largest possible advection time step (for explicit methods)
-  */
-  virtual Real compute_cfl_dt();
-
-  /*!
     @brief Compute the largest possible diffusive time step (for explicit methods)
   */
   virtual Real compute_advection_dt();

--- a/src/cdr_solver/cdr_solver.H
+++ b/src/cdr_solver/cdr_solver.H
@@ -341,7 +341,17 @@ public:
   /*!
     @brief Compute the largest possible diffusive time step (for explicit methods)
   */
-  virtual Real compute_diffusive_dt();
+  virtual Real compute_advection_dt();
+
+  /*!
+    @brief Compute the largest possible diffusive time step (for explicit methods)
+  */
+  virtual Real compute_diffusion_dt();
+
+  /*!
+    @brief Compute the largest possible diffusive time step (for explicit methods)
+  */
+  virtual Real compute_advection_diffusion_dt();
 
   /*!
     @brief Compute the largest possible source time step (for explicit methods

--- a/src/cdr_solver/cdr_solverF.ChF
+++ b/src/cdr_solver/cdr_solverF.ChF
@@ -67,35 +67,6 @@
       return
       end
 
-      subroutine advective_cfl(
-     &     chf_const_fra[velo],
-     &     chf_const_real[dx],
-     &     chf_box[dcalc],
-     &     chf_real[min_dt])
-
-      real_t vel, dt
-      integer chf_ddecl[i; j; k]
-
-#if CH_SPACEDIM==3
-      do k = CHF_LBOUND[dcalc;2], CHF_UBOUND[dcalc;2]
-#endif
-         do j = CHF_LBOUND[dcalc;1], CHF_UBOUND[dcalc;1]
-            do i = CHF_LBOUND[dcalc;0], CHF_UBOUND[dcalc;0]
-     	       vel = CHF_DTERM[
-     &                velo(chf_ix[i;j;k],0)*velo(chf_ix[i;j;k],0);
-     &              + velo(chf_ix[i;j;k],1)*velo(chf_ix[i;j;k],1);
-     &              + velo(chf_ix[i;j;k],2)*velo(chf_ix[i;j;k],2)]
-     	       dt = dx/sqrt(vel)
-     	       min_dt = min(dt, min_dt)
-            enddo
-         enddo
-#if CH_SPACEDIM==3
-      enddo
-#endif
-
-      return
-      end
-
 
       subroutine source_dt(
      &     chf_real[min_dt],
@@ -158,7 +129,7 @@
       return
       end
 
-      subroutine advective_cfl_dt(
+      subroutine advection_dt(
      &     chf_const_fra[velo],
      &     chf_const_real[dx],
      &     chf_box[dcalc],

--- a/src/cdr_solver/cdr_solverF.ChF
+++ b/src/cdr_solver/cdr_solverF.ChF
@@ -130,12 +130,12 @@
       end
 
       subroutine advection_dt(
+     &     chf_fra1[min_dt],      
      &     chf_const_fra[velo],
      &     chf_const_real[dx],
-     &     chf_box[dcalc],
-     &     chf_real[min_dt])
+     &     chf_box[dcalc])
 
-      real_t vel, dt
+      real_t vel
       integer chf_ddecl[i; j; k]
 
 #if CH_SPACEDIM==3
@@ -147,8 +147,7 @@
      &                abs(velo(chf_ix[i;j;k],0));
      &              + abs(velo(chf_ix[i;j;k],1));
      &              + abs(velo(chf_ix[i;j;k],2))]
-     	       dt = dx/vel
-     	       min_dt = min(dt, min_dt)
+     	       min_dt(chf_ix[i;j;k]) = dx/vel
             enddo
          enddo
 #if CH_SPACEDIM==3
@@ -158,7 +157,7 @@
       return
       end
 
-      subroutine diffusive_dt(
+      subroutine diffusion_dt(
      &     chf_const_fra1[diffco],
      &     chf_const_real[dx],
      &     chf_box[facebox],

--- a/src/cdr_solver/cdr_solverF.ChF
+++ b/src/cdr_solver/cdr_solverF.ChF
@@ -164,7 +164,7 @@
      &     chf_const_int[facedir],
      &     chf_box[cellbox])
 
-      real_t D, Dlo, Dhi
+      real_t D, Dlo, Dhi, dt
       integer chf_ddecl[i; j; k]
 
       integer chf_ddecl[ioff; joff; koff]
@@ -176,9 +176,86 @@
          Dlo = diffco(chf_ix[i;      j;      k])
          Dhi = diffco(chf_ix[i+ioff; j+joff; k+koff])      	 
          D   = max(Dlo, Dhi)
+         dt  = dx*dx/(2*CH_SPACEDIM*D)
 	 
-         min_dt(chf_ix[i;j;k]) = dx*dx/(2*CH_SPACEDIM*D)
+         min_dt(chf_ix[i;j;k]) = min(min_dt(chf_ix[i;j;k]), dt)
       chf_enddo	 
+
+      return
+      end
+
+      subroutine advection_diffusion_dt_one(
+     &     chf_fra1[invDt],      
+     &     chf_const_fra1[diffco],
+     &     chf_const_real[dx],
+     &     chf_const_int[facedir],
+     &     chf_box[cellbox])
+
+      real_t D, Dlo, Dhi, idt
+      integer chf_ddecl[i; j; k]
+
+      integer chf_ddecl[ioff; joff; koff]
+      chf_dterm[ioff = chf_id(0,facedir);
+                joff = chf_id(1,facedir);
+                koff = chf_id(2,facedir)]
+      		
+      chf_multido[cellbox; i;j; k]
+         Dlo = diffco(chf_ix[i;      j;      k])
+         Dhi = diffco(chf_ix[i+ioff; j+joff; k+koff])      	 
+         D   = max(Dlo, Dhi)
+         idt = (2*CH_SPACEDIM*D)/dx*dx
+	 
+         invDt(chf_ix[i;j;k]) = max(invDt(chf_ix[i;j;k]), idt)
+      chf_enddo	 
+
+      return
+      end
+
+      subroutine advection_diffusion_dt_two(
+     &     chf_fra1[invDt],      
+     &     chf_const_fra[velo],
+     &     chf_const_real[dx],
+     &     chf_box[dcalc])
+
+      real_t vel
+      integer chf_ddecl[i; j; k]
+
+#if CH_SPACEDIM==3
+      do k = CHF_LBOUND[dcalc;2], CHF_UBOUND[dcalc;2]
+#endif
+         do j = CHF_LBOUND[dcalc;1], CHF_UBOUND[dcalc;1]
+            do i = CHF_LBOUND[dcalc;0], CHF_UBOUND[dcalc;0]
+     	       vel = CHF_DTERM[
+     &                abs(velo(chf_ix[i;j;k],0));
+     &              + abs(velo(chf_ix[i;j;k],1));
+     &              + abs(velo(chf_ix[i;j;k],2))]
+     	       invDt(chf_ix[i;j;k]) = invDt(chf_ix[i;j;k]) + vel/dx
+            enddo
+         enddo
+#if CH_SPACEDIM==3
+      enddo
+#endif
+
+      return
+      end
+
+      subroutine advection_diffusion_dt_invert(
+     &     chf_fra1[invDt],      
+     &     chf_box[dcalc])
+
+      integer chf_ddecl[i; j; k]
+
+#if CH_SPACEDIM==3
+      do k = CHF_LBOUND[dcalc;2], CHF_UBOUND[dcalc;2]
+#endif
+         do j = CHF_LBOUND[dcalc;1], CHF_UBOUND[dcalc;1]
+            do i = CHF_LBOUND[dcalc;0], CHF_UBOUND[dcalc;0]
+     	       invDt(chf_ix[i;j;k]) = 1.0/invDt(chf_ix[i;j;k])
+            enddo
+         enddo
+#if CH_SPACEDIM==3
+      enddo
+#endif
 
       return
       end
@@ -246,4 +323,5 @@
          divD(chf_ix[i;j;k]) = dco(chf_ix[i;j;k])*(hival-loval)*idx
       chf_enddo
       return
-      end      
+      end
+

--- a/src/cdr_solver/cdr_solverF.ChF
+++ b/src/cdr_solver/cdr_solverF.ChF
@@ -158,17 +158,26 @@
       end
 
       subroutine diffusion_dt(
+     &     chf_fra1[min_dt],      
      &     chf_const_fra1[diffco],
      &     chf_const_real[dx],
-     &     chf_box[facebox],
-     &     chf_real[min_dt])
+     &     chf_const_int[facedir],
+     &     chf_box[cellbox])
 
-      real_t dt
+      real_t D, Dlo, Dhi
       integer chf_ddecl[i; j; k]
 
-      chf_multido[facebox; i;j; k]
-         dt = dx*dx/(2*CH_SPACEDIM*diffco(chf_ix[i;j;k]))
-         min_dt = min(dt, min_dt);
+      integer chf_ddecl[ioff; joff; koff]
+      chf_dterm[ioff = chf_id(0,facedir);
+                joff = chf_id(1,facedir);
+                koff = chf_id(2,facedir)]
+      		
+      chf_multido[cellbox; i;j; k]
+         Dlo = diffco(chf_ix[i;      j;      k])
+         Dhi = diffco(chf_ix[i+ioff; j+joff; k+koff])      	 
+         D   = max(Dlo, Dhi)
+	 
+         min_dt(chf_ix[i;j;k]) = dx*dx/(2*CH_SPACEDIM*D)
       chf_enddo	 
 
       return

--- a/src/cdr_solver/cdr_solverF_F.H
+++ b/src/cdr_solver/cdr_solverF_F.H
@@ -196,26 +196,29 @@ inline void FORTRAN_NAME(inlineADVECTION_DT, inlineADVECTION_DT)(
 // Prototype for Fortran procedure diffusion_dt ...
 //
 void FORTRAN_NAME( DIFFUSION_DT ,diffusion_dt )(
-      CHFp_CONST_FRA1(diffco)
+      CHFp_FRA1(min_dt)
+      ,CHFp_CONST_FRA1(diffco)
       ,CHFp_CONST_REAL(dx)
-      ,CHFp_BOX(facebox)
-      ,CHFp_REAL(min_dt) );
+      ,CHFp_CONST_INT(facedir)
+      ,CHFp_BOX(cellbox) );
 
 #define FORT_DIFFUSION_DT FORTRAN_NAME( inlineDIFFUSION_DT, inlineDIFFUSION_DT)
 #define FORTNT_DIFFUSION_DT FORTRAN_NAME( DIFFUSION_DT, diffusion_dt)
 
 inline void FORTRAN_NAME(inlineDIFFUSION_DT, inlineDIFFUSION_DT)(
-      CHFp_CONST_FRA1(diffco)
+      CHFp_FRA1(min_dt)
+      ,CHFp_CONST_FRA1(diffco)
       ,CHFp_CONST_REAL(dx)
-      ,CHFp_BOX(facebox)
-      ,CHFp_REAL(min_dt) )
+      ,CHFp_CONST_INT(facedir)
+      ,CHFp_BOX(cellbox) )
 {
  CH_TIMELEAF("FORT_DIFFUSION_DT");
  FORTRAN_NAME( DIFFUSION_DT ,diffusion_dt )(
-      CHFt_CONST_FRA1(diffco)
+      CHFt_FRA1(min_dt)
+      ,CHFt_CONST_FRA1(diffco)
       ,CHFt_CONST_REAL(dx)
-      ,CHFt_BOX(facebox)
-      ,CHFt_REAL(min_dt) );
+      ,CHFt_CONST_INT(facedir)
+      ,CHFt_BOX(cellbox) );
 }
 #endif  // GUARDDIFFUSION_DT 
 

--- a/src/cdr_solver/cdr_solverF_F.H
+++ b/src/cdr_solver/cdr_solverF_F.H
@@ -222,6 +222,87 @@ inline void FORTRAN_NAME(inlineDIFFUSION_DT, inlineDIFFUSION_DT)(
 }
 #endif  // GUARDDIFFUSION_DT 
 
+#ifndef GUARDADVECTION_DIFFUSION_DT_ONE 
+#define GUARDADVECTION_DIFFUSION_DT_ONE 
+// Prototype for Fortran procedure advection_diffusion_dt_one ...
+//
+void FORTRAN_NAME( ADVECTION_DIFFUSION_DT_ONE ,advection_diffusion_dt_one )(
+      CHFp_FRA1(invDt)
+      ,CHFp_CONST_FRA1(diffco)
+      ,CHFp_CONST_REAL(dx)
+      ,CHFp_CONST_INT(facedir)
+      ,CHFp_BOX(cellbox) );
+
+#define FORT_ADVECTION_DIFFUSION_DT_ONE FORTRAN_NAME( inlineADVECTION_DIFFUSION_DT_ONE, inlineADVECTION_DIFFUSION_DT_ONE)
+#define FORTNT_ADVECTION_DIFFUSION_DT_ONE FORTRAN_NAME( ADVECTION_DIFFUSION_DT_ONE, advection_diffusion_dt_one)
+
+inline void FORTRAN_NAME(inlineADVECTION_DIFFUSION_DT_ONE, inlineADVECTION_DIFFUSION_DT_ONE)(
+      CHFp_FRA1(invDt)
+      ,CHFp_CONST_FRA1(diffco)
+      ,CHFp_CONST_REAL(dx)
+      ,CHFp_CONST_INT(facedir)
+      ,CHFp_BOX(cellbox) )
+{
+ CH_TIMELEAF("FORT_ADVECTION_DIFFUSION_DT_ONE");
+ FORTRAN_NAME( ADVECTION_DIFFUSION_DT_ONE ,advection_diffusion_dt_one )(
+      CHFt_FRA1(invDt)
+      ,CHFt_CONST_FRA1(diffco)
+      ,CHFt_CONST_REAL(dx)
+      ,CHFt_CONST_INT(facedir)
+      ,CHFt_BOX(cellbox) );
+}
+#endif  // GUARDADVECTION_DIFFUSION_DT_ONE 
+
+#ifndef GUARDADVECTION_DIFFUSION_DT_TWO 
+#define GUARDADVECTION_DIFFUSION_DT_TWO 
+// Prototype for Fortran procedure advection_diffusion_dt_two ...
+//
+void FORTRAN_NAME( ADVECTION_DIFFUSION_DT_TWO ,advection_diffusion_dt_two )(
+      CHFp_FRA1(invDt)
+      ,CHFp_CONST_FRA(velo)
+      ,CHFp_CONST_REAL(dx)
+      ,CHFp_BOX(dcalc) );
+
+#define FORT_ADVECTION_DIFFUSION_DT_TWO FORTRAN_NAME( inlineADVECTION_DIFFUSION_DT_TWO, inlineADVECTION_DIFFUSION_DT_TWO)
+#define FORTNT_ADVECTION_DIFFUSION_DT_TWO FORTRAN_NAME( ADVECTION_DIFFUSION_DT_TWO, advection_diffusion_dt_two)
+
+inline void FORTRAN_NAME(inlineADVECTION_DIFFUSION_DT_TWO, inlineADVECTION_DIFFUSION_DT_TWO)(
+      CHFp_FRA1(invDt)
+      ,CHFp_CONST_FRA(velo)
+      ,CHFp_CONST_REAL(dx)
+      ,CHFp_BOX(dcalc) )
+{
+ CH_TIMELEAF("FORT_ADVECTION_DIFFUSION_DT_TWO");
+ FORTRAN_NAME( ADVECTION_DIFFUSION_DT_TWO ,advection_diffusion_dt_two )(
+      CHFt_FRA1(invDt)
+      ,CHFt_CONST_FRA(velo)
+      ,CHFt_CONST_REAL(dx)
+      ,CHFt_BOX(dcalc) );
+}
+#endif  // GUARDADVECTION_DIFFUSION_DT_TWO 
+
+#ifndef GUARDADVECTION_DIFFUSION_DT_INVERT 
+#define GUARDADVECTION_DIFFUSION_DT_INVERT 
+// Prototype for Fortran procedure advection_diffusion_dt_invert ...
+//
+void FORTRAN_NAME( ADVECTION_DIFFUSION_DT_INVERT ,advection_diffusion_dt_invert )(
+      CHFp_FRA1(invDt)
+      ,CHFp_BOX(dcalc) );
+
+#define FORT_ADVECTION_DIFFUSION_DT_INVERT FORTRAN_NAME( inlineADVECTION_DIFFUSION_DT_INVERT, inlineADVECTION_DIFFUSION_DT_INVERT)
+#define FORTNT_ADVECTION_DIFFUSION_DT_INVERT FORTRAN_NAME( ADVECTION_DIFFUSION_DT_INVERT, advection_diffusion_dt_invert)
+
+inline void FORTRAN_NAME(inlineADVECTION_DIFFUSION_DT_INVERT, inlineADVECTION_DIFFUSION_DT_INVERT)(
+      CHFp_FRA1(invDt)
+      ,CHFp_BOX(dcalc) )
+{
+ CH_TIMELEAF("FORT_ADVECTION_DIFFUSION_DT_INVERT");
+ FORTRAN_NAME( ADVECTION_DIFFUSION_DT_INVERT ,advection_diffusion_dt_invert )(
+      CHFt_FRA1(invDt)
+      ,CHFt_BOX(dcalc) );
+}
+#endif  // GUARDADVECTION_DIFFUSION_DT_INVERT 
+
 #ifndef GUARDCONSDIV_BLOCK 
 #define GUARDCONSDIV_BLOCK 
 // Prototype for Fortran procedure consdiv_block ...

--- a/src/cdr_solver/cdr_solverF_F.H
+++ b/src/cdr_solver/cdr_solverF_F.H
@@ -168,56 +168,56 @@ inline void FORTRAN_NAME(inlineGET_MAXNORM, inlineGET_MAXNORM)(
 // Prototype for Fortran procedure advection_dt ...
 //
 void FORTRAN_NAME( ADVECTION_DT ,advection_dt )(
-      CHFp_CONST_FRA(velo)
+      CHFp_FRA1(min_dt)
+      ,CHFp_CONST_FRA(velo)
       ,CHFp_CONST_REAL(dx)
-      ,CHFp_BOX(dcalc)
-      ,CHFp_REAL(min_dt) );
+      ,CHFp_BOX(dcalc) );
 
 #define FORT_ADVECTION_DT FORTRAN_NAME( inlineADVECTION_DT, inlineADVECTION_DT)
 #define FORTNT_ADVECTION_DT FORTRAN_NAME( ADVECTION_DT, advection_dt)
 
 inline void FORTRAN_NAME(inlineADVECTION_DT, inlineADVECTION_DT)(
-      CHFp_CONST_FRA(velo)
+      CHFp_FRA1(min_dt)
+      ,CHFp_CONST_FRA(velo)
       ,CHFp_CONST_REAL(dx)
-      ,CHFp_BOX(dcalc)
-      ,CHFp_REAL(min_dt) )
+      ,CHFp_BOX(dcalc) )
 {
  CH_TIMELEAF("FORT_ADVECTION_DT");
  FORTRAN_NAME( ADVECTION_DT ,advection_dt )(
-      CHFt_CONST_FRA(velo)
+      CHFt_FRA1(min_dt)
+      ,CHFt_CONST_FRA(velo)
       ,CHFt_CONST_REAL(dx)
-      ,CHFt_BOX(dcalc)
-      ,CHFt_REAL(min_dt) );
+      ,CHFt_BOX(dcalc) );
 }
 #endif  // GUARDADVECTION_DT 
 
-#ifndef GUARDDIFFUSIVE_DT 
-#define GUARDDIFFUSIVE_DT 
-// Prototype for Fortran procedure diffusive_dt ...
+#ifndef GUARDDIFFUSION_DT 
+#define GUARDDIFFUSION_DT 
+// Prototype for Fortran procedure diffusion_dt ...
 //
-void FORTRAN_NAME( DIFFUSIVE_DT ,diffusive_dt )(
+void FORTRAN_NAME( DIFFUSION_DT ,diffusion_dt )(
       CHFp_CONST_FRA1(diffco)
       ,CHFp_CONST_REAL(dx)
       ,CHFp_BOX(facebox)
       ,CHFp_REAL(min_dt) );
 
-#define FORT_DIFFUSIVE_DT FORTRAN_NAME( inlineDIFFUSIVE_DT, inlineDIFFUSIVE_DT)
-#define FORTNT_DIFFUSIVE_DT FORTRAN_NAME( DIFFUSIVE_DT, diffusive_dt)
+#define FORT_DIFFUSION_DT FORTRAN_NAME( inlineDIFFUSION_DT, inlineDIFFUSION_DT)
+#define FORTNT_DIFFUSION_DT FORTRAN_NAME( DIFFUSION_DT, diffusion_dt)
 
-inline void FORTRAN_NAME(inlineDIFFUSIVE_DT, inlineDIFFUSIVE_DT)(
+inline void FORTRAN_NAME(inlineDIFFUSION_DT, inlineDIFFUSION_DT)(
       CHFp_CONST_FRA1(diffco)
       ,CHFp_CONST_REAL(dx)
       ,CHFp_BOX(facebox)
       ,CHFp_REAL(min_dt) )
 {
- CH_TIMELEAF("FORT_DIFFUSIVE_DT");
- FORTRAN_NAME( DIFFUSIVE_DT ,diffusive_dt )(
+ CH_TIMELEAF("FORT_DIFFUSION_DT");
+ FORTRAN_NAME( DIFFUSION_DT ,diffusion_dt )(
       CHFt_CONST_FRA1(diffco)
       ,CHFt_CONST_REAL(dx)
       ,CHFt_BOX(facebox)
       ,CHFt_REAL(min_dt) );
 }
-#endif  // GUARDDIFFUSIVE_DT 
+#endif  // GUARDDIFFUSION_DT 
 
 #ifndef GUARDCONSDIV_BLOCK 
 #define GUARDCONSDIV_BLOCK 

--- a/src/cdr_solver/cdr_solverF_F.H
+++ b/src/cdr_solver/cdr_solverF_F.H
@@ -76,34 +76,6 @@ inline void FORTRAN_NAME(inlineCONSDIV_REG, inlineCONSDIV_REG)(
 }
 #endif  // GUARDCONSDIV_REG 
 
-#ifndef GUARDADVECTIVE_CFL 
-#define GUARDADVECTIVE_CFL 
-// Prototype for Fortran procedure advective_cfl ...
-//
-void FORTRAN_NAME( ADVECTIVE_CFL ,advective_cfl )(
-      CHFp_CONST_FRA(velo)
-      ,CHFp_CONST_REAL(dx)
-      ,CHFp_BOX(dcalc)
-      ,CHFp_REAL(min_dt) );
-
-#define FORT_ADVECTIVE_CFL FORTRAN_NAME( inlineADVECTIVE_CFL, inlineADVECTIVE_CFL)
-#define FORTNT_ADVECTIVE_CFL FORTRAN_NAME( ADVECTIVE_CFL, advective_cfl)
-
-inline void FORTRAN_NAME(inlineADVECTIVE_CFL, inlineADVECTIVE_CFL)(
-      CHFp_CONST_FRA(velo)
-      ,CHFp_CONST_REAL(dx)
-      ,CHFp_BOX(dcalc)
-      ,CHFp_REAL(min_dt) )
-{
- CH_TIMELEAF("FORT_ADVECTIVE_CFL");
- FORTRAN_NAME( ADVECTIVE_CFL ,advective_cfl )(
-      CHFt_CONST_FRA(velo)
-      ,CHFt_CONST_REAL(dx)
-      ,CHFt_BOX(dcalc)
-      ,CHFt_REAL(min_dt) );
-}
-#endif  // GUARDADVECTIVE_CFL 
-
 #ifndef GUARDSOURCE_DT 
 #define GUARDSOURCE_DT 
 // Prototype for Fortran procedure source_dt ...
@@ -191,33 +163,33 @@ inline void FORTRAN_NAME(inlineGET_MAXNORM, inlineGET_MAXNORM)(
 }
 #endif  // GUARDGET_MAXNORM 
 
-#ifndef GUARDADVECTIVE_CFL_DT 
-#define GUARDADVECTIVE_CFL_DT 
-// Prototype for Fortran procedure advective_cfl_dt ...
+#ifndef GUARDADVECTION_DT 
+#define GUARDADVECTION_DT 
+// Prototype for Fortran procedure advection_dt ...
 //
-void FORTRAN_NAME( ADVECTIVE_CFL_DT ,advective_cfl_dt )(
+void FORTRAN_NAME( ADVECTION_DT ,advection_dt )(
       CHFp_CONST_FRA(velo)
       ,CHFp_CONST_REAL(dx)
       ,CHFp_BOX(dcalc)
       ,CHFp_REAL(min_dt) );
 
-#define FORT_ADVECTIVE_CFL_DT FORTRAN_NAME( inlineADVECTIVE_CFL_DT, inlineADVECTIVE_CFL_DT)
-#define FORTNT_ADVECTIVE_CFL_DT FORTRAN_NAME( ADVECTIVE_CFL_DT, advective_cfl_dt)
+#define FORT_ADVECTION_DT FORTRAN_NAME( inlineADVECTION_DT, inlineADVECTION_DT)
+#define FORTNT_ADVECTION_DT FORTRAN_NAME( ADVECTION_DT, advection_dt)
 
-inline void FORTRAN_NAME(inlineADVECTIVE_CFL_DT, inlineADVECTIVE_CFL_DT)(
+inline void FORTRAN_NAME(inlineADVECTION_DT, inlineADVECTION_DT)(
       CHFp_CONST_FRA(velo)
       ,CHFp_CONST_REAL(dx)
       ,CHFp_BOX(dcalc)
       ,CHFp_REAL(min_dt) )
 {
- CH_TIMELEAF("FORT_ADVECTIVE_CFL_DT");
- FORTRAN_NAME( ADVECTIVE_CFL_DT ,advective_cfl_dt )(
+ CH_TIMELEAF("FORT_ADVECTION_DT");
+ FORTRAN_NAME( ADVECTION_DT ,advection_dt )(
       CHFt_CONST_FRA(velo)
       ,CHFt_CONST_REAL(dx)
       ,CHFt_BOX(dcalc)
       ,CHFt_REAL(min_dt) );
 }
-#endif  // GUARDADVECTIVE_CFL_DT 
+#endif  // GUARDADVECTION_DT 
 
 #ifndef GUARDDIFFUSIVE_DT 
 #define GUARDDIFFUSIVE_DT 

--- a/src/driver/time_stepper.H
+++ b/src/driver/time_stepper.H
@@ -15,32 +15,18 @@
 /*!
   @brief Time code for output
 */
-#if 0 // Orignal code
-namespace time_code {
-  enum which_code {
-    cfl             = 0,
-    diffusion       = 1,
-    source          = 2,
-    relaxation_time = 3,
-    restricted      = 4,
-    hardcap         = 5,
-    error           = 6,
-    adv_diffusion   = 7,
-  };
-};
-#else
 enum class time_code {
-  cfl,
+  advection,
   diffusion,
+  advection_diffusion,  
   source,
   relaxation_time,
   restricted,
   hardcap,
   error,
-  adv_diffusion,
+
   physics
 };
-#endif
 
 /*!
   @brief Abstract class for performing time stepping


### PR DESCRIPTION
The advection-diffusion code used dt = 1/(1/dtA + 1/dtD) where dtA was the smallest global advection step and dtD was the smallest global diffusion step. 

This was done for simplicity but both dtA and dtD should be computed locally in each cell, which is what this PR does. 

CDR-related code has updated for advection_diffusion_stepper and cdr_plasma. 

Closes #27 