### PR TITLE
Moving load balancing routines for Electrostatics

### DIFF
--- a/Physics/Electrostatics/CD_FieldStepper.H
+++ b/Physics/Electrostatics/CD_FieldStepper.H
@@ -63,11 +63,11 @@ namespace Physics {
       void preRegrid(const int a_lbase, const int a_finestLevel) override;
       bool loadBalanceThisRealm(const std::string a_realm) const override;
       void loadBalanceBoxes(Vector<Vector<int> >&            a_procs,
-			      Vector<Vector<Box> >&            a_boxes,
-			      const std::string                a_realm,
-			      const Vector<DisjointBoxLayout>& a_grids,
-			      const int                        a_lmin,
-			      const int                        a_finestLevel) override;
+			    Vector<Vector<Box> >&            a_boxes,
+			    const std::string                a_realm,
+			    const Vector<DisjointBoxLayout>& a_grids,
+			    const int                        a_lmin,
+			    const int                        a_finestLevel) override;
       void regrid(const int a_lmin, const int a_oldFinestLevel, const int a_newFinestLevel) override;
       void postRegrid() override;
 
@@ -80,7 +80,7 @@ namespace Physics {
       BoxSorting m_boxSort;
 
       RefCountedPtr<FieldSolver> m_fieldSolver;
-      RefCountedPtr<SigmaSolver>   m_sigma;
+      RefCountedPtr<SigmaSolver> m_sigma;
 
       std::string m_realm;
 

--- a/Physics/Electrostatics/CD_FieldStepperImplem.H
+++ b/Physics/Electrostatics/CD_FieldStepperImplem.H
@@ -255,7 +255,11 @@ namespace Physics {
 	  dit.mergeTime();
 
 	  // Now do the load balancing. When we do this, the boxes are standard-sorted! I.e. the new mesh ignores the desired sorting from AmrMesh
+#if 0 // old way
 	  Vector<unsigned long long> loads = dit.getTime();
+#else // new awy
+	  Vector<long long> loads = m_fieldSolver->computeLoads(a_grids[lvl], lvl);
+#endif
 	  a_boxes[lvl] = dit.getBoxes();
 
 	  // Do the desired sorting

--- a/Physics/Electrostatics/CD_FieldStepperImplem.H
+++ b/Physics/Electrostatics/CD_FieldStepperImplem.H
@@ -205,11 +205,11 @@ namespace Physics {
 
     template <class T>
     void FieldStepper<T>::loadBalanceBoxes(Vector<Vector<int> >&            a_procs,
-					      Vector<Vector<Box> >&            a_boxes,
-					      const std::string                a_realm,
-					      const Vector<DisjointBoxLayout>& a_grids,
-					      const int                        a_lmin,
-					      const int                        a_finestLevel){
+					   Vector<Vector<Box> >&            a_boxes,
+					   const std::string                a_realm,
+					   const Vector<DisjointBoxLayout>& a_grids,
+					   const int                        a_lmin,
+					   const int                        a_finestLevel){
       if(m_loadBalance){
 	constexpr int num_apply = 50;
 	

--- a/Physics/Electrostatics/CD_FieldStepperImplem.H
+++ b/Physics/Electrostatics/CD_FieldStepperImplem.H
@@ -4,8 +4,8 @@
  */
 
 /*!
-  @file   FieldStepperImplem.H
-  @brief  Implementation of FieldStepper.H
+  @file   CD_FieldStepperImplem.H
+  @brief  Implementation of CD_FieldStepper.H
   @author Robert Marskar
 */
 
@@ -14,7 +14,6 @@
 
 // Chombo includes
 #include <ParmParse.H>
-#include <EBEllipticLoadBalance.H>
 
 // Our includes
 #include <CD_FieldStepper.H>
@@ -211,68 +210,23 @@ namespace Physics {
 					   const int                        a_lmin,
 					   const int                        a_finestLevel){
       if(m_loadBalance){
-	constexpr int num_apply = 50;
-	
 	a_procs.resize(1+a_finestLevel);
 	a_boxes.resize(1+a_finestLevel);
 
-	FieldSolverMultigrid* solver = (FieldSolverMultigrid*) (&(*m_fieldSolver));
-
-	MFAMRCellData dummy1, dummy2;
-
-	m_amr->allocate(dummy1, m_realm, 1);
-	m_amr->allocate(dummy2, m_realm, 1);
-
-	const Vector<ProblemDomain>& domains = m_amr->getDomains();
-
-	// We need to make AmrMesh restore some operators that we need. This is overkill because we only need
-	// operators for ghost cell interpolation....
-
+	// We need to make AmrMesh restore some operators that we need. Note that this is overkill because we only need
+	// the multigrid ghost cell interpolation operator. But for simplicity, do all of them. 
 	m_amr->regridOperators(a_lmin, a_finestLevel, 1);
 
-	// Set up the operator factor and fetch it.
-	solver->setMultigridCoefficients();
-	solver->setupOperatorFactory();
-	RefCountedPtr<MfHelmholtzOpFactory>& factory = solver->getOperatorFactory();
 
-	// Go through each level and load balance. 
+	// Field solver implementation gets the responsibility of computing loads on each level. 
 	for (int lvl = 0; lvl <= a_finestLevel; lvl++){
-	  // Make an operator
-	  auto oper = RefCountedPtr<MfHelmholtzOp> ((MfHelmholtzOp*) factory->MGnewOp(domains[lvl], 0, false));
-
-	  // Reset time
-	  TimedDataIterator dit = a_grids[lvl].timedDataIterator();
-	  dit.clearTime();
-	  dit.enableTime();
-
-	  // Do some relaxations on each level. This includes BCs.
-	  for (int k = 0; k < num_apply; k++){
-	    oper->applyOp(*dummy1[lvl], *dummy2[lvl], dit, true);
-	  }
-
-	  // Merge times
-	  dit.disableTime();
-	  dit.mergeTime();
-
-	  // Now do the load balancing. When we do this, the boxes are standard-sorted! I.e. the new mesh ignores the desired sorting from AmrMesh
-#if 0 // old way
-	  Vector<unsigned long long> loads = dit.getTime();
-#else // new awy
 	  Vector<long long> loads = m_fieldSolver->computeLoads(a_grids[lvl], lvl);
-#endif
-	  a_boxes[lvl] = dit.getBoxes();
 
-	  // Do the desired sorting
-	  LoadBalancing::sort(a_boxes[lvl], loads, m_boxSort);
-
-	  // Bah - need long long for LoadBalance
-	  Vector<long long> lloads(loads.size());
-	  for (int i = 0; i < loads.size(); i++){
-	    lloads[i] = (long long) loads[i];
-	  }
+	  // Do the desired sorting and load balancing
+	  a_boxes[lvl] = a_grids[lvl].boxArray();
 	  
-	  // Do the friggin load balancing. 
-	  LoadBalancing::makeBalance(a_procs[lvl], lloads, a_boxes[lvl]);
+	  LoadBalancing::sort(a_boxes[lvl], loads, m_boxSort);
+	  LoadBalancing::makeBalance(a_procs[lvl], loads, a_boxes[lvl]);
 	}
       }
     }

--- a/Physics/Electrostatics/python/app_main.py
+++ b/Physics/Electrostatics/python/app_main.py
@@ -15,7 +15,7 @@ def write_template(args):
     mainf = open(main_filename, "w")
     mainf.write('#include <CD_Driver.H>\n')
     mainf.write('#include <CD_' + args.field_solver + '.H>\n')
-    mainf.write('#include <CD' + args.geometry + '.H>\n')
+    mainf.write('#include <CD_' + args.geometry + '.H>\n')
     mainf.write('#include <CD_FieldStepper.H>\n')
     mainf.write('#include <ParmParse.H>\n')
     mainf.write("\n")

--- a/Source/Electrostatics/CD_FieldSolver.H
+++ b/Source/Electrostatics/CD_FieldSolver.H
@@ -277,6 +277,11 @@ public:
   virtual Vector<std::string> getPlotVariableNames() const;
 
   /*!
+    @brief Get computational loads for a level
+  */
+  virtual Vector<long long> computeLoads(const DisjointBoxLayout& a_dbl, const int a_level);
+
+  /*!
     @brief Get the Realm where this solver is registered. 
   */
   const std::string getRealm() const;

--- a/Source/Electrostatics/CD_FieldSolver.H
+++ b/Source/Electrostatics/CD_FieldSolver.H
@@ -278,6 +278,8 @@ public:
 
   /*!
     @brief Get computational loads for a level
+    @return Loads for each box on a grid level. 
+    @note The return vector should have the same order as the boxes in a_dbl. E.g. ret[0] must be the load for a_dbl.boxArray()[0];
   */
   virtual Vector<long long> computeLoads(const DisjointBoxLayout& a_dbl, const int a_level);
 

--- a/Source/Electrostatics/CD_FieldSolver.cpp
+++ b/Source/Electrostatics/CD_FieldSolver.cpp
@@ -842,6 +842,33 @@ Vector<std::string> FieldSolver::getPlotVariableNames() const {
   return names;
 }
 
+Vector<long long> FieldSolver::computeLoads(const DisjointBoxLayout& a_dbl, const int a_level){
+  CH_TIME("FieldSolver::computeLoads");
+  if(m_verbosity > 5){
+    pout() << "FieldSolver::computeLoads" << endl;
+  }
+
+  // Compute number of cells
+  Vector<int> numCells(a_dbl.size(), 0);
+  for (DataIterator dit = a_dbl.dataIterator(); dit.ok(); ++dit){
+    numCells[dit().intCode()] = a_dbl[dit()].numPts();
+  }
+
+#ifdef CH_MPI
+  int count = numCells.size();
+  Vector<int> tmp(count);
+  MPI_Allreduce(&(numCells[0]),&(tmp[0]), count, MPI_INT, MPI_SUM, Chombo_MPI::comm);
+  numCells = tmp;
+#endif
+
+  Vector<long long> loads(numCells.size());
+  for (int i = 0; i < loads.size(); i++){
+    loads[i] = (long long) numCells[i];
+  }
+
+  return loads;
+}
+
 Real FieldSolver::getTime() const{
   return m_time;
 }

--- a/Source/Electrostatics/CD_FieldSolverMultigrid.H
+++ b/Source/Electrostatics/CD_FieldSolverMultigrid.H
@@ -162,6 +162,11 @@ public:
     @brief Get irregular b coefficient
   */
   virtual MFAMRIVData& getBCoefficientIrreg();
+
+  /*!
+    @brief Compute grid loads
+  */
+  virtual Vector<long long> computeLoads(const DisjointBoxLayout& a_dbl, const int a_level) override;
   
 protected:
 

--- a/Source/Electrostatics/CD_FieldSolverMultigrid.cpp
+++ b/Source/Electrostatics/CD_FieldSolverMultigrid.cpp
@@ -786,7 +786,9 @@ Vector<long long> FieldSolverMultigrid::computeLoads(const DisjointBoxLayout& a_
 
   delete oper;
 
-  return FieldSolver::computeLoads(a_dbl, a_level);
+  return ret;
+
+  //  return FieldSolver::computeLoads(a_dbl, a_level);
 }
 
 MFAMRCellData& FieldSolverMultigrid::getACoefficient(){

--- a/Source/Electrostatics/CD_FieldSolverMultigrid.cpp
+++ b/Source/Electrostatics/CD_FieldSolverMultigrid.cpp
@@ -741,6 +741,10 @@ void FieldSolverMultigrid::setupMultigridSolver(){
   m_multigridSolver.init(phi, rhs, finest_level, 0);
 }
 
+Vector<long long> FieldSolverMultigrid::computeLoads(const DisjointBoxLayout& a_dbl, const int a_level) {
+  return FieldSolver::computeLoads(a_dbl, a_level);
+}
+
 MFAMRCellData& FieldSolverMultigrid::getACoefficient(){
   return m_aCoef;
 }


### PR DESCRIPTION
Physics/Electrostatics now just calls the load balancing routine from the FieldSolver. The previous functionality did an explicit cast, which breaks when we use different field solvers. 

Closes #68 