### PR TITLE
Improvement of curvature-based refinement

### DIFF
--- a/Regression/AdvectionDiffusion/RodSphere/regression2d.inputs
+++ b/Regression/AdvectionDiffusion/RodSphere/regression2d.inputs
@@ -56,7 +56,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = false         # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 0.0           # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = 0             # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/AdvectionDiffusion/RodSphere/regression3d.inputs
+++ b/Regression/AdvectionDiffusion/RodSphere/regression3d.inputs
@@ -56,7 +56,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = false         # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/CdrPlasma/Air7Stephens/regression2d.inputs
+++ b/Regression/CdrPlasma/Air7Stephens/regression2d.inputs
@@ -62,7 +62,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/CdrPlasma/Air9EedBourdon/regression2d.inputs
+++ b/Regression/CdrPlasma/Air9EedBourdon/regression2d.inputs
@@ -62,7 +62,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = false         # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/CdrPlasma/AirStreamer/regression2d.inputs
+++ b/Regression/CdrPlasma/AirStreamer/regression2d.inputs
@@ -60,7 +60,7 @@ Driver.plt_vars                        = 0                # 'tags', 'mpi_rank', 
 Driver.restart                         = 0                # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = false            # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1               # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1               # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1               # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/CdrPlasma/AirStreamer/regression3d.inputs
+++ b/Regression/CdrPlasma/AirStreamer/regression3d.inputs
@@ -60,7 +60,7 @@ Driver.plt_vars                        = 0                # 'tags', 'mpi_rank', 
 Driver.restart                         = 0                # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true             # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1               # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1               # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1               # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/CdrPlasma/ImExSDC/regression2d.inputs
+++ b/Regression/CdrPlasma/ImExSDC/regression2d.inputs
@@ -62,7 +62,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = false         # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/CdrPlasma/ImExSDC/template.inputs
+++ b/Regression/CdrPlasma/ImExSDC/template.inputs
@@ -59,7 +59,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Electrostatics/FieldSolverProxy/debug.inputs
+++ b/Regression/Electrostatics/FieldSolverProxy/debug.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = 0                # 'tags', 'mpi_rank', 
 Driver.restart                         = 0                # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true             # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 100              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1                # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1               # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1               # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Electrostatics/FieldSolverProxy/debug3d.inputs
+++ b/Regression/Electrostatics/FieldSolverProxy/debug3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = 0                # 'tags', 'mpi_rank', 
 Driver.restart                         = 0                # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true             # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 0              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = 0                # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = 10               # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = 0               # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Electrostatics/FieldSolverProxy/template.inputs
+++ b/Regression/Electrostatics/FieldSolverProxy/template.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = 0                # 'tags', 'mpi_rank', 
 Driver.restart                         = 0                # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true             # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1               # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1               # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1               # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Electrostatics/MechShaft/regression3d.inputs
+++ b/Regression/Electrostatics/MechShaft/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset      # 'tags', 'mpi_r
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 100.          # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = 0             # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Electrostatics/Profile/regression2d_circle.inputs
+++ b/Regression/Electrostatics/Profile/regression2d_circle.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = levelset mpi_rank             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Electrostatics/Profile/regression2d_square.inputs
+++ b/Regression/Electrostatics/Profile/regression2d_square.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = levelset      # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 20.           # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = 1             # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Electrostatics/RodSphere/debug_plane.inputs
+++ b/Regression/Electrostatics/RodSphere/debug_plane.inputs
@@ -56,7 +56,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Electrostatics/RodSphere/debug_rod.inputs
+++ b/Regression/Electrostatics/RodSphere/debug_rod.inputs
@@ -56,7 +56,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Electrostatics/RodSphere/regression2d.inputs
+++ b/Regression/Electrostatics/RodSphere/regression2d.inputs
@@ -56,7 +56,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Electrostatics/RodSphere/regression3d.inputs
+++ b/Regression/Electrostatics/RodSphere/regression3d.inputs
@@ -56,7 +56,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/Aerosol/regression2d.inputs
+++ b/Regression/Geometry/Aerosol/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = levelset mpi_rank             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/Aerosol/regression3d.inputs
+++ b/Regression/Geometry/Aerosol/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = levelset mpi_rank             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/Aerosol/template.inputs
+++ b/Regression/Geometry/Aerosol/template.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank', 'le
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/CoaxialCable/regression2d.inputs
+++ b/Regression/Geometry/CoaxialCable/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/CoaxialCable/regression3d.inputs
+++ b/Regression/Geometry/CoaxialCable/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/DoubleRod/regression2d.inputs
+++ b/Regression/Geometry/DoubleRod/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = levelset mpi_rank             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/DoubleRod/regression3d.inputs
+++ b/Regression/Geometry/DoubleRod/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = levelset mpi_rank             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/DoubleRod/template.inputs
+++ b/Regression/Geometry/DoubleRod/template.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank', 'le
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/ElectrodeArray/regression2d.inputs
+++ b/Regression/Geometry/ElectrodeArray/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset # 'tags', 'mpi_rank',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/ElectrodeArray/regression3d.inputs
+++ b/Regression/Geometry/ElectrodeArray/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset # 'tags', 'mpi_rank',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/ElectrodeArray/template.inputs
+++ b/Regression/Geometry/ElectrodeArray/template.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank', 'le
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/MechanicalShaft/regression3d.inputs
+++ b/Regression/Geometry/MechanicalShaft/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/MechanicalShaft/template.inputs
+++ b/Regression/Geometry/MechanicalShaft/template.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank', 'le
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RegularGeometry/regression2d.inputs
+++ b/Regression/Geometry/RegularGeometry/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset      # 'tags', 'mpi_r
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RegularGeometry/regression3d.inputs
+++ b/Regression/Geometry/RegularGeometry/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RegularGeometry/template.inputs
+++ b/Regression/Geometry/RegularGeometry/template.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank', 'le
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RodBox/regression2d.inputs
+++ b/Regression/Geometry/RodBox/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RodBox/regression3d.inputs
+++ b/Regression/Geometry/RodBox/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RodBox/template.inputs
+++ b/Regression/Geometry/RodBox/template.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank', 'le
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RodPerlinBox/regression2d.inputs
+++ b/Regression/Geometry/RodPerlinBox/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RodPerlinBox/regression3d.inputs
+++ b/Regression/Geometry/RodPerlinBox/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RodPerlinBox/template.inputs
+++ b/Regression/Geometry/RodPerlinBox/template.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank', 'le
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RodPlane/regression2d.inputs
+++ b/Regression/Geometry/RodPlane/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RodPlane/regression3d.inputs
+++ b/Regression/Geometry/RodPlane/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RodPlane/template.inputs
+++ b/Regression/Geometry/RodPlane/template.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank', 'le
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RodSphere/regression2d.inputs
+++ b/Regression/Geometry/RodSphere/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RodSphere/regression3d.inputs
+++ b/Regression/Geometry/RodSphere/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RodSphere/template.inputs
+++ b/Regression/Geometry/RodSphere/template.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank', 'le
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RoughRod/regression2d.inputs
+++ b/Regression/Geometry/RoughRod/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RoughRod/regression3d.inputs
+++ b/Regression/Geometry/RoughRod/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RoughSphere/regression2d.inputs
+++ b/Regression/Geometry/RoughSphere/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset # 'tags', 'mpi_rank',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/RoughSphere/regression3d.inputs
+++ b/Regression/Geometry/RoughSphere/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset # 'tags', 'mpi_rank',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/Tesselation/regression3d.inputs
+++ b/Regression/Geometry/Tesselation/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/Vessel/regression2d.inputs
+++ b/Regression/Geometry/Vessel/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/Vessel/regression3d.inputs
+++ b/Regression/Geometry/Vessel/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/WireWire/regression2d.inputs
+++ b/Regression/Geometry/WireWire/regression2d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/Geometry/WireWire/regression3d.inputs
+++ b/Regression/Geometry/WireWire/regression3d.inputs
@@ -54,7 +54,7 @@ Driver.plt_vars                        = mpi_rank levelset             # 'tags',
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/ItoDiffusion/DriftDiffusion/regression2d.inputs
+++ b/Regression/ItoDiffusion/DriftDiffusion/regression2d.inputs
@@ -56,7 +56,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = false         # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/ItoDiffusion/DriftDiffusion/regression3d.inputs
+++ b/Regression/ItoDiffusion/DriftDiffusion/regression3d.inputs
@@ -56,7 +56,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = false         # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/ItoDiffusion/DriftDiffusion/template.inputs
+++ b/Regression/ItoDiffusion/DriftDiffusion/template.inputs
@@ -53,7 +53,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/ItoPlasma/Air3/development3d.inputs
+++ b/Regression/ItoPlasma/Air3/development3d.inputs
@@ -62,7 +62,7 @@ Driver.plt_vars                        = mpi_rank             # 'tags', 'mpi_ran
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = false         # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/RadiativeTransfer/Eddington/regression2d.inputs
+++ b/Regression/RadiativeTransfer/Eddington/regression2d.inputs
@@ -56,7 +56,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/RadiativeTransfer/Eddington/regression3d.inputs
+++ b/Regression/RadiativeTransfer/Eddington/regression3d.inputs
@@ -56,7 +56,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/RadiativeTransfer/McPhoto/regression2d.inputs
+++ b/Regression/RadiativeTransfer/McPhoto/regression2d.inputs
@@ -56,7 +56,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/RadiativeTransfer/McPhoto/regression3d.inputs
+++ b/Regression/RadiativeTransfer/McPhoto/regression3d.inputs
@@ -56,7 +56,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Regression/RadiativeTransfer/McPhoto/template.inputs
+++ b/Regression/RadiativeTransfer/McPhoto/template.inputs
@@ -53,7 +53,7 @@ Driver.plt_vars                        = 0             # 'tags', 'mpi_rank'
 Driver.restart                         = 0             # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true          # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1            # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1            # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1            # Refine dielectric surfaces. -1 => equal to refine_geometry

--- a/Source/Driver/CD_Driver.H
+++ b/Source/Driver/CD_Driver.H
@@ -320,9 +320,9 @@ protected:
   Real m_wallClockTwo;
 
   /*!
-    @brief Curvature refinement threshold (multiple of dx)
+    @brief Angle refinement threshold
   */
-  Real m_refineCurvature;
+  Real m_refineAngle;
 
   /*!
     @brief Special option for when geometric tags are changed during a simulation. 

--- a/Source/Driver/CD_Driver.cpp
+++ b/Source/Driver/CD_Driver.cpp
@@ -1144,7 +1144,7 @@ void Driver::parseGeometryRefinement(){
 
   int depth0;
 
-  pp.get("refine_curvature",                m_refineAngle);
+  pp.get("refine_angles",                   m_refineAngle);
   pp.get("refine_geometry",                 depth0);
   pp.get("refine_electrodes",               m_conductorTagsDepth);
   pp.get("refine_dielectrics",              m_dielectricTagsDepth);

--- a/Source/Driver/CD_Driver.cpp
+++ b/Source/Driver/CD_Driver.cpp
@@ -14,6 +14,7 @@
 
 // Chombo includes
 #include <EBArith.H>
+#include <PolyGeom.H>
 #include <EBAlias.H>
 #include <LevelData.H>
 #include <EBCellFAB.H>
@@ -23,6 +24,7 @@
 
 // Our includes
 #include <CD_Driver.H>
+#include <CD_VofUtils.H>
 #include <CD_DataOps.H>
 #include <CD_MultifluidAlias.H>
 #include <CD_Units.H>
@@ -260,30 +262,43 @@ void Driver::getGeometryTags(){
     m_geomTags[lvl] |= solid_tags;
 
 
-    // Evaluate curvature of the level-set function in the cut-cells. 
+    // Evaluate angles between cut-cells and refine based on that. 
     DisjointBoxLayout irregGrids = ebis_gas->getIrregGrids(cur_dom);
     EBISLayout ebisl;
-    ebis_gas->fillEBISLayout(ebisl, irregGrids, cur_dom, 0);
+    ebis_gas->fillEBISLayout(ebisl, irregGrids, cur_dom, 1); // Need one ghost cell because we fetch neighboring vofs. 
 
     const Real dx         = m_amr->getDx()[lvl];
     const RealVect probLo = m_amr->getProbLo();
     
     for (DataIterator dit(irregGrids); dit.ok(); ++dit){
       const Box box = irregGrids[dit()];
+
       const EBISBox& ebisbox = ebisl[dit()];
       const EBGraph& ebgraph = ebisbox.getEBGraph();
       const IntVectSet irreg = ebisbox.getIrregIVS(box);
 
       for (VoFIterator vofit(irreg, ebgraph); vofit.ok(); ++vofit){
-	const VolIndex& vof = vofit();
-	const IntVect iv = vof.gridIndex();
+	const VolIndex& vof    = vofit();
+	const IntVect   iv     = vof.gridIndex();
+	const RealVect  normal = ebisbox.normal(vof);
 	
-	const RealVect pos = probLo + (0.5*RealVect::Unit + RealVect(iv))*dx + ebisbox.bndryCentroid(vof)*dx;
+	// Check the angle between the normal vector in this irregular cell and neighboring irregular cells. If the
+	// angle exceeds a specified threshold the cell is refined. 
+	const Vector<VolIndex> otherVofs = VofUtils::getVofsInRadius(vof, ebisbox, 1, VofUtils::Connectivity::MonotonePath, false);
 
-	const std::pair<Real, Real> curv = m_computationalGeometry->getPrincipalCurvatures(phase::gas, pos, 1.E-4*dx);
+	for (int i = 0; i < otherVofs.size(); i++){
+	  const VolIndex& curVof = otherVofs[i];
 
-	// First entry in curv is the smallest. 
-	if(std::abs(curv.first)*m_refineCurvature*dx >= 1.0 ) m_geomTags[lvl] |= iv;
+	  if(ebisbox.isIrregular(curVof.gridIndex())){ // Only check irregular cells
+	    constexpr Real degreesPerRadian = 180.0/Units::pi;
+	    const RealVect curNormal = ebisbox.normal(curVof);
+	    const Real cosAngle      = PolyGeom::dot(normal, curNormal)/(normal.vectorLength()*curNormal.vectorLength());
+	    const Real theta         = acos(cosAngle)*degreesPerRadian;
+
+	    // Refine if angle exceeds threshold
+	    if(std::abs(theta) > m_refineAngle) m_geomTags[lvl] |= iv;
+	  }
+	}
       }
     }
   }
@@ -1118,7 +1133,7 @@ void Driver::parseGeometryRefinement(){
   // this routine again. But we need something to tell us that we got new refinement criteria for geometric tags so we can avoid regrid if they didn't change.
   // This is my clunky way of doing that. 
   
-  const auto c1 = m_refineCurvature;
+  const auto c1 = m_refineAngle;
   const auto c2 = m_conductorTagsDepth;
   const auto c3 = m_dielectricTagsDepth;
   const auto c4 = m_gasConductorInterfaceTagDepth;
@@ -1129,7 +1144,7 @@ void Driver::parseGeometryRefinement(){
 
   int depth0;
 
-  pp.get("refine_curvature",                m_refineCurvature);
+  pp.get("refine_curvature",                m_refineAngle);
   pp.get("refine_geometry",                 depth0);
   pp.get("refine_electrodes",               m_conductorTagsDepth);
   pp.get("refine_dielectrics",              m_dielectricTagsDepth);
@@ -1147,7 +1162,7 @@ void Driver::parseGeometryRefinement(){
   m_solidSolidInterfaceTagDepth     = (m_solidSolidInterfaceTagDepth    < 0) ? depth0 : m_solidSolidInterfaceTagDepth;
 
   if(m_timeStep > 0){ // Simulation is already running, and we need to check if we need new geometric tags for regridding. 
-    if(c1 != m_refineCurvature                ||
+    if(c1 != m_refineAngle                    ||
        c2 != m_conductorTagsDepth             ||
        c3 != m_dielectricTagsDepth            ||
        c4 != m_gasConductorInterfaceTagDepth  ||

--- a/Source/Driver/CD_Driver.options
+++ b/Source/Driver/CD_Driver.options
@@ -26,7 +26,7 @@ Driver.plt_vars                        = 0                # 'tags', 'mpi_rank', 
 Driver.restart                         = 0                # Restart step (less or equal to 0 implies fresh simulation)
 Driver.allow_coarsening                = true             # Allows removal of grid levels according to CellTagger
 Driver.grow_geo_tags                   = 2                # How much to grow tags when using geometry-based refinement. 
-Driver.refine_curvature                = 10.              # Curvature based refinement. Refines cells if curvature*dx*this > 1
+Driver.refine_angles                   = 30.              # Refine cells if angle between elements exceed this value.
 Driver.refine_geometry                 = -1               # Refine geometry, -1 => Refine all the way down
 Driver.refine_electrodes               = -1               # Refine electrode surfaces. -1 => equal to refine_geometry
 Driver.refine_dielectrics              = -1               # Refine dielectric surfaces. -1 => equal to refine_geometry


### PR DESCRIPTION
The previous curvature-based refinement was based on the principal curvatures of the signed distance function.

That approach was not precise enough since it was based on a finite-difference approximation to the level-set in the vicinity of the cut-cells, which is sensitive to the differencing distance as well as the differentiability of the function.

This PR replaces that functionality with angle-based refinement, checking the angle between cut-cells faces and refining them if their subtended angle isbelow a specified threshold angle. 