### PR TITLE
Guard against divide-by-zero in Helmholtz kernel

### DIFF
--- a/Examples/CdrPlasma/PositiveStreamerProfiledSurface/example2d.inputs
+++ b/Examples/CdrPlasma/PositiveStreamerProfiledSurface/example2d.inputs
@@ -42,7 +42,7 @@ Driver.ebis_memory_load_balance        = false            # If using Chombo geo-
 Driver.plot_interval                   = 10               # Plot interval
 Driver.checkpoint_interval             = 10               # Checkpoint interval
 Driver.regrid_interval                 = 10               # Regrid interval
-Driver.write_regrid_files              = false            # Write regrid files or not.
+Driver.write_regrid_files              = true             # Write regrid files or not.
 Driver.write_restart_files             = false            # Write restart files or not
 Driver.initial_regrids                 = 4                # Number of initial regrids
 Driver.start_time                      = 0                # Start time (fresh simulations only)
@@ -105,22 +105,22 @@ CdrGodunov.bc.z.lo               = data                    # 'data', 'function',
 CdrGodunov.bc.z.hi               = data                    # 'data', 'function', 'wall', or 'outflow'
 CdrGodunov.limit_slopes          = true                    # Use slope-limiters for godunov
 CdrGodunov.plt_vars              = phi vel src dco ebflux  # Plot variables. Options are 'phi', 'vel', 'dco', 'src'
-CdrGodunov.extrap_source         = false                   # Flag for including source term for time-extrapolation
+CdrGodunov.extrap_source         = false                    # Flag for including source term for time-extrapolation
 CdrGodunov.plot_mode             = density                 # Plot densities 'density' or particle numbers ('numbers')
 CdrGodunov.blend_conservation    = true                    # Turn on/off blending with nonconservative divergenceo
 CdrGodunov.redist_mass_weighted  = false                   # Mass weighted redistribution or not
-CdrGodunov.gmg_verbosity         = -1                      # GMG verbosity
-CdrGodunov.gmg_pre_smooth        = 12                      # Number of relaxations in GMG downsweep
-CdrGodunov.gmg_post_smooth       = 12                      # Number of relaxations in upsweep
-CdrGodunov.gmg_bott_smooth       = 12                      # NUmber of relaxations before dropping to bottom solver
+CdrGodunov.gmg_verbosity         = 10                      # GMG verbosity
+CdrGodunov.gmg_pre_smooth        = 16                      # Number of relaxations in GMG downsweep
+CdrGodunov.gmg_post_smooth       = 16                      # Number of relaxations in upsweep
+CdrGodunov.gmg_bott_smooth       = 16                      # NUmber of relaxations before dropping to bottom solver
 CdrGodunov.gmg_min_iter          = 5                       # Minimum number of iterations
 CdrGodunov.gmg_max_iter          = 32                      # Maximum number of iterations
-CdrGodunov.gmg_exit_tol          = 1.E-8                   # Residue tolerance
+CdrGodunov.gmg_exit_tol          = 1.E-10                  # Residue tolerance
 CdrGodunov.gmg_exit_hang         = 0.2                     # Solver hang
-CdrGodunov.gmg_min_cells         = 16                      # Bottom drop
+CdrGodunov.gmg_min_cells         = 8                       # Bottom drop
 CdrGodunov.gmg_bottom_solver     = bicgstab                # Bottom solver type. Valid options are 'simple' and 'bicgstab'
 CdrGodunov.gmg_cycle             = vcycle                  # Cycle type. Only 'vcycle' supported for now
-CdrGodunov.gmg_smoother          = red_black               # Relaxation type. 'jacobi', 'multi_color', or 'red_black'
+CdrGodunov.gmg_smoother          = jacobi               # Relaxation type. 'jacobi', 'multi_color', or 'red_black'
 
 # ====================================================================================================
 # EddingtonSP1 class options
@@ -221,7 +221,7 @@ CdrPlasmaGodunovStepper.fhd              = false     # Set to true if you want t
 CdrPlasmaGodunovStepper.source_comp      = interp    # Interpolated 'interp' or cell-average 'cell_ave' for source computations
 CdrPlasmaGodunovStepper.extrap_advect    = true      # Use time-extrapolation capabilities (if they exist) in the CdrSolver
 CdrPlasmaGodunovStepper.floor_cdr        = true      # Floor CDR solvers to avoid negative densities
-CdrPlasmaGodunovStepper.debug            = false     # Turn on debugging messages. Also monitors mass if it was injected into the system. 
+CdrPlasmaGodunovStepper.debug            = true      # Turn on debugging messages. Also monitors mass if it was injected into the system. 
 
 # ====================================================================================================
 # AIR3_BOURDON CLASS OPTIONS
@@ -233,8 +233,8 @@ CdrPlasmaAir3Bourdon.temperature         = 300                             # Gas
 CdrPlasmaAir3Bourdon.use_alpha_corr      = true                            # Soloviev alpha correction	
 CdrPlasmaAir3Bourdon.mobile_electrons    = true                            # Mobile Electrons or not
 CdrPlasmaAir3Bourdon.diffusive_electrons = true                            # Diffusive Electrons or not
-CdrPlasmaAir3Bourdon.mobile_ions         = true                            # Mobile ions or not
-CdrPlasmaAir3Bourdon.diffusive_ions      = true                            # Diffusive ions or not
+CdrPlasmaAir3Bourdon.mobile_ions         = false                            # Mobile ions or not
+CdrPlasmaAir3Bourdon.diffusive_ions      = false                            # Diffusive ions or not
 CdrPlasmaAir3Bourdon.ion_mobility        = 2.E-4                           # Ion mobility
 
 CdrPlasmaAir3Bourdon.uniform_density       = 1.E10                         # Uniform density
@@ -271,7 +271,7 @@ CdrPlasmaStreamerTagger.verbosity         = -1           # Verbosity
 CdrPlasmaStreamerTagger.num_boxes         = 0            # Number of allowed tag boxes (0 = tags allowe everywhere)
 CdrPlasmaStreamerTagger.box1_lo           = 0.0 0.0 0.0  # Only allow tags that fall between
 CdrPlasmaStreamerTagger.box1_hi           = 0.0 0.0 0.0  # these two corners
-CdrPlasmaStreamerTagger.buffer            = 8            # Grow tagged cells
+CdrPlasmaStreamerTagger.buffer            = 4            # Grow tagged cells
 
 CdrPlasmaStreamerTagger.refine_curvature  = 10000.0         # Curvature refinement
 CdrPlasmaStreamerTagger.coarsen_curvature = 10000.0         # Curvature coarsening	

--- a/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
+++ b/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
@@ -1124,11 +1124,11 @@ void CdrPlasmaStepper::computeCdrDiffusionFace(Vector<EBAMRFluxData*>&       a_d
     const int idx = solver_it.index();
 
     if(solver->isDiffusive()){ // Only need to do this for diffusive things
-      DataOps::setValue(*a_diffusionCoefficient_face[idx], 1.0);
+      DataOps::setValue(*a_diffusionCoefficient_face[idx], 0.0);
       m_amr->averageDown(diffco[idx], m_realm, m_cdr->getPhase());
       m_amr->interpGhost(diffco[idx], m_realm, m_cdr->getPhase()); 
 
-      DataOps::averageCellToFaceAllComps(*a_diffusionCoefficient_face[idx], diffco[idx], m_amr->getDomains());
+      DataOps::averageCellToFace(*a_diffusionCoefficient_face[idx], diffco[idx], m_amr->getDomains());
     }
   }
 }
@@ -2614,7 +2614,7 @@ void CdrPlasmaStepper::computeElectricField(EBAMRFluxData& a_E_face, const phase
       }
 
     }
-    //    DataOps::averageCellToFaceAllComps(*a_E_face[lvl], *a_E_cell[lvl], m_amr->getDomains()[lvl]);
+    //    DataOps::averageCellToFace(*a_E_face[lvl], *a_E_cell[lvl], m_amr->getDomains()[lvl]);
     a_E_face[lvl]->exchange();
   }
 }

--- a/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
@@ -311,7 +311,7 @@ void CdrSolver::averageVelocityToFaces(EBAMRFluxData& a_faceVelocity, const EBAM
   CH_assert(a_cellVelocity[0]->nComp() == SpaceDim);
 
   for (int lvl = 0; lvl <= m_amr->getFinestLevel(); lvl++){
-    DataOps::averageCellToFace(*a_faceVelocity[lvl], *a_cellVelocity[lvl], m_amr->getDomains()[lvl]);
+    DataOps::averageCellVectorToFaceScalar(*a_faceVelocity[lvl], *a_cellVelocity[lvl], m_amr->getDomains()[lvl]);
     
     a_faceVelocity[lvl]->exchange();
   }

--- a/Source/Elliptic/CD_EBHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_EBHelmholtzOp.cpp
@@ -364,8 +364,6 @@ void EBHelmholtzOp::defineStencils(){
       m_betaDiagWeight[dit()](vof, m_comp) = betaWeight;
     }
   }
-
-
     
   // Compute the alpha-weight and relaxation coefficient. 
   this->computeAlphaWeight();
@@ -677,11 +675,11 @@ void EBHelmholtzOp::applyOp(LevelData<EBCellFAB>&             a_Lphi,
   // do a local copy, but that can end up being expensive since this is called on every relaxation.
   LevelData<EBCellFAB>& phi = (LevelData<EBCellFAB>& ) a_phi;
 
+  phi.exchange();  
+
   if(m_hasCoar && !m_turnOffBCs){
     this->interpolateCF(phi, a_phiCoar, a_homogeneousCFBC);
   }
-  
-  phi.exchange();
 
   // Apply operator in each kernel. 
   const DisjointBoxLayout& dbl = a_Lphi.disjointBoxLayout();
@@ -1482,9 +1480,10 @@ void EBHelmholtzOp::incrementFRFine(const LevelData<EBCellFAB>& a_phiFine, const
   
   // Doing the nasty here -- there's no guarantee that a_phiFine has the ghost cells it needs. 
   LevelData<EBCellFAB>& phiFine = (LevelData<EBCellFAB>&) a_phiFine;
+  phiFine.exchange();
+  
   EBHelmholtzOp& finerOp        = (EBHelmholtzOp&)       (a_finerOp);
   finerOp.inhomogeneousCFInterp(phiFine, a_phi);
-  phiFine.exchange();
 
   LevelData<EBFluxFAB>& fineFlux = finerOp.getFlux();
   const Real scale = 1.0; 

--- a/Source/Elliptic/CD_EBHelmholtzOpF.ChF
+++ b/Source/Elliptic/CD_EBHelmholtzOpF.ChF
@@ -211,21 +211,35 @@
       integer chf_ddecl[ioff;joff;koff]
 
       real_t scaledflux
+      real_t B
+      real_t tol
 
       chf_dterm[
         ioff = chf_id(0,dir);
         joff = chf_id(1, dir);
         koff = chf_id(2, dir)]
 
+      tol = 1.0d-15
+
 c flux and phi are cell-centered but bco is face-centered. 
       if(side .eq. -1) then
-         chf_multido[ghostbox; i;j;k]	       
-            scaledflux         = flux(chf_ix[i+ioff; j+joff; k+koff])/bco(chf_ix[i+ioff; j+joff; k+koff]) 	 
+         chf_multido[ghostbox; i;j;k]
+            B = bco(chf_ix[i+ioff; j+joff; k+koff])
+            if(abs(B) > tol) then
+               scaledflux  = flux(chf_ix[i+ioff; j+joff; k+koff])/B
+            else
+                scaledflux = 0.0
+            endif
             phi(chf_ix[i;j;k]) = phi( chf_ix[i+ioff; j+joff; k+koff]) - scaledflux*dx	 
          chf_enddo      
       else
-         chf_multido[ghostbox; i;j;k]	 
-            scaledflux         = flux(chf_ix[i-ioff; j-joff; k-koff])/bco(chf_ix[i; j; k]) 	 
+         chf_multido[ghostbox; i;j;k]
+            B = bco(chf_ix[i; j; k])
+            if(abs(B) > tol) then
+               scaledflux  = flux(chf_ix[i-ioff; j-joff; k-koff])/B
+            else
+                scaledflux = 0.0
+            endif
             phi(chf_ix[i;j;k]) = phi (chf_ix[i-ioff; j-joff; k-koff]) + scaledflux*dx
          chf_enddo
       endif	 

--- a/Source/RadiativeTransfer/CD_EddingtonSP1.cpp
+++ b/Source/RadiativeTransfer/CD_EddingtonSP1.cpp
@@ -651,10 +651,9 @@ void EddingtonSP1::setHelmholtzCoefficients(){
     m_amr->averageDown(m_helmAco, m_realm, m_phase);
     m_amr->interpGhost(m_helmAco, m_realm, m_phase);
     
-    DataOps::averageCellToFaceAllComps(m_helmBco, m_helmAco, m_amr->getDomains()); // Average aco onto face
-    DataOps::invert(m_helmBco);                                                    // Make m_helmBco = 1./kappa
+    DataOps::averageCellToFace(m_helmBco, m_helmAco, m_amr->getDomains()); // Average aco onto face
+    DataOps::invert(m_helmBco);                                            // Make m_helmBco = 1./kappa
   }
-
 
   DataOps::scale(m_helmAco,      1.0);       // m_helmAco      = kappa
   DataOps::scale(m_helmBco,      1.0/(3.0)); // m_helmBco      = 1/(3*kappa)

--- a/Source/Utilities/CD_DataOps.H
+++ b/Source/Utilities/CD_DataOps.H
@@ -31,21 +31,21 @@ public:
   template <typename T>
   static int sgn(const T a_value);
 
-  static void averageCellToFace(EBAMRFluxData&               a_facedata,
-				const EBAMRCellData&         a_celldata,
+  static void averageCellVectorToFaceScalar(EBAMRFluxData&               a_facedata,
+					    const EBAMRCellData&         a_celldata,
+					    const Vector<ProblemDomain>& a_domains);
+
+  static void averageCellVectorToFaceScalar(LevelData<EBFluxFAB>&       a_facedata,
+					    const LevelData<EBCellFAB>& a_celldata,
+					    const ProblemDomain&        a_domain);
+
+  static void averageCellToFace(EBAMRFluxData& a_face_data,
+				const EBAMRCellData& a_cell_data,
 				const Vector<ProblemDomain>& a_domains);
 
   static void averageCellToFace(LevelData<EBFluxFAB>&       a_facedata,
 				const LevelData<EBCellFAB>& a_celldata,
 				const ProblemDomain&        a_domain);
-
-  static void averageCellToFaceAllComps(EBAMRFluxData& a_face_data,
-					const EBAMRCellData& a_cell_data,
-					const Vector<ProblemDomain>& a_domains);
-
-  static void averageCellToFaceAllComps(LevelData<EBFluxFAB>&       a_facedata,
-					const LevelData<EBCellFAB>& a_celldata,
-					const ProblemDomain&        a_domain);
 
   static void averageFaceToCell(EBAMRCellData&               a_celldata,
 				const EBAMRFluxData&         a_fluxdata,


### PR DESCRIPTION
This PR adds a divide-by-zero guard when injecting the domain flux in EBHelmholtzOp. 