### PR TITLE
HDF5 and MPI guards

### DIFF
--- a/Local/Make.defs.HDF5.SINTEFPC9498
+++ b/Local/Make.defs.HDF5.SINTEFPC9498
@@ -127,9 +127,9 @@ CXXSTD         = 14
 #USE_COMPLEX   =
 USE_EB         = TRUE
 #USE_CCSE      =
-USE_HDF        = FALSE
-#HDFINCFLAGS    = -I/usr/local/serial-hdf5-1.8.14/include
-#HDFLIBFLAGS    = -L/usr/local/serial-hdf5-1.8.14/lib -lhdf5 -lz
+USE_HDF        = TRUE
+HDFINCFLAGS    = -I/usr/local/serial-hdf5-1.8.14/include
+HDFLIBFLAGS    = -L/usr/local/serial-hdf5-1.8.14/lib -lhdf5 -lz
 ## Note: don't set the HDFMPI* variables if you don't have parallel HDF installed
 #HDFMPIINCFLAGS = -I/usr/local/hdf5-1.8.14/include
 #HDFMPILIBFLAGS = -L/usr/local/hdf5-1.8.14/lib -lhdf5 -lz

--- a/Local/Make.defs.MPI.HDF5.SINTEFPC9498
+++ b/Local/Make.defs.MPI.HDF5.SINTEFPC9498
@@ -116,9 +116,9 @@ PRECISION      = DOUBLE
 #PROFILE       =
 CXX            = g++-6
 FC             = gfortran
-MPI            = FALSE
+MPI            = TRUE
 ## Note: don't set the MPICXX variable if you don't have MPI installed
-#MPICXX         = mpicxx
+MPICXX         = mpicxx
 #OBJMODEL      =
 #XTRACONFIG    =
 ## Optional features
@@ -127,12 +127,12 @@ CXXSTD         = 14
 #USE_COMPLEX   =
 USE_EB         = TRUE
 #USE_CCSE      =
-USE_HDF        = FALSE
-#HDFINCFLAGS    = -I/usr/local/serial-hdf5-1.8.14/include
-#HDFLIBFLAGS    = -L/usr/local/serial-hdf5-1.8.14/lib -lhdf5 -lz
+USE_HDF        = TRUE
+HDFINCFLAGS    = -I/usr/local/hdf5-1.8.14/include
+HDFLIBFLAGS    = -L/usr/local/hdf5-1.8.14/lib -lhdf5 -lz
 ## Note: don't set the HDFMPI* variables if you don't have parallel HDF installed
-#HDFMPIINCFLAGS = -I/usr/local/hdf5-1.8.14/include
-#HDFMPILIBFLAGS = -L/usr/local/hdf5-1.8.14/lib -lhdf5 -lz
+HDFMPIINCFLAGS = -I/usr/local/hdf5-1.8.14/include
+HDFMPILIBFLAGS = -L/usr/local/hdf5-1.8.14/lib -lhdf5 -lz
 USE_MF         = TRUE
 #USE_MT        =
 #USE_SETVAL    =

--- a/Local/Make.defs.MPI.SINTEFPC9498
+++ b/Local/Make.defs.MPI.SINTEFPC9498
@@ -116,9 +116,9 @@ PRECISION      = DOUBLE
 #PROFILE       =
 CXX            = g++-6
 FC             = gfortran
-MPI            = FALSE
+MPI            = TRUE	
 ## Note: don't set the MPICXX variable if you don't have MPI installed
-#MPICXX         = mpicxx
+MPICXX         = mpicxx
 #OBJMODEL      =
 #XTRACONFIG    =
 ## Optional features

--- a/Local/Make.defs.serial.GNU
+++ b/Local/Make.defs.serial.GNU
@@ -1,0 +1,171 @@
+# Copy this file to:
+#
+#    Chombo/lib/mk/Make.defs.local
+#
+# before modifying it.
+#
+# Use this file to set Chombo makefile variables for the local
+# installation.  To set variables for just a single computer
+# create a file named:
+#
+#    Chombo/lib/mk/local/Make.defs.<hostname>
+#
+# where <hostname> is the value of `uname -n` (or `hostname`, if uname doesn't work)
+
+# The default values for the main variables here are in:
+#
+#    Chombo/lib/mk/Make.defs.defaults
+
+# This file is include'd from Make.defs after:
+#    Make.defs.defaults
+# and before:
+#    Make.defs.<hostname> Make.defs.config Make.rules
+
+makefiles+=Make.defs.local
+
+################################################################
+
+# Chombo configuration variables that affect filenames:
+
+#  DIM          :(2,3) number of dimensions in PDEs
+#  DEBUG        :(TRUE,FALSE) compile with symbol table or not
+#  OPT          :(TRUE,HIGH,FALSE) optimize, high optimize, or not
+#  PRECISION    :(FLOAT,DOUBLE) size of floating point variables
+#  PROFILE      :(TRUE,FALSE) compile for performance profiling or not
+#  CXX          : command to compile/link C++ code
+#  FC           : command to compile Fortran code
+#  MPI          :(TRUE,FALSE) compile for parallel if TRUE, else serial
+#  OPENMPCC     : TRUE for threading with OpenMP, FALSE without OpenMP
+#  MPICXX       : command to compile/link C++ code in parallel
+#  ROSE         : (TRUE,FALSE) preprocess with Rose-based translator
+#  GPU          : (TRUE,FALSE) compile CUDA kernels
+#  OBJMODEL     : special config for non-default compiler mode
+#  XTRACONFIG   : user-defined special config
+
+# Variables for optional features that don't affect filenames:
+
+#  CXXSTD          : Chombo default is C++11.  Set to 14 for C++14, etc.  This
+#                    should not be changed unless you want to experiment with
+#                    different C++ standards.  Only the default is supported.
+#  USE_64          : if TRUE, use 64bit pointers on systems where 32bits is the default
+#  USE_COMPLEX     : if TRUE, enable the 'Complex' type
+#                    (default is TRUE, disable only if compiler doesn't allow it)
+#  USE_EB          : if TRUE, build Chombo Embedded Boundary code
+#  USE_CCSE        : if TRUE, build CCSE mglib and supporting code into one lib
+#  USE_HDF         : if TRUE, use the HDF5 library
+#   HDFINCFLAGS    : cpp options (-I*) for HDF5 include files
+#   HDFLIBFLAGS    : link options (-L* -l*) for HDF5 library files
+#   HDFMPIINCFLAGS : cpp options (-I*) for parallel HDF5 include files
+#   HDFMPILIBFLAGS : link options (-L* -l*) for parallel HDF5 library files
+#  USE_MF          : if TRUE, build Chombo MultiFluid code (requires USE_EB=TRUE)
+#  USE_MT          : if TRUE, enable Chombo memory tracking
+#  USE_SETVAL      : (TRUE,FALSE) use setVal to initialize all BaseFab<Real>
+
+# These variables are system-dependent but usually dont have to be changed:
+
+#  CH_AR       : command to add object files to a library file
+#  CH_CPP      : command to run the C preprocessor on Fortran files
+#  DOXYGEN  : command to run the 'doyxgen' program
+#  LD       : command to run the linker (default: use $CXX or $MPICXX, as appropriate)
+#  PERL     : command to run perl
+#  RANLIB   : command to post-process a library archive for random access
+
+# Compiler variables.  The 'Make.rules' file chooses whether to use
+# the 'opt' flags or the 'dbg' flags.  The 'prof' flags are added if
+# PROFILE=TRUE.
+#
+#  cppdbgflags : debug options for the C-preprocessor (both C++ and Fortran)
+#  cppoptflags : optimization options for the C-preprocessor (")
+#  cxxcppflags : C-preprocessor flags for C++ compiles only
+#  cxxdbgflags : debug options for the C++ and MPIC++ compilers
+#  cxxoptflags : optimization options for the C++ and MPIC++ compilers
+#  cxxprofflags: profiling options for the C++ and MPIC++ compilers
+#  fcppflags   : C-preprocessor flags for Fortran compiles only
+#  fdbgflags   : debug options for the Fortran compiler
+#  foptflags   : optimization options for the Fortran compiler
+#  fprofflags  : profiling options for the Fortran compiler
+#  lddbgflags  : debug options for the linker
+#  ldoptflags  : optimization options for the linker
+#  ldprofflags : profiling options for the linker
+#  flibflags   : options for the linker to specify the Fortran libraries
+#                (this usually is needed only when mixing C++ and
+#                 Fortran compilers from different vendors)
+#  syslibflags : extra linker options to get libraries needed on this system
+#
+# Notes:
+# 1) The linker command always uses the CXX options in addition to its own variables,
+#    so options that are common to both do not need to be repeated in the ld*flags vars
+#    (e.g. -g for debugging, or -pg for profiling)
+# 2) The compiler options can be set on the command line using the
+#    variables: CPPFLAGS CXXFLAGS FFLAGS LDFLAGS.
+#    These variables supercede any settings in the makefiles.
+# 3) The GNUmakefile in "Chombo/lib" will check these variables and complain if
+#    they have invalid values.  On systems that don't have MPI installed, the
+#    various MPI variables should not be set (or should be set to empty strings)
+#    to prevent the checker from complaining.
+
+#begin  -- dont change this line
+
+## Override the default values here
+
+## Configuration variables
+DIM            = 2
+DEBUG          = FALSE
+OPT            = HIGH
+PRECISION      = DOUBLE
+#PROFILE       =
+CXX            = g++
+FC             = gfortran
+#MPI           =
+## Note: don't set the MPICXX variable if you don't have MPI installed
+#MPICXX        =
+#OBJMODEL      =
+#XTRACONFIG    =
+## Optional features
+CXXSTD         = 14
+#USE_64        =
+#USE_COMPLEX   =
+USE_EB         = TRUE
+#USE_CCSE      =
+#USE_HDF       =
+#HDFINCFLAGS   = -I<hdf_serial_dir>/include
+#HDFLIBFLAGS   = -L<hdf_serial_dir>/lib -lhdf5 -lz
+## Note: don't set the HDFMPI* variables if you don't have parallel HDF installed
+#HDFMPIINCFLAGS= -I<hdf_parallel_dir>/include
+#HDFMPILIBFLAGS= -L<hdf_parallel_dir>/lib -lhdf5 -lz
+USE_MF         = TRUE
+#USE_MT        =
+#USE_SETVAL    =
+#CH_AR         =
+#CH_CPP        =
+#DOXYGEN       =
+#LD            =
+#PERL          =
+#RANLIB        =
+#ROSE          =
+#ROSECC        =
+#ROSEINCFLAGS  =
+#ROSELIBFLAGS  =
+## Note: don't set the CUDA variables if you are not using a CUDA GPU
+#GPU           =
+#NVCC          =
+#NVCCFLAGS     =
+#PTXASFLAGS    =
+#CUBIN         =
+#cppdbgflags   =
+#cppoptflags   =
+#cxxcppflags   =
+#cxxdbgflags   =
+cxxoptflags    = -O3
+#cxxprofflags  =
+#fcppflags     =
+#fdbgflags     =
+#foptflags     =
+#fprofflags    =
+flibflags      = -O3
+#lddbgflags    =
+#ldoptflags    =
+#ldprofflags   =
+syslibflags    = -llapack -lblas -ldl -lm
+
+#end  -- dont change this line

--- a/Local/Make.defs.serial.GNU
+++ b/Local/Make.defs.serial.GNU
@@ -127,7 +127,7 @@ CXXSTD         = 14
 #USE_COMPLEX   =
 USE_EB         = TRUE
 #USE_CCSE      =
-#USE_HDF       =
+USE_HDF        = FALSE
 #HDFINCFLAGS   = -I<hdf_serial_dir>/include
 #HDFLIBFLAGS   = -L<hdf_serial_dir>/lib -lhdf5 -lz
 ## Note: don't set the HDFMPI* variables if you don't have parallel HDF installed

--- a/Physics/AdvectionDiffusion/CD_AdvectionDiffusionStepper.H
+++ b/Physics/AdvectionDiffusion/CD_AdvectionDiffusionStepper.H
@@ -36,8 +36,12 @@ namespace Physics {
       void postInitialize() override;
 
       // IO routines
+#ifdef CH_USE_HDF5
       void writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const override;
+#endif
+#ifdef CH_USE_HDF5      
       void readCheckpointData(HDF5Handle& a_handle, const int a_lvl) override;
+#endif
       void postCheckpointSetup() override;
       int getNumberOfPlotVariables() const override;
       void writePlotData(EBAMRCellData& a_output, Vector<std::string>& a_plotVariableNames, int& a_icomp) const override;

--- a/Physics/AdvectionDiffusion/CD_AdvectionDiffusionStepper.cpp
+++ b/Physics/AdvectionDiffusion/CD_AdvectionDiffusionStepper.cpp
@@ -135,13 +135,17 @@ void AdvectionDiffusionStepper::setVelocity(const int a_level){
 
 }
 
+#ifdef CH_USE_HDF5
 void AdvectionDiffusionStepper::writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const {
   m_solver->writeCheckpointLevel(a_handle, a_lvl);
 }
+#endif
 
+#ifdef CH_USE_HDF5
 void AdvectionDiffusionStepper::readCheckpointData(HDF5Handle& a_handle, const int a_lvl){
   m_solver->readCheckpointLevel(a_handle, a_lvl);
 }
+#endif
 
 void AdvectionDiffusionStepper::postCheckpointSetup(){
   m_solver->setSource(0.0);

--- a/Physics/BrownianWalker/CD_BrownianWalkerStepper.H
+++ b/Physics/BrownianWalker/CD_BrownianWalkerStepper.H
@@ -46,8 +46,12 @@ namespace Physics {
 			    const int                        a_finestLevel) override;
 
       // IO routines
+#ifdef CH_USE_HDF5
       void writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const override;
+#endif
+#ifdef CH_USE_HDF5      
       void readCheckpointData(HDF5Handle& a_handle, const int a_lvl) override;
+#endif      
       void postCheckpointSetup() override;
       int getNumberOfPlotVariables() const override;
       void writePlotData(EBAMRCellData& a_output, Vector<std::string>& a_plotVariableNames, int& a_icomp) const override;

--- a/Physics/BrownianWalker/CD_BrownianWalkerStepper.cpp
+++ b/Physics/BrownianWalker/CD_BrownianWalkerStepper.cpp
@@ -219,6 +219,7 @@ void BrownianWalkerStepper::setVelocity(const int a_level){
   }
 }
 
+#ifdef CH_USE_HDF5
 void BrownianWalkerStepper::writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const{
   CH_TIME("BrownianWalkerStepper::writeCheckpointData");
   if(m_verbosity > 5){
@@ -227,7 +228,9 @@ void BrownianWalkerStepper::writeCheckpointData(HDF5Handle& a_handle, const int 
 
   m_solver->writeCheckpointLevel(a_handle, a_lvl);
 }
+#endif
 
+#ifdef CH_USE_HDF5
 void BrownianWalkerStepper::readCheckpointData(HDF5Handle& a_handle, const int a_lvl) {
   CH_TIME("BrownianWalkerStepper::readCheckpointData");
   if(m_verbosity > 5){
@@ -236,6 +239,7 @@ void BrownianWalkerStepper::readCheckpointData(HDF5Handle& a_handle, const int a
   
   m_solver->readCheckpointLevel(a_handle, a_lvl);
 }
+#endif
 
 void BrownianWalkerStepper::postCheckpointSetup() {
   CH_TIME("BrownianWalkerStepper::postCheckpointSetup");

--- a/Physics/CdrPlasma/CD_CdrPlasmaStepper.H
+++ b/Physics/CdrPlasma/CD_CdrPlasmaStepper.H
@@ -53,8 +53,12 @@ namespace Physics {
       static Real s_constant_one(const RealVect a_pos);
 
       // New functions for new Driver interface
+#ifdef CH_USE_HDF5
       virtual void writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const;
+#endif
+#ifdef CH_USE_HDF5      
       virtual void readCheckpointData(HDF5Handle& a_handle, const int a_lvl);
+#endif
       virtual int getNumberOfPlotVariables() const;
       virtual void writePlotData(EBAMRCellData& a_output, Vector<std::string>& a_plotVariableNames, int& a_icomp) const;
       virtual void writeJ(EBAMRCellData& a_output, int& a_comp) const;

--- a/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
+++ b/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
@@ -20,6 +20,7 @@
 #include <CD_CdrIterator.H>
 #include <CD_RtIterator.H>
 #include <CD_Units.H>
+#include <CD_Timer.H>
 #include <CD_NamespaceHeader.H>
 
 // C-style VLA methods can have occasional memory issues. Use them at your own peril. 
@@ -3989,7 +3990,7 @@ Real CdrPlasmaStepper::computeRelaxationTime(){
   const int finest_level = 0;
   const Real SAFETY      = 1.E-20;
 
-  Real t1 = MPI_Wtime();
+  Real t1 = Timer::wallClock();
   EBAMRCellData E, J, dt;
   m_amr->allocate(E,  m_realm, m_cdr->getPhase(), SpaceDim);
   m_amr->allocate(J,  m_realm, m_cdr->getPhase(), SpaceDim);

--- a/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
+++ b/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
@@ -4089,7 +4089,7 @@ RefCountedPtr<SigmaSolver>& CdrPlasmaStepper::getSigmaSolver(){
   return m_sigma;
 }
 
-// New functions for Driver
+#ifdef CH_USE_HDF5
 void CdrPlasmaStepper::writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const{
   CH_TIME("Driver::writeCheckpointData");
   if(m_verbosity > 3){
@@ -4111,7 +4111,9 @@ void CdrPlasmaStepper::writeCheckpointData(HDF5Handle& a_handle, const int a_lvl
   m_fieldSolver->writeCheckpointLevel(a_handle, a_lvl);
   m_sigma->writeCheckpointLevel(a_handle, a_lvl);
 }
+#endif
 
+#ifdef CH_USE_HDF5
 void CdrPlasmaStepper::readCheckpointData(HDF5Handle& a_handle, const int a_lvl){
   CH_TIME("Driver::readCheckpointData");
   if(m_verbosity > 3){
@@ -4131,6 +4133,7 @@ void CdrPlasmaStepper::readCheckpointData(HDF5Handle& a_handle, const int a_lvl)
   m_fieldSolver->readCheckpointLevel(a_handle, a_lvl);
   m_sigma->readCheckpointLevel(a_handle, a_lvl);
 }
+#endif
 
 int CdrPlasmaStepper::getNumberOfPlotVariables() const{
   CH_TIME("CdrPlasmaStepper::getNumberOfPlotVariables");

--- a/Physics/CdrPlasma/Timesteppers/CdrPlasmaGodunovStepper/CD_CdrPlasmaGodunovStepper.cpp
+++ b/Physics/CdrPlasma/Timesteppers/CdrPlasmaGodunovStepper/CD_CdrPlasmaGodunovStepper.cpp
@@ -12,8 +12,10 @@
 // Chombo includes
 #include <ParmParse.H>
 
+// Our includes
 #include <CD_CdrPlasmaGodunovStepper.H>
 #include <CD_CdrPlasmaGodunovStorage.H>
+#include <CD_Timer.H>
 #include <CD_DataOps.H>
 #include <CD_Units.H>
 #include <CD_NamespaceHeader.H>
@@ -271,12 +273,12 @@ Real CdrPlasmaGodunovStepper::advance(const Real a_dt){
   Real t_tot  = 0.0;
 
   Real t0, t1;
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   t_tot  = -t0;
 
   // These calls are responsible for filling CDR and sigma solver boundary conditions
   // on the EB and on the domain walls
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   CdrPlasmaGodunovStepper::computeElectricFieldIntoScratch();       // Compute the electric field
   CdrPlasmaGodunovStepper::computeCdrGradients();        // Compute cdr gradients
   CdrPlasmaGodunovStepper::extrapolateSourceTerm(a_dt);            // If we used advective extrapolation, BCs are more work. 
@@ -285,54 +287,54 @@ Real CdrPlasmaGodunovStepper::advance(const Real a_dt){
   CdrPlasmaGodunovStepper::computeCdrDomainStates();    // Extrapolate cell-centered states to domain edges
   CdrPlasmaGodunovStepper::computeCdrDomainFluxes();    // Extrapolate cell-centered fluxes to domain edges
   CdrPlasmaGodunovStepper::computeSigmaFlux();           // Update charge flux for sigma solver
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_filBC = t1 - t0;
   
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   CdrPlasmaGodunovStepper::advanceTransport(a_dt);
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_tran = t1 - t0;
   
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   if((m_timeStep +1) % m_fast_poisson == 0){
     CdrPlasmaStepper::solvePoisson();         // Update the Poisson equation
   }
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_pois = t1 - t0;
 
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   CdrPlasmaGodunovStepper::computeElectricFieldIntoScratch();       // Update electric fields too
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_filE = t1-t0;
 
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   //  CdrPlasmaGodunovStepper::computeCdrGradients();        // I'm not doing this. Gradients don't change that much. 
   CdrPlasmaGodunovStepper::computeReactionNetwork(a_dt); // Advance the reaction network. Put the result in solvers
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_reac = t1-t0;
 
   // Move Photons
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   if((m_timeStep +1) % m_fast_rte == 0){
     CdrPlasmaGodunovStepper::advanceRadiativeTransfer(a_dt);              // Update RTE equations
   }
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_rte = t1-t0;
 
   // Post step
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   CdrPlasmaGodunovStepper::postStep();
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_post = t1 - t0;
   
   // Update velocities and diffusion coefficients. We don't do sources here.
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   CdrPlasmaGodunovStepper::computeCdrDriftVelocities(m_time + a_dt);
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_filV = t1 - t0;
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   CdrPlasmaGodunovStepper::computeCdrDiffusionCoefficients(m_time + a_dt);
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_filD = t1 - t0;
   t_tot += t1;
 

--- a/Physics/CdrPlasma/Timesteppers/CdrPlasmaImExSdcStepper/CD_CdrPlasmaImExSdcStepper.cpp
+++ b/Physics/CdrPlasma/Timesteppers/CdrPlasmaImExSdcStepper/CD_CdrPlasmaImExSdcStepper.cpp
@@ -22,6 +22,7 @@
 #include <CD_CdrPlasmaImExSdcStorage.H>
 #include <CD_DataOps.H>
 #include <CD_Units.H>
+#include <CD_Timer.H>
 #include <CD_CdrGodunov.H>
 #include "CD_LaPackUtils.H"
 #include <CD_NamespaceHeader.H>
@@ -684,32 +685,32 @@ void CdrPlasmaImExSdcStepper::integrate(const Real a_dt, const Real a_time, cons
     // which is what we need to do at the start of the time step. In principle, these things do not change
     // and so we could probably store them somewhere for increased performance. 
     if(m == 0 && !a_lagged_terms){ // This updates the CDR boundary conditions; since these are used to compute the slopes,
-      t0 = MPI_Wtime();            // and the m=0 hyperbolic slopes do not change, we only need to do this for the predictor. 
+      t0 = Timer::wallClock();            // and the m=0 hyperbolic slopes do not change, we only need to do this for the predictor. 
       CdrPlasmaImExSdcStepper::computeCdrEbStates();
       CdrPlasmaImExSdcStepper::computeCdrFluxes(a_time);
       CdrPlasmaImExSdcStepper::computeCdrDomainStates();
       CdrPlasmaImExSdcStepper::computeCdrDomainFluxes(a_time);
       CdrPlasmaImExSdcStepper::computeSigmaFlux();
-      t1 = MPI_Wtime();
+      t1 = Timer::wallClock();
 
       total_time = -t0;
       setup_time = t1-t0;
     }
     
     // This does the transient rte advance. Source terms were uåpdated in the computeReactionNetwork routine above. 
-    t0 = MPI_Wtime();
+    t0 = Timer::wallClock();
     if(!(m_rte->isStationary())) CdrPlasmaImExSdcStepper::integrateRtTransient(a_dt);
 
     // This computes phi_(m+1) = phi_m + dtm*FAR_m(phi_m) + lagged quadrature and lagged advection-reaction
-    t0 = MPI_Wtime();
+    t0 = Timer::wallClock();
     CdrPlasmaImExSdcStepper::integrateAdvectionReaction(a_dt, m, a_lagged_terms);
-    t1 = MPI_Wtime();
+    t1 = Timer::wallClock();
     advect_time += t1-t0;
 
     // This does the diffusion advance. It also adds in the remaining lagged diffusion terms before the implicit diffusion solve
-    t0 = MPI_Wtime();
+    t0 = Timer::wallClock();
     CdrPlasmaImExSdcStepper::integrateDiffusion(a_dt, m, a_lagged_terms);
-    t1 = MPI_Wtime();
+    t1 = Timer::wallClock();
     diffusive_time += t1-t0;
 
     // After the diffusion step we update the Poisson and *stationary* RTE equations
@@ -745,7 +746,7 @@ void CdrPlasmaImExSdcStepper::integrate(const Real a_dt, const Real a_time, cons
 
     time += m_dtm[m];
   }
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
 
   total_time += t1;
 
@@ -770,11 +771,11 @@ void CdrPlasmaImExSdcStepper::integrateAdvectionReaction(const Real a_dt, const 
   // if m=0 and a_lagged_terms=true, we can increment directly with the precomputed advection-reaction. This means that
   // we can skip the advective advance. The sigma advance is accordingly also skipped.
   const bool skip = (a_m == 0 && a_lagged_terms);
-  const Real t0 = MPI_Wtime();
+  const Real t0 = Timer::wallClock();
   if(!skip){
     CdrPlasmaImExSdcStepper::integrateAdvection(a_dt, a_m, a_lagged_terms);
   }
-  const Real t1 = MPI_Wtime();
+  const Real t1 = Timer::wallClock();
 
   // Add in the reaction term and then compute the new operator slopes.
   // If this is the corrector and m=0, we skipped the advection advance because we can use the precomputed
@@ -832,7 +833,7 @@ void CdrPlasmaImExSdcStepper::integrateAdvectionReaction(const Real a_dt, const 
       DataOps::incr(phi_m1, scratch, 0.5*a_dt);    // phi_(m+1)^(k+1) = phi_m^(k+1) + dtm*(FAR_m^(k+1) - FAR_m^k) + I_m^(m+1)
     }
   }
-  const Real t2 = MPI_Wtime();
+  const Real t2 = Timer::wallClock();
 
   // Add in the lagged terms for sigma. As above, m=0 and corrector is a special case where we just use the old slopes.
   EBAMRIVData& sigma_m1      = m_sigma_scratch->getSigmaSolver()[a_m+1];
@@ -843,7 +844,7 @@ void CdrPlasmaImExSdcStepper::integrateAdvectionReaction(const Real a_dt, const 
     DataOps::incr(sigma_m1, Fsig_m, m_dtm[a_m]);
   }
 
-  const Real t3 = MPI_Wtime();
+  const Real t3 = Timer::wallClock();
   if(a_lagged_terms){ // Add in the lagged terms. When we make it here, sigma_(m+1) = sigma_m + dtm*Fsig_m. 
     EBAMRIVData& Fsig_lag = m_sigma_scratch->getFold()[a_m];
     DataOps::incr(sigma_m1, Fsig_lag, -m_dtm[a_m]);
@@ -853,7 +854,7 @@ void CdrPlasmaImExSdcStepper::integrateAdvectionReaction(const Real a_dt, const 
     CdrPlasmaImExSdcStepper::quad(scratch, m_sigma_scratch->getFold(), a_m);
     DataOps::incr(sigma_m1, scratch, 0.5*a_dt); // Mult by 0.5*a_dt due to scaling on [-1,1] for quadrature
   }
-  const Real t4 = MPI_Wtime();
+  const Real t4 = Timer::wallClock();
 
 #if 0
   pout() << "integrateAdvectionReaction::" << endl;

--- a/Physics/CdrPlasma/Timesteppers/deprecated/euler_maruyama/euler_maruyama.cpp
+++ b/Physics/CdrPlasma/Timesteppers/deprecated/euler_maruyama/euler_maruyama.cpp
@@ -217,66 +217,66 @@ Real euler_maruyama::advance(const Real a_dt){
   Real t_tot  = 0.0;
 
   Real t0, t1;
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   t_tot  = -t0;
 
   // These calls are responsible for filling CDR and sigma solver boundary conditions
   // on the EB and on the domain walls
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   euler_maruyama::compute_E_into_scratch();       // Compute the electric field
   euler_maruyama::computeCdrGradients();        // Extrapolate cell-centered stuff to EB centroids
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_grad = t1 - t0;
 
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   euler_maruyama::computeCdrEbStates();        // Extrapolate cell-centered stuff to EB centroids
   euler_maruyama::computeCdrEbFluxes();        // Extrapolate cell-centered fluxes to EB centroids
   euler_maruyama::computeCdrDomainStates();    // Extrapolate cell-centered states to domain edges
   euler_maruyama::computeCdrDomainFluxes();    // Extrapolate cell-centered fluxes to domain edges
   euler_maruyama::computeSigmaFlux();           // Update charge flux for sigma solver
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_filBC = t1 - t0;
 
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   euler_maruyama::computeReactionNetwork(a_dt); // Advance the reaction network
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_reac = t1-t0;
 
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   euler_maruyama::advance_cdr(a_dt);              // Update cdr equations
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_cdr = t1 - t0;
 
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   euler_maruyama::advance_rte(a_dt);              // Update RTE equations
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_rte = t1-t0;
 
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   euler_maruyama::advance_sigma(a_dt);            // Update sigma equation
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_sig = t1 - t0;
   
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   if((m_timeStep +1) % m_fast_poisson == 0){
     TimeStepper::solve_poisson();                  // Update the Poisson equation
   }
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_pois = t1 - t0;
 
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   euler_maruyama::compute_E_into_scratch();       // Update electric fields too
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_filE = t1-t0;
 
   // Update velocities and diffusion coefficients. We don't do sources here.
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   euler_maruyama::computeCdrVelo(m_time + a_dt);
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_filV = t1 - t0;
-  t0 = MPI_Wtime();
+  t0 = Timer::wallClock();
   euler_maruyama::compute_cdr_diffco(m_time + a_dt);
-  t1 = MPI_Wtime();
+  t1 = Timer::wallClock();
   t_filD = t1 - t0;
   t_tot += t1;
 

--- a/Physics/CdrPlasma/Timesteppers/deprecated/rk2/rk2.cpp
+++ b/Physics/CdrPlasma/Timesteppers/deprecated/rk2/rk2.cpp
@@ -119,72 +119,72 @@ Real rk2::advance(const Real a_dt){
   }
 
   // Prepare for k1 advance
-  const Real t0 = MPI_Wtime();
+  const Real t0 = Timer::wallClock();
   this->compute_E_at_start_of_time_step();
-  const Real t00 = MPI_Wtime();
+  const Real t00 = Timer::wallClock();
   this->computeCdrVelo_at_start_of_time_step();
-  const Real t01 = MPI_Wtime();
+  const Real t01 = Timer::wallClock();
   this->computeCdrEbStates_at_start_of_time_step();
-  const Real t02 = MPI_Wtime();
+  const Real t02 = Timer::wallClock();
   this->compute_cdr_diffco_at_start_of_time_step();
-  const Real t03 = MPI_Wtime();
+  const Real t03 = Timer::wallClock();
   this->compute_cdr_sources_at_start_of_time_step();
-  const Real t04 = MPI_Wtime();
+  const Real t04 = Timer::wallClock();
   this->compute_cdr_fluxes_at_start_of_time_step();
-  const Real t05 = MPI_Wtime();
+  const Real t05 = Timer::wallClock();
   this->computeSigmaFlux_at_start_of_time_step();
 
   // Do k1 advance
-  const Real t1 = MPI_Wtime();
+  const Real t1 = Timer::wallClock();
   this->advance_cdr_k1(a_dt);
-  const Real t10 = MPI_Wtime();
+  const Real t10 = Timer::wallClock();
   this->advance_sigma_k1(a_dt);
-  const Real t11 = MPI_Wtime();
+  const Real t11 = Timer::wallClock();
   this->solve_poisson_k1();
-  const Real t12 = MPI_Wtime();
+  const Real t12 = Timer::wallClock();
   this->compute_E_after_k1();
-  const Real t13 = MPI_Wtime();
+  const Real t13 = Timer::wallClock();
   if(m_rte->isStationary()){
     this->advance_rte_k1_stationary(a_dt);
   }
   else{
     this->advance_rte_k1_transient(a_dt);
   }
-  const Real t14 = MPI_Wtime();
+  const Real t14 = Timer::wallClock();
 
   // Recompute things in order to do k2 advance
-  const Real t2 = MPI_Wtime();
+  const Real t2 = Timer::wallClock();
   this->computeCdrEbStates_after_k1();
-  const Real t20 = MPI_Wtime();
+  const Real t20 = Timer::wallClock();
   this->computeCdrVelo_after_k1(a_dt);
-  const Real t21 = MPI_Wtime();
+  const Real t21 = Timer::wallClock();
   this->compute_cdr_diffco_after_k1(a_dt);
-  const Real t22 = MPI_Wtime();
+  const Real t22 = Timer::wallClock();
   this->compute_cdr_sources_after_k1(a_dt);
-  const Real t23 = MPI_Wtime();
+  const Real t23 = Timer::wallClock();
   this->compute_cdr_fluxes_after_k1(a_dt);
-  const Real t24 = MPI_Wtime();
+  const Real t24 = Timer::wallClock();
   this->computeSigmaFlux_after_k1();
-  const Real t25 = MPI_Wtime();
+  const Real t25 = Timer::wallClock();
   
   // Do k2 advance
-  const Real t3 = MPI_Wtime();
-  const Real t30 = MPI_Wtime();
+  const Real t3 = Timer::wallClock();
+  const Real t30 = Timer::wallClock();
   this->advance_cdr_k2(a_dt);
-  const Real t31 = MPI_Wtime();
+  const Real t31 = Timer::wallClock();
   this->advance_sigma_k2(a_dt);
-  const Real t32 = MPI_Wtime();
+  const Real t32 = Timer::wallClock();
   this->solve_poisson_k2();
-  const Real t33 = MPI_Wtime();
+  const Real t33 = Timer::wallClock();
   this->compute_E_after_k2();
-  const Real t34 = MPI_Wtime();
+  const Real t34 = Timer::wallClock();
   if(m_rte->isStationary()){
     this->advance_rte_k2_stationary(a_dt);
   }
   else{
     this->advance_rte_k2_transient(a_dt);
   }
-  const Real t4 = MPI_Wtime();
+  const Real t4 = Timer::wallClock();
 
 #if RK2_DEBUG_TIMER
   pout() << endl;

--- a/Physics/Electrostatics/CD_FieldStepper.H
+++ b/Physics/Electrostatics/CD_FieldStepper.H
@@ -42,8 +42,12 @@ namespace Physics {
       void allocate() override;
 
       // IO routines
-      void writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const override{}
+#ifdef CH_USE_HDF5
+      void writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const override;
+#endif
+#ifdef CH_USE_HDF5      
       void readCheckpointData(HDF5Handle& a_handle, const int a_lvl) override;
+#endif
       void postCheckpointSetup() override {}
       int getNumberOfPlotVariables() const override;
       void writePlotData(EBAMRCellData& a_output, Vector<std::string>& a_plotVariableNames, int& a_icomp) const override;

--- a/Physics/Electrostatics/CD_FieldStepperImplem.H
+++ b/Physics/Electrostatics/CD_FieldStepperImplem.H
@@ -179,10 +179,18 @@ namespace Physics {
       return 1.E99;
     }
 
+#ifdef CH_USE_HDF5    
+    template <class T>
+    void FieldStepper<T>::writeCheckpointData(HDF5Handle& a_handle, const int a_lvl){
+    }
+#endif
+
+#ifdef CH_USE_HDF5    
     template <class T>
     void FieldStepper<T>::readCheckpointData(HDF5Handle& a_handle, const int a_lvl){
       MayDay::Abort("FieldStepper<T>::readCheckpointData - checkpointing not supported for this class");
     }
+#endif
 
     template <class T>
     int FieldStepper<T>::getNumberOfPlotVariables() const{

--- a/Physics/Geometry/CD_GeometryStepper.H
+++ b/Physics/Geometry/CD_GeometryStepper.H
@@ -40,8 +40,12 @@ namespace Physics {
       virtual void registerOperators() override;
 
       // IO routines
+#ifdef CH_USE_HDF5
       virtual void writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const override;
+#endif
+#ifdef CH_USE_HDF5
       virtual void readCheckpointData(HDF5Handle& a_handle, const int a_lvl) override;
+#endif      
       virtual void writePlotData(EBAMRCellData& a_output, Vector<std::string>& a_plotVariableNames, int& a_icomp) const override;
       virtual int  getNumberOfPlotVariables() const override;
 

--- a/Physics/Geometry/CD_GeometryStepper.cpp
+++ b/Physics/Geometry/CD_GeometryStepper.cpp
@@ -33,8 +33,12 @@ void GeometryStepper::registerOperators(){
 }
 
 // IO routines
+#ifdef CH_USE_HDF5
 void GeometryStepper::writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const {}
+#endif
+#ifdef CH_USE_HDF5
 void GeometryStepper::readCheckpointData(HDF5Handle& a_handle, const int a_lvl) {}
+#endif
 void GeometryStepper::writePlotData(EBAMRCellData& a_output, Vector<std::string>& a_plotVariableNames, int& a_icomp) const {}
 int  GeometryStepper::getNumberOfPlotVariables() const {return 0;}
 

--- a/Physics/ItoPlasma/CD_ItoPlasmaStepper.H
+++ b/Physics/ItoPlasma/CD_ItoPlasmaStepper.H
@@ -69,8 +69,12 @@ namespace Physics {
       void setupSigma();
   
       // IO routines
+#ifdef CH_USE_HDF5
       void writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const override;
+#endif      
+#ifdef CH_USE_HDF5      
       void readCheckpointData(HDF5Handle& a_handle, const int a_lvl) override;
+#endif
       virtual void writePlotData(EBAMRCellData& a_output, Vector<std::string>& a_plotVariableNames, int& a_icomp) const override;
       void writeJ(EBAMRCellData& a_output, int& a_icomp) const;
       void writeNumParticlesPerPatch(EBAMRCellData& a_output, int& a_icomp) const;

--- a/Physics/ItoPlasma/CD_ItoPlasmaStepper.cpp
+++ b/Physics/ItoPlasma/CD_ItoPlasmaStepper.cpp
@@ -285,6 +285,7 @@ void ItoPlasmaStepper::postCheckpointPoisson(){
   // std::cout << Emax << std::endl;
 }
 
+#ifdef CH_USE_HDF5
 void ItoPlasmaStepper::writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const {
   CH_TIME("ItoPlasmaStepper::writeCheckpointData");
   if(m_verbosity > 5){
@@ -304,7 +305,9 @@ void ItoPlasmaStepper::writeCheckpointData(HDF5Handle& a_handle, const int a_lvl
   m_fieldSolver->writeCheckpointLevel(a_handle, a_lvl);
   m_sigma->writeCheckpointLevel(a_handle, a_lvl);
 }
+#endif
 
+#ifdef CH_USE_HDF5
 void ItoPlasmaStepper::readCheckpointData(HDF5Handle& a_handle, const int a_lvl){
   CH_TIME("ItoPlasmaStepper::readCheckpointData");
   if(m_verbosity > 5){
@@ -324,6 +327,7 @@ void ItoPlasmaStepper::readCheckpointData(HDF5Handle& a_handle, const int a_lvl)
   m_fieldSolver->readCheckpointLevel(a_handle, a_lvl);
   m_sigma->readCheckpointLevel(a_handle, a_lvl);
 }
+#endif
 
 void ItoPlasmaStepper::writePlotData(EBAMRCellData& a_output, Vector<std::string>& a_plotVariableNames, int& a_icomp) const {
   CH_TIME("ItoPlasmaStepper::writePlotData");

--- a/Physics/RadiativeTransfer/CD_RtPhysicsStepper.H
+++ b/Physics/RadiativeTransfer/CD_RtPhysicsStepper.H
@@ -37,8 +37,12 @@ namespace Physics {
       void postInitialize() override;
 
       // IO routines
+#ifdef CH_USE_HDF5
       void writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const override;
+#endif
+#ifdef CH_USE_HDF5      
       void readCheckpointData(HDF5Handle& a_handle, const int a_lvl) override;
+#endif
       void postCheckpointSetup() override;
       int getNumberOfPlotVariables() const override;
       void writePlotData(EBAMRCellData& a_output, Vector<std::string>& a_plotVariableNames, int& a_icomp) const override;

--- a/Physics/RadiativeTransfer/CD_RtPhysicsStepperImplem.H
+++ b/Physics/RadiativeTransfer/CD_RtPhysicsStepperImplem.H
@@ -77,15 +77,19 @@ template <typename T>
 void RtPhysicsStepper<T>::postInitialize(){
 }
 
+#ifdef CH_USE_HDF5      
 template <typename T>
 void RtPhysicsStepper<T>::writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const {
   m_solver->writeCheckpointLevel(a_handle, a_lvl);
 }
+#endif
 
+#ifdef CH_USE_HDF5      
 template <typename T>
 void RtPhysicsStepper<T>::readCheckpointData(HDF5Handle& a_handle, const int a_lvl){
   m_solver->readCheckpointLevel(a_handle, a_lvl);
 }
+#endif
 
 template <typename T>
 void RtPhysicsStepper<T>::postCheckpointSetup() {

--- a/Regression/UnitTests/bvh/main.cpp
+++ b/Regression/UnitTests/bvh/main.cpp
@@ -1,6 +1,7 @@
 #include "CD_Driver.H"
 #include <CD_ItoMerge.H>
 #include <CD_PointMass.H>
+#include <CD_Timer.H>
 
 #include <iostream>
 #include <fstream>
@@ -68,9 +69,9 @@ int main(int argc, char* argv[]){
   // Do particle merging/splitting
 
   Tree<PointMass> tree(inputParticles, Mass);
-  const Real t0 = MPI_Wtime();
+  const Real t0 = Timer::wallClock();
   tree.buildTree(ppc);
-  const Real t1 = MPI_Wtime();
+  const Real t1 = Timer::wallClock();
 
   // Create output particles
   std::vector<PointMass> outputParticles(0);

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -22,6 +22,7 @@
 #include <CD_AmrMesh.H>
 #include <CD_MultifluidAlias.H>
 #include <CD_LoadBalancing.H>
+#include <CD_Timer.H>
 #include <CD_gradientF_F.H>
 #include <CD_DomainFluxIFFABFactory.H>
 #include <CD_TiledMeshRefine.H>

--- a/Source/AmrMesh/CD_LoadBalancing.cpp
+++ b/Source/AmrMesh/CD_LoadBalancing.cpp
@@ -38,7 +38,7 @@ void LoadBalancing::sort(Vector<Box>& a_boxes, const BoxSorting a_which){
 }
 
 void LoadBalancing::gatherBoxes(Vector<Box>& a_boxes){
-
+#ifdef CH_MPI
   // TLDR: This code does a gather operation on the loads and boxes. They are gather globally in this way:
   //       (BoxesForMPIRank=0, BoxesForMPIRank=1, BoxesForMPIRank=2, ....)
 
@@ -100,11 +100,11 @@ void LoadBalancing::gatherBoxes(Vector<Box>& a_boxes){
 
   delete recv_buffer;
   delete send_buffer;
-
+#endif
 }
 
 void LoadBalancing::gatherLoads(Vector<Real>& a_loads){
-
+#ifdef CH_MPI
   // TLDR: This code does a gather operation on the loads. They are gather globally in this way:
   //       (LoadsForRank=0, LoadsForRank=1, LoadsForRank2=2, ....)
 
@@ -145,10 +145,11 @@ void LoadBalancing::gatherLoads(Vector<Real>& a_loads){
 
   delete recv_buffer;
   delete send_buffer;
+#endif
 }
 
 void LoadBalancing::gatherLoads(Vector<int>& a_loads){
-
+#ifdef CH_MPI
   // TLDR: This code does a gather operation on the loads. They are gather globally in this way:
   //       (LoadsForRank=0, LoadsForRank=1, LoadsForRank2=2, ....)
 
@@ -189,11 +190,14 @@ void LoadBalancing::gatherLoads(Vector<int>& a_loads){
 
   delete recv_buffer;
   delete send_buffer;
+#endif
 }
 
 void LoadBalancing::gatherBoxes_and_loads(Vector<Box>& a_boxes, Vector<int>& a_loads){
+#ifdef CH_MPI
   LoadBalancing::gatherBoxes(a_boxes);
   LoadBalancing::gatherLoads(a_loads);
+#endif
 }
 
 int LoadBalancing::maxBits(std::vector<Box>::iterator a_first, std::vector<Box>::iterator a_last){

--- a/Source/AmrMesh/CD_LoadBalancingImplem.H
+++ b/Source/AmrMesh/CD_LoadBalancingImplem.H
@@ -18,6 +18,7 @@
 #include <chrono>
 
 // Chombo includes
+#include <LoadBalance.H>
 #include <BoxLayout.H>
 
 // Our includes

--- a/Source/ConvectionDiffusionReaction/CD_CdrSolver.H
+++ b/Source/ConvectionDiffusionReaction/CD_CdrSolver.H
@@ -390,14 +390,18 @@ public:
     @paramo[out] a_handle HDF5 file. 
     @param[in]   a_level Grid level
   */
+#ifdef CH_USE_HDF5
   virtual void writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const;
+#endif
 
   /*!
     @brief Read checkpoint data from HDF5 file. 
     @param[in] a_handle HDF5 handle.
     @param[in] const int a_level Grid level
   */
+#ifdef CH_USE_HDF5  
   virtual void readCheckpointLevel(HDF5Handle& a_handle, const int a_level);
+#endif
 
   /*!
     @brief Regrid this solver. 

--- a/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
@@ -1729,6 +1729,7 @@ void CdrSolver::writePlotFile(){
   Vector<LevelData<EBCellFAB>* > outputPtr;
   m_amr->alias(outputPtr, output);
 
+#ifdef CH_USE_HDF5
   writeEBHDF5(fname,
 	      m_amr->getGrids(m_realm),
 	      outputPtr,
@@ -1742,6 +1743,7 @@ void CdrSolver::writePlotFile(){
 	      false,
 	      Vector<Real>(numPlotVars, 0.0), //coveredValues,
 	      IntVect::Unit);
+#endif
 }
 
 void CdrSolver::writePlotData(EBAMRCellData& a_output, int& a_icomp){
@@ -1828,6 +1830,7 @@ void CdrSolver::writeData(EBAMRCellData& a_output, int& a_comp, const EBAMRCellD
   a_comp += ncomp;
 }
 
+#ifdef CH_USE_HDF5
 void CdrSolver::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const {
   CH_TIME("CdrSolver::writeCheckpointLevel(HDF5Handle, int)");
   if(m_verbosity > 5){
@@ -1838,7 +1841,9 @@ void CdrSolver::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) co
   write(a_handle, *m_phi   [a_level], m_name       );
   write(a_handle, *m_source[a_level], m_name+"_src");
 }
+#endif
 
+#ifdef CH_USE_HDF5
 void CdrSolver::readCheckpointLevel(HDF5Handle& a_handle, const int a_level){
   CH_TIME("CdrSolver::readCheckpointLevel(HDF5Handle, int)");
   if(m_verbosity > 5){
@@ -1850,6 +1855,7 @@ void CdrSolver::readCheckpointLevel(HDF5Handle& a_handle, const int a_level){
   read<EBCellFAB>(a_handle, *m_phi   [a_level], m_name,        m_amr->getGrids(m_realm)[a_level], interv, false);
   read<EBCellFAB>(a_handle, *m_source[a_level], m_name+"_src", m_amr->getGrids(m_realm)[a_level], interv, false);
 }
+#endif
 
 Real CdrSolver::computeAdvectionDt(){
   CH_TIME("CdrSolver::computeAdvectionDt()");

--- a/Source/Driver/CD_Driver.H
+++ b/Source/Driver/CD_Driver.H
@@ -494,12 +494,16 @@ protected:
   /*!
     @brief Read checkpoint file
   */
+#ifdef CH_USE_HDF5  
   void readCheckpointFile(const std::string& a_restartFile);
+#endif
 
   /*!
     @brief Read vector data up to and including a_step
   */
+#ifdef CH_USE_HDF5  
   void readVectorData(HDF5HeaderData& a_header, Vector<Real>& a_data, const std::string a_name, const int a_elements);
+#endif
 
   /*!
     @brief Do a regrid step. 
@@ -549,7 +553,9 @@ protected:
   /*!
     @brief Set for restart
   */
+#ifdef CH_USE_HDF5
   void setupForRestart(const int a_initialRegrids, const std::string a_restartFile);
+#endif
 
   /*!
     @brief Set up for geometry only
@@ -609,32 +615,44 @@ protected:
   /*!
     @brief Write checkpoint data
   */
+#ifdef CH_USE_HDF5
   void writeCheckpointLevel(HDF5Handle& a_handle, const int a_level);
-
+#endif
+  
   /*!
     @brief Write tags
   */
+#ifdef CH_USE_HDF5  
   void writeCheckpointTags(HDF5Handle& a_handle, const int a_level);
+#endif
 
   /*!
     @brief Write checkpoint Realm loads
   */
+#ifdef CH_USE_HDF5    
   void writeCheckpointRealmLoads(HDF5Handle& a_handle, const int a_level);
+#endif
 
   /*!
     @brief Write checkpoint data
   */
+#ifdef CH_USE_HDF5      
   void readCheckpointLevel(HDF5Handle& a_handle, const int a_level);
+#endif
 
   /*!
     @brief Read Realm loads. 
   */
+#ifdef CH_USE_HDF5        
   void readCheckpointRealmLoads(Vector<long int>& a_loads, HDF5Handle& a_handle, const std::string a_realm, const int a_level);
+#endif
 
   /*!
     @brief Write vector data to a HDF5Header. This writes up to a_step
   */
+#ifdef CH_USE_HDF5  
   void writeVectorData(HDF5HeaderData& a_header, const Vector<Real>& a_data, const std::string a_name, const int a_elem);
+#endif
 
   /*!
     @brief Write the geometry to file. 

--- a/Source/Driver/CD_TimeStepper.H
+++ b/Source/Driver/CD_TimeStepper.H
@@ -96,14 +96,18 @@ public:
     @param[inout] a_handle HDF5 handle
     @param[in]    a_lvl    Grid level
   */
+#ifdef CH_USE_HDF5
   virtual void writeCheckpointData(HDF5Handle& a_handle, const int a_lvl) const = 0;
+#endif
 
   /*!
     @brief Read checkpoint data from file
     @param[inout] a_handle HDF5 handle
     @param[in]    a_lvl    Grid level
   */
+#ifdef CH_USE_HDF5  
   virtual void readCheckpointData(HDF5Handle& a_handle, const int a_lvl) = 0;
+#endif
 
   /*!
     @brief Write plot data to file

--- a/Source/Electrostatics/CD_FieldSolver.H
+++ b/Source/Electrostatics/CD_FieldSolver.H
@@ -212,7 +212,9 @@ public:
     @param[in]   a_level Grid level
     @details This writes m_potential[a_level] to the checkpoint file. 
   */
+#ifdef CH_USE_HDF5
   virtual void writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const;
+#endif
 
   /*!
     @brief Read checkpoint data onto a level
@@ -220,7 +222,9 @@ public:
     @param[in] const int a_level Grid level
     @details This fills m_potential[a_level] with data from a_handle. 
   */
+#ifdef CH_USE_HDF5  
   virtual void readCheckpointLevel(HDF5Handle& a_handle, const int a_level);
+#endif
 
   /*!
     @brief Post checkpoint method. 

--- a/Source/Electrostatics/CD_FieldSolver.cpp
+++ b/Source/Electrostatics/CD_FieldSolver.cpp
@@ -906,6 +906,8 @@ void FieldSolver::writePlotFile(){
 
   Vector<Real> covered_values(numPlotVars, 0.0);
   string fname(file_char);
+
+#ifdef CH_USE_HDF5
   writeEBHDF5(fname,
 	      m_amr->getGrids(m_realm),
 	      outputPtr,
@@ -919,8 +921,10 @@ void FieldSolver::writePlotFile(){
 	      false,
 	      covered_values,
 	      IntVect::Unit);
+#endif
 }
 
+#ifdef CH_USE_HDF5
 void FieldSolver::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const {
   CH_TIME("FieldSolver::writeCheckpointLevel");
   if(m_verbosity > 5){
@@ -941,7 +945,9 @@ void FieldSolver::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) 
   if(!ebisGas.isNull()) write(a_handle, potentialGas, "FieldSolver::m_potential(gas)"  );
   if(!ebisSol.isNull()) write(a_handle, potentialSol, "FieldSolver::m_potential(solid)");
 }
+#endif
 
+#ifdef CH_USE_HDF5
 void FieldSolver::readCheckpointLevel(HDF5Handle& a_handle, const int a_level){
   CH_TIME("FieldSolver::readCheckpointLevel");
   if(m_verbosity > 5){
@@ -962,6 +968,7 @@ void FieldSolver::readCheckpointLevel(HDF5Handle& a_handle, const int a_level){
   if(!ebisGas.isNull()) read<EBCellFAB>(a_handle, potentialGas, "FieldSolver::m_potential(gas)",   m_amr->getGrids(m_realm)[a_level], Interval(0,0), false);
   if(!ebisSol.isNull()) read<EBCellFAB>(a_handle, potentialSol, "FieldSolver::m_potential(solid)", m_amr->getGrids(m_realm)[a_level], Interval(0,0), false);
 }
+#endif
 
 void FieldSolver::postCheckpoint(){
   CH_TIME("FieldSolver::postCheckpoint");

--- a/Source/Electrostatics/CD_ProxyFieldSolver.cpp
+++ b/Source/Electrostatics/CD_ProxyFieldSolver.cpp
@@ -49,6 +49,7 @@
 #include <CD_MFHelmholtzOpFactory.H>
 #include <CD_MFQuadCFInterp.H>
 #include <CD_MFLevelGrid.H>
+#include <CD_Timer.H>
 #include <CD_MFFluxReg.H>
 #include <CD_MFCoarAve.H>
 #include <CD_Units.H>
@@ -75,7 +76,7 @@ bool ProxyFieldSolver::solve(MFAMRCellData&       a_potential,
   std::string str;
   pp.get("solver", str);
 
-  Real t1 = -MPI_Wtime();
+  Real t1 = -Timer::wallClock();
   if(str == "ebcond"){
     this->solveEBCond(   gasData, gasResi);
   }
@@ -88,7 +89,7 @@ bool ProxyFieldSolver::solve(MFAMRCellData&       a_potential,
   else{
     MayDay::Error("ProxyFieldSolver::solve - bad argument to ProxyFieldSolver.solver");
   }
-  t1 += MPI_Wtime();
+  t1 += Timer::wallClock();
   if(procID() == 0) std::cout << "solve time = " << t1 << "\n";
 
   m_amr->averageDown(a_potential, m_realm);
@@ -563,9 +564,9 @@ void ProxyFieldSolver::solveHelmholtz(EBAMRCellData& a_phi, EBAMRCellData& a_res
   multigridSolver.m_verbosity=10;
   multigridSolver.init(phi, rhs, finestLevel, 0);
   multigridSolver.m_convergenceMetric = multigridSolver.computeAMRResidual(zer, rhs, finestLevel, baseLevel);
-  Real t1 = -MPI_Wtime();
+  Real t1 = -Timer::wallClock();
   multigridSolver.solveNoInit(phi, rhs, finestLevel, baseLevel, false);
-  t1 += MPI_Wtime();
+  t1 += Timer::wallClock();
   if(procID() == 0) std::cout << "Multigrid solve time for Helm = " << t1 << std::endl;
 }
 
@@ -834,9 +835,9 @@ void ProxyFieldSolver::solveMF(MFAMRCellData&       a_potential,
 
   multigridSolver.m_verbosity = 10;
   multigridSolver.init(phi, rhs, finestLevel, baseLevel);
-  Real t1 = -MPI_Wtime();
+  Real t1 = -Timer::wallClock();
   multigridSolver.solveNoInit(phi, rhs, finestLevel, baseLevel, false);
-  t1 += MPI_Wtime();
+  t1 += Timer::wallClock();
   if(procID() == 0) std::cout << "Multigrid solve time for MFHelm = " << t1 << std::endl;
 }
 

--- a/Source/Elliptic/CD_EBHelmholtzOpFactory.cpp
+++ b/Source/Elliptic/CD_EBHelmholtzOpFactory.cpp
@@ -17,6 +17,7 @@
 // Chombo includes
 #include <ParmParse.H>
 #include <BRMeshRefine.H>
+#include <LoadBalance.H>
 
 // Our includes
 #include <CD_EBHelmholtzOpFactory.H>

--- a/Source/Elliptic/CD_MFHelmholtzOpFactory.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzOpFactory.cpp
@@ -12,6 +12,7 @@
 // Chombo includes
 #include <ParmParse.H>
 #include <BRMeshRefine.H>
+#include <LoadBalance.H>
 
 // Our includes
 #include <CD_MFHelmholtzOpFactory.H>

--- a/Source/Geometry/CD_ComputationalGeometry.H
+++ b/Source/Geometry/CD_ComputationalGeometry.H
@@ -124,8 +124,10 @@ public:
   /*!
     @brief Build geometries from files
   */
+#ifdef CH_USE_HDF5
   virtual void buildGeometriesFromFiles(const std::string&   a_gas_file,
 					const std::string&   a_sol_file);
+#endif
 
   /*!
     @brief Compute curvature of the implicit function

--- a/Source/Geometry/CD_ComputationalGeometry.cpp
+++ b/Source/Geometry/CD_ComputationalGeometry.cpp
@@ -114,6 +114,7 @@ void ComputationalGeometry::buildGeometries(const ProblemDomain   a_finestDomain
   }
 }
 
+#ifdef CH_USE_HDF5
 void ComputationalGeometry::buildGeometriesFromFiles(const std::string&   a_gas_file,
 						     const std::string&   a_sol_file){
 
@@ -134,6 +135,7 @@ void ComputationalGeometry::buildGeometriesFromFiles(const std::string&   a_gas_
     ebis_sol = RefCountedPtr<EBIndexSpace> (NULL);
   }
 }
+#endif
 
 void ComputationalGeometry::buildGasGeoServ(GeometryService*&   a_geoserver,
 					    const ProblemDomain a_finestDomain,

--- a/Source/Geometry/CD_ScanShop.cpp
+++ b/Source/Geometry/CD_ScanShop.cpp
@@ -465,7 +465,7 @@ void ScanShop::printNumBoxesLevel(const int a_level){
 }
 
 void ScanShop::gatherBoxesParallel(Vector<Box>& a_boxes){
-
+#ifdef CH_MPI
   // 1. Linearize local boxes
   int send_size    = 2*CH_SPACEDIM;                 // Message size for one box
   int send_count   = a_boxes.size()*send_size;      // Number of elements sent from this rank
@@ -528,6 +528,7 @@ void ScanShop::gatherBoxesParallel(Vector<Box>& a_boxes){
 
   delete recv_buffer;
   delete send_buffer;
+#endif
 }
 
 #include <CD_NamespaceFooter.H>

--- a/Source/ItoDiffusion/CD_ItoSolver.H
+++ b/Source/ItoDiffusion/CD_ItoSolver.H
@@ -404,22 +404,30 @@ public:
   /*!
     @brief Write checkpoint data into handle
   */
+#ifdef CH_USE_HDF5
   virtual void writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const;
+#endif
 
   /*!
     @brief Checkpoint particles
   */
+#ifdef CH_USE_HDF5  
   virtual void writeCheckPointLevelParticles(HDF5Handle& a_handle, const int a_level) const;
+#endif
 
   /*!
     @brief Checkpoint particles
   */
+#ifdef CH_USE_HDF5  
   virtual void writeCheckPointLevelFluid(HDF5Handle& a_handle, const int a_level) const;
+#endif
 
   /*!
     @brief Read checkpoint data from handle
   */
+#ifdef CH_USE_HDF5  
   virtual void readCheckpointLevel(HDF5Handle& a_handle, const int a_level);
+#endif
 
   /*!
     @brief Set the species

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -996,6 +996,7 @@ void ItoSolver::allocateInternals(){
   }
 }
 
+#ifdef CH_USE_HDF5  
 void ItoSolver::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const {
   CH_TIME("ItoSolver::writeCheckpointLevel");
   if(m_verbosity > 5){
@@ -1013,7 +1014,9 @@ void ItoSolver::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) co
     this->writeCheckPointLevelFluid(a_handle, a_level);
   }
 }
+#endif
 
+#ifdef CH_USE_HDF5  
 void ItoSolver::writeCheckPointLevelParticles(HDF5Handle& a_handle, const int a_level) const {
   CH_TIME("ItoSolver::writeCheckPointLevelParticles");
   if(m_verbosity > 5){
@@ -1041,7 +1044,9 @@ void ItoSolver::writeCheckPointLevelParticles(HDF5Handle& a_handle, const int a_
 
   writeParticlesToHDF(a_handle, RealmParticles[a_level], str);
 }
+#endif
 
+#ifdef CH_USE_HDF5  
 void ItoSolver::writeCheckPointLevelFluid(HDF5Handle& a_handle, const int a_level) const {
   CH_TIME("ItoSolver::writeCheckPointLevelFluid");
   if(m_verbosity > 5){
@@ -1085,7 +1090,9 @@ void ItoSolver::writeCheckPointLevelFluid(HDF5Handle& a_handle, const int a_leve
 
   write(a_handle, particleNumbers, str);
 }
+#endif
 
+#ifdef CH_USE_HDF5  
 void ItoSolver::readCheckpointLevel(HDF5Handle& a_handle, const int a_level){
   CH_TIME("ItoSolver::readCheckpointLevel");
   if(m_verbosity > 5){
@@ -1127,6 +1134,7 @@ void ItoSolver::readCheckpointLevel(HDF5Handle& a_handle, const int a_level){
   }
     
 }
+#endif
 
 void ItoSolver::restartParticles(LevelData<EBCellFAB>& a_num_particles, const int a_level){
   CH_TIME("ItoSolver::restartParticles");

--- a/Source/RadiativeTransfer/CD_EddingtonSP1.H
+++ b/Source/RadiativeTransfer/CD_EddingtonSP1.H
@@ -171,14 +171,18 @@ public:
     @param[out] a_handle HDF5 file
     @param[in]  a_level  Grid level
   */
+#ifdef CH_USE_HDF5
   virtual void writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const override;
+#endif
 
   /*!
     @brief Read checkpoint data from handle
     @param[out] a_handle HDF5 file
     @param[in]  a_level  Grid level
   */
+#ifdef CH_USE_HDF5  
   virtual void readCheckpointLevel(HDF5Handle& a_handle, const int a_level) override;
+#endif
 
 protected:
 

--- a/Source/RadiativeTransfer/CD_EddingtonSP1.cpp
+++ b/Source/RadiativeTransfer/CD_EddingtonSP1.cpp
@@ -1044,6 +1044,8 @@ void EddingtonSP1::writePlotFile(){
 
   Vector<Real> covered_values(ncomps, 0.0);
   string fname(file_char);
+
+#ifdef CH_USE_HDF5
   writeEBHDF5(fname,
 	      m_amr->getGrids(m_realm),
 	      output_ptr,
@@ -1056,8 +1058,10 @@ void EddingtonSP1::writePlotFile(){
 	      m_amr->getFinestLevel() + 1,
 	      true,
 	      covered_values);
+#endif
 }
 
+#ifdef CH_USE_HDF5
 void EddingtonSP1::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const {
   CH_TIME("EddingtonSP1::writeCheckpointLevel");
   if(m_verbosity > 5){
@@ -1067,7 +1071,9 @@ void EddingtonSP1::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level)
   // Write state vector
   write(a_handle, *m_phi[a_level], m_name);
 }
+#endif
 
+#ifdef CH_USE_HDF5
 void EddingtonSP1::readCheckpointLevel(HDF5Handle& a_handle, const int a_level){
   CH_TIME("EddingtonSP1::readCheckpointLevel");
   if(m_verbosity > 5){
@@ -1076,5 +1082,6 @@ void EddingtonSP1::readCheckpointLevel(HDF5Handle& a_handle, const int a_level){
 
   read<EBCellFAB>(a_handle, *m_phi[a_level], m_name, m_amr->getGrids(m_realm)[a_level], Interval(0,0), false);
 }
+#endif
 
 #include <CD_NamespaceFooter.H>

--- a/Source/RadiativeTransfer/CD_McPhoto.H
+++ b/Source/RadiativeTransfer/CD_McPhoto.H
@@ -304,14 +304,18 @@ public:
     @param[inout] a_handle HDF5 file
     @param[in]    a_level Grid level
   */
+#ifdef CH_USE_HDF5
   virtual void writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const override;
+#endif
 
   /*!
     @brief Read checkpoint data from handle
     @param[inout] a_handle HDF5 file
     @param[in]    a_level Grid level
   */
+#ifdef CH_USE_HDF5  
   virtual void readCheckpointLevel(HDF5Handle& a_handle, const int a_level) override;
+#endif
 
   /*!
     @brief Get output plot names

--- a/Source/RadiativeTransfer/CD_McPhoto.cpp
+++ b/Source/RadiativeTransfer/CD_McPhoto.cpp
@@ -583,6 +583,7 @@ void McPhoto::writePlotFile(){
   MayDay::Error("McPhoto::writePlotFile - not implemented for McPhoto (yet)");
 }
 
+#ifdef CH_USE_HDF5
 void McPhoto::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const {
   CH_TIME("McPhoto::writeCheckpointLevel");
   if(m_verbosity > 5){
@@ -596,7 +597,9 @@ void McPhoto::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) cons
   std::string str = m_name + "_particles";
   writeParticlesToHDF(a_handle, m_photons[a_level], str);
 }
+#endif
 
+#ifdef CH_USE_HDF5
 void McPhoto::readCheckpointLevel(HDF5Handle& a_handle, const int a_level){
   CH_TIME("McPhoto::readCheckpointLevel");
   if(m_verbosity > 5){
@@ -610,6 +613,7 @@ void McPhoto::readCheckpointLevel(HDF5Handle& a_handle, const int a_level){
   std::string str = m_name + "_particles";
   readParticlesFromHDF(a_handle, m_photons[a_level], str);
 }
+#endif
 
 Vector<std::string> McPhoto::getPlotVariableNames() const {
   CH_TIME("McPhoto::getPlotVariableNames");

--- a/Source/RadiativeTransfer/CD_RtSolver.H
+++ b/Source/RadiativeTransfer/CD_RtSolver.H
@@ -216,12 +216,16 @@ public:
   /*!
     @brief Write checkpoint data into handle
   */
+#ifdef CH_USE_HDF5
   virtual void writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const = 0;
+#endif
 
   /*!
     @brief Read checkpoint data from handle
   */
+#ifdef CH_USE_HDF5  
   virtual void readCheckpointLevel(HDF5Handle& a_handle, const int a_level) = 0;
+#endif
 
   /*!
     @brief Get number of output fields

--- a/Source/SigmaSolver/CD_SigmaSolver.H
+++ b/Source/SigmaSolver/CD_SigmaSolver.H
@@ -117,12 +117,16 @@ public:
   /*!
     @brief Write checkpoint data into handle
   */
+#ifdef CH_USE_HDF5
   virtual void writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const;
+#endif  
 
   /*!
     @brief Read checkpoint data from handle
   */
+#ifdef CH_USE_HDF5
   virtual void readCheckpointLevel(HDF5Handle& a_handle, const int a_level);
+#endif
 
   /*!
     @brief Write output data to a_output

--- a/Source/SigmaSolver/CD_SigmaSolver.cpp
+++ b/Source/SigmaSolver/CD_SigmaSolver.cpp
@@ -309,6 +309,7 @@ void SigmaSolver::setTime(const int a_step, const Real a_time, const Real a_dt){
   m_dt   = a_dt;
 }
 
+#ifdef CH_USE_HDF5
 void SigmaSolver::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const {
   CH_TIME("SigmaSolver::writeCheckpointLevel");
   if(m_verbosity > 5){
@@ -323,7 +324,9 @@ void SigmaSolver::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) 
   // Write state vector
   write(a_handle, scratch, "sigma");
 }
+#endif
 
+#ifdef CH_USE_HDF5
 void SigmaSolver::readCheckpointLevel(HDF5Handle& a_handle, const int a_level){
   CH_TIME("SigmaSolver::readCheckpointLevel");
   if(m_verbosity > 5){
@@ -342,6 +345,7 @@ void SigmaSolver::readCheckpointLevel(HDF5Handle& a_handle, const int a_level){
   DataOps::setValue(*m_phi[a_level], 0.0);
   DataOps::incr(*m_phi[a_level], scratch, 1.0);
 }
+#endif
 
 void SigmaSolver::writePlotData(EBAMRCellData& a_output, int& a_comp){
   CH_TIME("SigmaSolver::writePlotData");

--- a/Source/Utilities/CD_LaPackUtils.cpp
+++ b/Source/Utilities/CD_LaPackUtils.cpp
@@ -13,6 +13,7 @@
 #include <limits>
 #include <algorithm>
 #include <iostream>
+#include <cmath>
 
 // Our includes
 #include <CD_LaPackUtils.H>

--- a/Source/Utilities/CD_MemoryReport.cpp
+++ b/Source/Utilities/CD_MemoryReport.cpp
@@ -44,10 +44,18 @@ void MemoryReport::getMaxMinMemoryUsage(Real& a_max_peak, Real& a_min_peak, Real
   int min_unfreed_mem;
   int min_peak_mem;
 
+#ifdef CH_USE_MPI
   int result1 = MPI_Allreduce(&unfreed_mem, &max_unfreed_mem, 1, MPI_INT, MPI_MAX, Chombo_MPI::comm);
   int result2 = MPI_Allreduce(&peak_mem,    &max_peak_mem,    1, MPI_INT, MPI_MAX, Chombo_MPI::comm);
   int result3 = MPI_Allreduce(&unfreed_mem, &min_unfreed_mem, 1, MPI_INT, MPI_MIN, Chombo_MPI::comm);
   int result4 = MPI_Allreduce(&peak_mem,    &min_peak_mem,    1, MPI_INT, MPI_MIN, Chombo_MPI::comm);
+#else
+
+  max_unfreed_mem = unfreed_mem;
+  max_peak_mem    = peak_mem;
+  max_unfreed_mem = unfreed_mem;
+  min_peak_mem    = peak_mem;
+#endif
 
   a_max_peak    = 1.0*max_peak_mem/BytesPerMB;
   a_min_peak    = 1.0*min_peak_mem/BytesPerMB;
@@ -64,7 +72,7 @@ void MemoryReport::getMemoryUsage(Vector<Real>& a_peak, Vector<Real>& a_unfreed)
   int unfreed_mem = curMem;
   int peak_mem    = peakMem;
 
-
+#ifdef CH_MPI
   int* unfreed = (int*) malloc(numProc()*sizeof(int));//new int[numProc()];
   int* peak    = (int*) malloc(numProc()*sizeof(int));//new int[numProc()];
 
@@ -80,6 +88,13 @@ void MemoryReport::getMemoryUsage(Vector<Real>& a_peak, Vector<Real>& a_unfreed)
 
   delete unfreed;
   delete peak;
+#else
+  a_peak.resize(1);
+  a_unfreed.resize(1);
+
+  a_peak[0] = peak_mem;
+  a_unfreed[0] = unfreed_mem;
+#endif
 }
 
 #include <CD_NamespaceFooter.H>

--- a/Source/Utilities/CD_Timer.H
+++ b/Source/Utilities/CD_Timer.H
@@ -1,0 +1,35 @@
+/* chombo-discharge
+ * Copyright © 2021 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_Timer.H
+  @brief  Implementation of CD_Timer.H
+  @author Robert Marskar
+*/
+
+// Std includes
+#include <chrono>
+
+// Chombo includes
+#include <REAL.H>
+
+// Our includes
+#include <CD_NamespaceHeader.H>
+
+class Timer {
+public:
+  
+  inline
+  static Real wallClock(){
+#ifdef CH_MPI
+    return Timer::wallClock();
+#else
+    return 0.0;
+#endif
+  }
+
+};
+
+#include <CD_NamespaceFooter.H>

--- a/Source/Utilities/CD_Timer.H
+++ b/Source/Utilities/CD_Timer.H
@@ -87,7 +87,7 @@ public:
     @note This will give a run-time error if the event has already been started (i.e. startEvent(a_event) has not been called prior). 
   */
   inline
-  void startEvent(const std::string a_event);
+  void startEvent(const std::string a_event) noexcept;
 
   /*!
     @brief Stop an event
@@ -95,7 +95,7 @@ public:
     @note This will give a run-time error if the event has not already been started (i.e. startEvent(a_event) has not been called prior). 
   */
   inline
-  void stopEvent(const std::string a_event);
+  void stopEvent(const std::string a_event) noexcept;
 
   /*!
     @brief Reset all events. 
@@ -103,6 +103,24 @@ public:
   */
   inline
   void resetEvents();
+
+  /*!
+    @brief Reset/remove an event
+  */
+  inline
+  void resetEvents(const std::string a_event) noexcept;
+
+  /*!
+    @brief Print all timed events to cout.
+  */
+  inline
+  void reportEvents() const noexcept;
+
+  /*!
+    @brief Report a particular event
+  */
+  inline
+  void reportEvent(const std::string a_event) const noexcept;
 
 protected:
 

--- a/Source/Utilities/CD_Timer.H
+++ b/Source/Utilities/CD_Timer.H
@@ -7,10 +7,15 @@
   @file   CD_Timer.H
   @brief  Implementation of CD_Timer.H
   @author Robert Marskar
+  @todo   Make sure that events that were started but not stopped are reports as unfinished (or somesuch)
 */
+
+#ifndef CD_Timer_H
+#define CD_Timer_H
 
 // Std includes
 #include <chrono>
+#include <map>
 
 // Chombo includes
 #include <REAL.H>
@@ -18,18 +23,106 @@
 // Our includes
 #include <CD_NamespaceHeader.H>
 
+/*!
+  @brief Class which is used for run-time monitoring of events
+*/
 class Timer {
 public:
-  
-  inline
-  static Real wallClock(){
-#ifdef CH_MPI
-    return Timer::wallClock();
-#else
-    return 0.0;
-#endif
-  }
 
+  /*!
+    @brief Clock implements
+  */
+  using Clock = std::chrono::steady_clock;
+
+  /*!
+    @brief Point in time
+  */
+  using TimePoint = std::chrono::steady_clock::time_point;
+
+  /*!
+    @brief Static function which returns the time (in seconds) between now and an arbitrary time in the past
+  */
+  inline
+  static Real wallClock();
+
+  /*!
+    @brief Default constructor. This creates a timer without any timer events and without a name. 
+  */
+  inline
+  Timer();
+
+  /*!
+    @brief Destructor
+  */
+  inline
+  ~Timer();
+
+  /*!
+    @brief Disallowed copy construction
+    @param[in] a_other Other Timer
+  */
+  Timer(const Timer& a_other) = delete;
+
+  /*!
+    @brief Disallowed move construction
+    @param[in] a_other Other Timer
+  */
+  Timer(const Timer&& a_other) = delete;
+
+  /*!
+    @brief Disallowed copy assignement
+    @param[in] a_other Other Timer
+  */
+  Timer& operator=(const Timer& a_other) = delete;
+
+  /*!
+    @brief Disallowed move assignement
+    @param[in] a_other Other Timer
+  */
+  Timer& operator=(const Timer&& a_other) = delete;
+
+  /*!
+    @brief Start an event
+    @param[in] a_event Event name
+    @note This will give a run-time error if the event has already been started (i.e. startEvent(a_event) has not been called prior). 
+  */
+  inline
+  void startEvent(const std::string a_event);
+
+  /*!
+    @brief Stop an event
+    @param[in] a_event Event name
+    @note This will give a run-time error if the event has not already been started (i.e. startEvent(a_event) has not been called prior). 
+  */
+  inline
+  void stopEvent(const std::string a_event);
+
+  /*!
+    @brief Reset all events. 
+    @note This clears out m_events. 
+  */
+  inline
+  void resetEvents();
+
+protected:
+
+  /*!
+    @brief Enum for indexing tuple. A rare case of where unscoped enums are useful. 
+  */
+  enum EventFields {
+    StoppedEvent = 0,
+    StartClock   = 1,
+    StopClock    = 2
+  };
+
+  /*!
+    @brief Timer events. First entry is the name of the event, the second is the time.
+  */
+  std::map<std::string, std::tuple<bool, TimePoint, TimePoint> > m_events;
 };
 
 #include <CD_NamespaceFooter.H>
+
+#include <CD_TimerImplem.H>
+
+#endif

--- a/Source/Utilities/CD_TimerImplem.H
+++ b/Source/Utilities/CD_TimerImplem.H
@@ -17,12 +17,15 @@
 
 inline
 Real Timer::wallClock(){
-
+#ifdef CH_MPI
+  return MPI_Wtime();
+#else
   // TLDR: This just returns the current time in seconds (since an arbitrary time in the past). 
   const auto currentTime       = std::chrono::steady_clock::now();
   const auto durationInSeconds = std::chrono::duration<Real>(currentTime.time_since_epoch());
 
   return durationInSeconds.count();
+#endif
 }
 
 inline
@@ -31,7 +34,7 @@ Timer::~Timer() {
 }
 
 inline
-void Timer::startEvent(const std::string a_event) {
+void Timer::startEvent(const std::string a_event) noexcept {
 
   // Only start an event if it has not already been started. 
   if (m_events.find(a_event) == m_events.end() ) {
@@ -42,7 +45,7 @@ void Timer::startEvent(const std::string a_event) {
 }
 
 inline
-void Timer::stopEvent(const std::string a_event) {
+void Timer::stopEvent(const std::string a_event) noexcept {
   if (m_events.find(a_event) == m_events.end()) {
     tuple<bool, TimePoint, TimePoint>& event = m_events.at(a_event);
 

--- a/Source/Utilities/CD_TimerImplem.H
+++ b/Source/Utilities/CD_TimerImplem.H
@@ -1,0 +1,61 @@
+/* chombo-discharge
+ * Copyright © 2021 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_TimerImplem.H
+  @brief  Implementation of CD_Timer.H
+  @author Robert Marskar
+*/
+
+#ifndef CD_TimerImplem_H
+#define CD_TimerImplem_H
+
+#include <CD_Timer.H>
+#include <CD_NamespaceHeader.H>
+
+inline
+Real Timer::wallClock(){
+
+  // TLDR: This just returns the current time in seconds (since an arbitrary time in the past). 
+  const auto currentTime       = std::chrono::steady_clock::now();
+  const auto durationInSeconds = std::chrono::duration<Real>(currentTime.time_since_epoch());
+
+  return durationInSeconds.count();
+}
+
+inline
+Timer::~Timer() {
+  m_events.clear();
+}
+
+inline
+void Timer::startEvent(const std::string a_event) {
+
+  // Only start an event if it has not already been started. 
+  if (m_events.find(a_event) == m_events.end() ) {
+    const TimePoint start = Clock::now();
+    
+    m_events.emplace(a_event, std::make_tuple(false, start, start));
+  }
+}
+
+inline
+void Timer::stopEvent(const std::string a_event) {
+  if (m_events.find(a_event) == m_events.end()) {
+    tuple<bool, TimePoint, TimePoint>& event = m_events.at(a_event);
+
+    const TimePoint start = std::get<StartClock>(event);
+    const TimePoint stop  = Clock::now();
+
+    event = std::make_tuple(true, start, stop);
+  }
+  else{
+    std::cerr << "Timer::stopEvent -- event '" + a_event + "' has not been started\n";
+  }
+}
+ 
+#include <CD_NamespaceFooter.H>
+
+#endif


### PR DESCRIPTION
This PR ensures that HDF5 and MPI guards are in place so chombo-discharge can be compiled for serial/parallel executation with or without HDF5.

Closes #95  