### PR TITLE
Removed calls to tiled code

### DIFF
--- a/src/cdr_solver/cdr_solver.cpp
+++ b/src/cdr_solver/cdr_solver.cpp
@@ -718,30 +718,11 @@ void cdr_solver::consdiv_regular(LevelData<EBCellFAB>& a_divJ, const LevelData<E
       const EBFaceFAB& flx         = a_flux[dit()][dir];
       const BaseFab<Real>& flx_fab = flx.getSingleValuedFAB();
 
-      ParmParse pp ("cache_blocking");
-
-      int block_loops = 0;
-      pp.query("tile_loops", block_loops);
-      if(block_loops==0){
-	FORT_CONSDIV_REG(CHF_FRA1(divJ_fab, comp),
-			 CHF_CONST_FRA1(flx_fab, comp),
-			 CHF_CONST_INT(dir),
-			 CHF_CONST_REAL(dx),
-			 CHF_BOX(box));
-      }
-      else{
-	Vector<int> tilesize(SpaceDim);
-	pp.getarr("tile_size", tilesize, 0, SpaceDim);
-	pout() << tilesize << endl;
-	Vector<Box> boxes = m_amr->make_tiles(box, IntVect(D_DECL(tilesize[0], tilesize[1], tilesize[2])));
-	for (int ibox = 0; ibox < boxes.size(); ibox++){
-	  FORT_CONSDIV_REG(CHF_FRA1(divJ_fab, comp),
-			   CHF_CONST_FRA1(flx_fab, comp),
-			   CHF_CONST_INT(dir),
-			   CHF_CONST_REAL(dx),
-			   CHF_BOX(boxes[ibox]));
-	}
-      }
+      FORT_CONSDIV_REG(CHF_FRA1(divJ_fab, comp),
+		       CHF_CONST_FRA1(flx_fab, comp),
+		       CHF_CONST_INT(dir),
+		       CHF_CONST_REAL(dx),
+		       CHF_BOX(box));
     }
 
     VoFIterator& vofit = (*m_amr->get_vofit(m_realm, m_phase)[a_lvl])[dit()];

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -866,8 +866,6 @@ void driver::run(const Real a_start_time, const Real a_end_time, const int a_max
 #endif
 
       // Rebuild input parameters
-      // MPI_Barrier(Chombo_MPI::comm);
-      // Real TT = -MPI_Wtime();
       this->rebuildParmParse();
       this->parse_runtime_options();
       m_amr->parse_runtime_options();
@@ -875,8 +873,6 @@ void driver::run(const Real a_start_time, const Real a_end_time, const int a_max
       if(!m_celltagger.isNull()){
 	m_celltagger->parse_runtime_options();
       }
-      // TT += MPI_Wtime();
-      // if(procID() == 0) std::cout << TT << std::endl;
     }
   }
 

--- a/src/elliptic/jump_bcI.H
+++ b/src/elliptic/jump_bcI.H
@@ -10,7 +10,7 @@
 
 #include "jump_bc.H"
 
-#define DEBUG_JUMP 1
+#define DEBUG_JUMP 0
 
 inline
 void jump_bc::compute_avg_jump(const BaseIVFAB<Real>& a_jump, const MFCellFAB& a_phi, const DataIndex& a_dit){


### PR DESCRIPTION
Redefining ParmParse without clearing the previous table gave a performance hit. 

This PR removes some ParmParse-related code. 

Closes #39 