### PR TITLE
Fixing memory leaks after elliptic redesign

### DIFF
--- a/Examples/CdrPlasma/PositiveStreamerProfiledSurface/main.cpp
+++ b/Examples/CdrPlasma/PositiveStreamerProfiledSurface/main.cpp
@@ -34,10 +34,10 @@ int main(int argc, char* argv[]){
   // Get potential from input script 
   std::string basename; 
   {
-     ParmParse pp("PositiveStreamerProfiledSurface");
-     pp.get("potential", g_potential);
-     pp.get("basename",  basename);
-     setPoutBaseName(basename);
+    ParmParse pp("PositiveStreamerProfiledSurface");
+    pp.get("potential", g_potential);
+    pp.get("basename",  basename);
+    setPoutBaseName(basename);
   }
 
   // Set geometry and AMR 
@@ -66,11 +66,15 @@ int main(int argc, char* argv[]){
   timestepper->setRadiativeTransferSolvers(rte);
 
   // Set potential 
-timestepper->setVoltage(potential_curve);
+  timestepper->setVoltage(potential_curve);
 
   // Set up the Driver and run it
   RefCountedPtr<Driver> engine = RefCountedPtr<Driver> (new Driver(compgeom, timestepper, amr, tagger, geocoarsen));
   engine->setupAndRun(input_file);
+
+  delete poi_fact;
+  delete cdr_fact;
+  delete rte_fact;  
 
 #ifdef CH_MPI
   CH_TIMER_REPORT();

--- a/Physics/CdrPlasma/python/app_main.py
+++ b/Physics/CdrPlasma/python/app_main.py
@@ -117,6 +117,12 @@ def write_template(args):
     mainf.write("  engine->setupAndRun(input_file);\n");
     mainf.write("\n")
 
+    mainf.write("  // Clean up memory\n")
+    mainf.write("  delete poi_fact;\n")
+    mainf.write("  delete cdr_fact;\n")
+    mainf.write("  delete rte_fact;\n")
+    mainf.write("\n")    
+
     if args.use_mpi:
         mainf.write("#ifdef CH_MPI\n")
         mainf.write("  CH_TIMER_REPORT();\n")

--- a/Regression/CdrPlasma/Air7Stephens/main.cpp
+++ b/Regression/CdrPlasma/Air7Stephens/main.cpp
@@ -72,6 +72,10 @@ int main(int argc, char* argv[]){
   RefCountedPtr<Driver> engine = RefCountedPtr<Driver> (new Driver(compgeom, timestepper, amr, tagger, geocoarsen));
   engine->setupAndRun(input_file);
 
+  delete poi_fact;
+  delete cdr_fact;
+  delete rte_fact;  
+
 #ifdef CH_MPI
   CH_TIMER_REPORT();
   MPI_Finalize();

--- a/Regression/CdrPlasma/Air9EedBourdon/main.cpp
+++ b/Regression/CdrPlasma/Air9EedBourdon/main.cpp
@@ -72,6 +72,10 @@ int main(int argc, char* argv[]){
   RefCountedPtr<Driver> engine = RefCountedPtr<Driver> (new Driver(compgeom, timestepper, amr, tagger, geocoarsen));
   engine->setupAndRun(input_file);
 
+  delete poi_fact;
+  delete cdr_fact;
+  delete rte_fact;  
+
 #ifdef CH_MPI
   CH_TIMER_REPORT();
   MPI_Finalize();

--- a/Regression/CdrPlasma/AirStreamer/main.cpp
+++ b/Regression/CdrPlasma/AirStreamer/main.cpp
@@ -72,6 +72,10 @@ int main(int argc, char* argv[]){
   RefCountedPtr<Driver> engine = RefCountedPtr<Driver> (new Driver(compgeom, timestepper, amr, tagger, geocoarsen));
   engine->setupAndRun(input_file);
 
+  delete poi_fact;
+  delete cdr_fact;
+  delete rte_fact;
+
 #ifdef CH_MPI
   CH_TIMER_REPORT();
   MPI_Finalize();

--- a/Regression/CdrPlasma/ImExSDC/main.cpp
+++ b/Regression/CdrPlasma/ImExSDC/main.cpp
@@ -72,6 +72,10 @@ int main(int argc, char* argv[]){
   RefCountedPtr<Driver> engine = RefCountedPtr<Driver> (new Driver(compgeom, timestepper, amr, tagger, geocoarsen));
   engine->setupAndRun(input_file);
 
+  delete poi_fact;
+  delete cdr_fact;
+  delete rte_fact;  
+
 #ifdef CH_MPI
   CH_TIMER_REPORT();
   MPI_Finalize();

--- a/Source/ConvectionDiffusionReaction/CD_CdrSolver.H
+++ b/Source/ConvectionDiffusionReaction/CD_CdrSolver.H
@@ -244,13 +244,13 @@ public:
     @brief Set species
     @param[in] a_species Species (where this solver gets its name, charge, initial conditions etc). 
   */
-  virtual void setSpecies(const RefCountedPtr<CdrSpecies> a_species);
+  virtual void setSpecies(const RefCountedPtr<CdrSpecies>& a_species);
   
   /*!
     @brief Set computational geometry
     @param[in] a_computationalGeometry The computational geometry.
   */
-  virtual void setComputationalGeometry(const RefCountedPtr<ComputationalGeometry> a_computationalGeometry);
+  virtual void setComputationalGeometry(const RefCountedPtr<ComputationalGeometry>& a_computationalGeometry);
 
   /*!
     @brief Set the amr object

--- a/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
@@ -28,11 +28,12 @@ constexpr int CdrSolver::m_nComp;
 
 CdrSolver::CdrSolver(){
 
-  // Default options. 
+  // Default options.
+  m_verbosity  = -1;
   m_name       = "CdrSolver";
   m_className  = "CdrSolver";
 
-  this->setRealm(Realm::Primal); // Always primal as default.
+  this->setRealm(Realm::Primal);
   this->setDefaultDomainBC();    // Set default domain BCs (wall)
 }
 
@@ -106,7 +107,7 @@ void CdrSolver::setRealm(const std::string a_realm) {
     pout() << m_name + "::setRealm(std::string)" << endl;
   }
   
-  m_realm = a_realm;
+  m_realm.assign(a_realm);
 }
 
 Vector<std::string> CdrSolver::getPlotVariableNames() const {
@@ -1489,7 +1490,7 @@ void CdrSolver::registerOperators(){
   m_amr->registerOperator(s_noncons_div,     m_realm, m_phase);
 }
 
-void CdrSolver::setComputationalGeometry(const RefCountedPtr<ComputationalGeometry> a_computationalGeometry){
+void CdrSolver::setComputationalGeometry(const RefCountedPtr<ComputationalGeometry>& a_computationalGeometry){
   CH_TIME("CdrSolver::setComputationalGeometry(RefCountedPtr<ComputationalGeometry>)");
   if(m_verbosity > 5){
     pout() << m_name + "::setComputationalGeometry(RefCountedPtr<ComputationalGeometry>)" << endl;
@@ -1575,7 +1576,7 @@ void CdrSolver::setEbIndexSpace(const RefCountedPtr<EBIndexSpace>& a_ebis){
   m_ebis = a_ebis;
 }
 
-void CdrSolver::setSpecies(const RefCountedPtr<CdrSpecies> a_species){
+void CdrSolver::setSpecies(const RefCountedPtr<CdrSpecies>& a_species){
   CH_TIME("CdrSolver::setSpecies(RefCountedPtr<CdrSpecies>)");
   if(m_verbosity > 5){
     pout() << m_name + "::setSpecies(RefCountedPtr<CdrSpecies>)" << endl;

--- a/Source/Driver/CD_Driver.cpp
+++ b/Source/Driver/CD_Driver.cpp
@@ -865,11 +865,13 @@ void Driver::run(const Real a_startTime, const Real a_endTime, const int a_maxSt
       }
 
       // Write checkpoint file
-      if(m_timeStep % m_checkpointInterval == 0 && m_checkpointInterval > 0 || isLastStep == true && m_checkpointInterval > 0){
-	if(m_verbosity > 2){
-	  pout() << "Driver::run -- Writing checkpoint file" << endl;
+      if(m_checkpointInterval > 0){
+	if(m_timeStep % m_checkpointInterval || isLastStep == true){
+	  if(m_verbosity > 2){
+	    pout() << "Driver::run -- Writing checkpoint file" << endl;
+	  }
+	  this->writeCheckpointFile();
 	}
-	this->writeCheckpointFile();
       }
 #endif
 

--- a/Source/Driver/CD_Driver.cpp
+++ b/Source/Driver/CD_Driver.cpp
@@ -40,6 +40,8 @@ Driver::Driver(const RefCountedPtr<ComputationalGeometry>& a_computationalGeomet
 	       const RefCountedPtr<GeoCoarsener>&          a_geoCoarsen){
   CH_TIME("Driver::Driver(RefCPtr<ComputationalGeometry>, RefCPtr<TimeStepper>, RefCPtr<AmrMesh>, RefCPtr<CellTagger>, RefCPtr<GeoCoarsener>)");
 
+  m_verbosity = -1;
+  
   this->setComputationalGeometry(a_computationalGeometry); // Set computational geometry
   this->setTimeStepper(a_timeStepper);                     // Set time stepper
   this->setAmr(a_amr);                                     // Set amr

--- a/Source/Electrostatics/CD_MFHelmholtzElectrostaticDomainBCFactory.H
+++ b/Source/Electrostatics/CD_MFHelmholtzElectrostaticDomainBCFactory.H
@@ -63,7 +63,7 @@ public:
   /*!
     @brief Destructor (does nothing)
   */
-  ~MFHelmholtzElectrostaticDomainBCFactory();
+  virtual ~MFHelmholtzElectrostaticDomainBCFactory();
 
   /*!
     @brief Factory method

--- a/Source/Electrostatics/CD_MFHelmholtzElectrostaticEBBC.H
+++ b/Source/Electrostatics/CD_MFHelmholtzElectrostaticEBBC.H
@@ -53,7 +53,7 @@ public:
   /*!
     @brief Default constructor (does nothing). 
   */
-  ~MFHelmholtzElectrostaticEBBC();
+  virtual ~MFHelmholtzElectrostaticEBBC();
 
   /*!
     @brief No copy assignment

--- a/Source/Electrostatics/CD_MFHelmholtzElectrostaticEBBC.cpp
+++ b/Source/Electrostatics/CD_MFHelmholtzElectrostaticEBBC.cpp
@@ -24,6 +24,10 @@ MFHelmholtzElectrostaticEBBC::MFHelmholtzElectrostaticEBBC(const int a_phase, co
   m_electrostaticBCs = a_electrostaticBCs;
 }
 
+MFHelmholtzElectrostaticEBBC::~MFHelmholtzElectrostaticEBBC(){
+  CH_TIME("MFHelmholtzElectrostaticEBBC::~MFHelmholtzElectrostaticEBBC");
+}
+
 void MFHelmholtzElectrostaticEBBC::setOrder(const int a_order){
   CH_TIME("MFHelmholtzElectrostaticEBBC::setOrder(int)");
   

--- a/Source/Electrostatics/CD_MFHelmholtzElectrostaticEBBCFactory.H
+++ b/Source/Electrostatics/CD_MFHelmholtzElectrostaticEBBCFactory.H
@@ -67,7 +67,7 @@ public:
   /*!
     @brief Default constructor (does nothing)
   */
-  ~MFHelmholtzElectrostaticEBBCFactory();
+  virtual ~MFHelmholtzElectrostaticEBBCFactory();
   
   /*!
     @brief Factory method

--- a/Source/Elliptic/CD_EBHelmholtzDirichletDomainBCFactory.H
+++ b/Source/Elliptic/CD_EBHelmholtzDirichletDomainBCFactory.H
@@ -48,7 +48,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzDirichletDomainBCFactory();
+  virtual ~EBHelmholtzDirichletDomainBCFactory();
 
   /*!
     @brief Set the constant value on the domain side. 

--- a/Source/Elliptic/CD_EBHelmholtzDirichletEBBC.H
+++ b/Source/Elliptic/CD_EBHelmholtzDirichletEBBC.H
@@ -34,7 +34,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzDirichletEBBC();
+  virtual ~EBHelmholtzDirichletEBBC();
 
   /*!
     @brief Set BC order. 

--- a/Source/Elliptic/CD_EBHelmholtzDirichletEBBCFactory.H
+++ b/Source/Elliptic/CD_EBHelmholtzDirichletEBBCFactory.H
@@ -46,7 +46,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzDirichletEBBCFactory();
+  virtual ~EBHelmholtzDirichletEBBCFactory();
 
   /*!
     @brief Set BC order

--- a/Source/Elliptic/CD_EBHelmholtzDomainBC.H
+++ b/Source/Elliptic/CD_EBHelmholtzDomainBC.H
@@ -36,7 +36,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzDomainBC();
+  virtual ~EBHelmholtzDomainBC();
 
   /*!
     @brief Disallowed -- don't see why you would need it.

--- a/Source/Elliptic/CD_EBHelmholtzDomainBCFactory.H
+++ b/Source/Elliptic/CD_EBHelmholtzDomainBCFactory.H
@@ -34,7 +34,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzDomainBCFactory();
+  virtual ~EBHelmholtzDomainBCFactory();
 
   /*!
     @brief Disallowed -- don't see why you would need it.

--- a/Source/Elliptic/CD_EBHelmholtzEBBC.H
+++ b/Source/Elliptic/CD_EBHelmholtzEBBC.H
@@ -36,7 +36,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzEBBC();
+  virtual ~EBHelmholtzEBBC();
 
   /*!
     @brief Disallowed -- don't see why you would need it.

--- a/Source/Elliptic/CD_EBHelmholtzEBBCFactory.H
+++ b/Source/Elliptic/CD_EBHelmholtzEBBCFactory.H
@@ -33,7 +33,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzEBBCFactory();
+  virtual ~EBHelmholtzEBBCFactory();
 
   /*!
     @brief Disallowed -- don't see why you would need it.

--- a/Source/Elliptic/CD_EBHelmholtzNeumannDomainBCFactory.H
+++ b/Source/Elliptic/CD_EBHelmholtzNeumannDomainBCFactory.H
@@ -50,7 +50,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzNeumannDomainBCFactory();
+  virtual ~EBHelmholtzNeumannDomainBCFactory();
 
   /*!
     @brief Set value of dphi/dn on the EB. 

--- a/Source/Elliptic/CD_EBHelmholtzNeumannEBBC.H
+++ b/Source/Elliptic/CD_EBHelmholtzNeumannEBBC.H
@@ -35,7 +35,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzNeumannEBBC();
+  virtual ~EBHelmholtzNeumannEBBC();
 
   /*!
     @brief Set value of dphi/dn on the EB. 

--- a/Source/Elliptic/CD_EBHelmholtzNeumannEBBCFactory.H
+++ b/Source/Elliptic/CD_EBHelmholtzNeumannEBBCFactory.H
@@ -40,7 +40,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzNeumannEBBCFactory();
+  virtual ~EBHelmholtzNeumannEBBCFactory();
 
   /*!
     @brief Set value of dphi/dn on the EB. 

--- a/Source/Elliptic/CD_EBHelmholtzRobinDomainBCFactory.H
+++ b/Source/Elliptic/CD_EBHelmholtzRobinDomainBCFactory.H
@@ -54,7 +54,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzRobinDomainBCFactory();
+  virtual ~EBHelmholtzRobinDomainBCFactory();
 
   /*!
     @brief Set constant coefficients

--- a/Source/Elliptic/CD_EBHelmholtzRobinEBBC.H
+++ b/Source/Elliptic/CD_EBHelmholtzRobinEBBC.H
@@ -65,7 +65,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzRobinEBBC();
+  virtual ~EBHelmholtzRobinEBBC();
 
   /*!
     @brief Set BC order

--- a/Source/Elliptic/CD_EBHelmholtzRobinEBBCFactory.H
+++ b/Source/Elliptic/CD_EBHelmholtzRobinEBBCFactory.H
@@ -64,7 +64,7 @@ public:
   /*!
     @brief Destructor (does nothing). 
   */
-  ~EBHelmholtzRobinEBBCFactory();
+  virtual ~EBHelmholtzRobinEBBCFactory();
 
   /*!
     @brief Set BC order

--- a/Source/Elliptic/CD_MFHelmholtzDirichletDomainBCFactory.H
+++ b/Source/Elliptic/CD_MFHelmholtzDirichletDomainBCFactory.H
@@ -48,7 +48,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~MFHelmholtzDirichletDomainBCFactory();
+  virtual ~MFHelmholtzDirichletDomainBCFactory();
 
   /*!
     @brief Set the constant value on the domain side. 

--- a/Source/Elliptic/CD_MFHelmholtzDirichletEBBC.H
+++ b/Source/Elliptic/CD_MFHelmholtzDirichletEBBC.H
@@ -32,7 +32,7 @@ public:
   /*!
     @brief Default constructor
   */
-  ~MFHelmholtzDirichletEBBC();
+  virtual ~MFHelmholtzDirichletEBBC();
 
   /*!
     @brief Set the value on the EB. 

--- a/Source/Elliptic/CD_MFHelmholtzDomainBCFactory.H
+++ b/Source/Elliptic/CD_MFHelmholtzDomainBCFactory.H
@@ -33,7 +33,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~MFHelmholtzDomainBCFactory();
+  virtual ~MFHelmholtzDomainBCFactory();
 
   /*!
     @brief Disallowed -- don't see why you would need it.

--- a/Source/Elliptic/CD_MFHelmholtzEBBC.H
+++ b/Source/Elliptic/CD_MFHelmholtzEBBC.H
@@ -44,7 +44,7 @@ public:
   /*!
     @brief Default constructor
   */
-  ~MFHelmholtzEBBC();
+  virtual ~MFHelmholtzEBBC();
   
   /*!
     @brief Apply the EB flux. This is the version that is called by EBHelmholtzOp. 

--- a/Source/Elliptic/CD_MFHelmholtzEBBCFactory.H
+++ b/Source/Elliptic/CD_MFHelmholtzEBBCFactory.H
@@ -31,7 +31,7 @@ public:
   /*!
     @brief Default constructor
   */
-  ~MFHelmholtzEBBCFactory();
+  virtual ~MFHelmholtzEBBCFactory();
 
   /*!
     @brief Factory method for 

--- a/Source/Elliptic/CD_MFHelmholtzNeumannDomainBCFactory.H
+++ b/Source/Elliptic/CD_MFHelmholtzNeumannDomainBCFactory.H
@@ -50,7 +50,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~MFHelmholtzNeumannDomainBCFactory();
+  virtual ~MFHelmholtzNeumannDomainBCFactory();
 
   /*!
     @brief Set value of dphi/dn on the EB. 

--- a/Source/Elliptic/CD_MFHelmholtzNeumannEBBC.H
+++ b/Source/Elliptic/CD_MFHelmholtzNeumannEBBC.H
@@ -35,7 +35,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~MFHelmholtzNeumannEBBC();
+  virtual ~MFHelmholtzNeumannEBBC();
 
   /*!
     @brief Set value of dphi/dn on the MF. 

--- a/Source/Elliptic/CD_MFHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzOp.cpp
@@ -175,16 +175,19 @@ MFHelmholtzOp::MFHelmholtzOp(const Location::Cell                             a_
 											ebHelmRelax));
 
 
-    m_helmOps.emplace(iphase, oper);
+    m_helmOps.insert({iphase, oper});
   }
 }
 
 MFHelmholtzOp::~MFHelmholtzOp(){
   CH_TIME("MFHelmholtzOp()::~MFHelmholtzOp()");
+
+  m_helmOps.clear();
 }
 
 void MFHelmholtzOp::setJump(const RefCountedPtr<LevelData<BaseIVFAB<Real> > >& a_jump){
   CH_TIME("MFHelmholtzOp::setJump(RefCountedPtr<BaseIVFAB<Real> >)");
+  
   m_jump = a_jump;
 }
 

--- a/Source/Elliptic/CD_MFHelmholtzRobinDomainBCFactory.H
+++ b/Source/Elliptic/CD_MFHelmholtzRobinDomainBCFactory.H
@@ -54,7 +54,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~MFHelmholtzRobinDomainBCFactory();
+  virtual ~MFHelmholtzRobinDomainBCFactory();
 
   /*!
     @brief Set constant coefficients

--- a/Source/Elliptic/CD_MFHelmholtzRobinEBBC.H
+++ b/Source/Elliptic/CD_MFHelmholtzRobinEBBC.H
@@ -36,7 +36,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~MFHelmholtzRobinEBBC();
+  virtual ~MFHelmholtzRobinEBBC();
 
   /*!
     @brief Set BC order

--- a/Source/Geometry/CD_ScanShop.cpp
+++ b/Source/Geometry/CD_ScanShop.cpp
@@ -534,8 +534,10 @@ void ScanShop::gatherBoxesParallel(Vector<Box>& a_boxes) const {
   }
   receiveBuffer = recv_buf2;
 
-  delete receiveBuffer;
-  delete sendBuffer;
+  delete[] sendCounts;
+  delete[] offsets;
+  delete[] receiveBuffer;
+  delete[] sendBuffer;
 #endif
 }
 

--- a/Source/RadiativeTransfer/CD_EBHelmholtzEddingtonSP1DomainBC.H
+++ b/Source/RadiativeTransfer/CD_EBHelmholtzEddingtonSP1DomainBC.H
@@ -57,7 +57,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzEddingtonSP1DomainBC();
+  virtual ~EBHelmholtzEddingtonSP1DomainBC();
 
   /*!
     @brief Disallowed - don't see why you would need it.

--- a/Source/RadiativeTransfer/CD_EBHelmholtzEddingtonSP1DomainBCFactory.H
+++ b/Source/RadiativeTransfer/CD_EBHelmholtzEddingtonSP1DomainBCFactory.H
@@ -61,7 +61,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzEddingtonSP1DomainBCFactory();
+  virtual ~EBHelmholtzEddingtonSP1DomainBCFactory();
 
   /*!
     @brief Disallowed -- don't see why you would need it.

--- a/Source/RadiativeTransfer/CD_EBHelmholtzLarsenDomainBC.H
+++ b/Source/RadiativeTransfer/CD_EBHelmholtzLarsenDomainBC.H
@@ -67,7 +67,7 @@ public:
   /*!
     @brief Destructor
   */
-  ~EBHelmholtzLarsenDomainBC();
+  virtual ~EBHelmholtzLarsenDomainBC();
 
 protected:
 

--- a/Source/RadiativeTransfer/CD_EBHelmholtzLarsenDomainBCFactory.H
+++ b/Source/RadiativeTransfer/CD_EBHelmholtzLarsenDomainBCFactory.H
@@ -70,7 +70,7 @@ public:
   /*!
     @brief Default constructor
   */
-  ~EBHelmholtzLarsenDomainBCFactory();
+  virtual ~EBHelmholtzLarsenDomainBCFactory();
 
   /*!
     @brief No copy assignment

--- a/Source/RadiativeTransfer/CD_EBHelmholtzLarsenEBBCFactory.H
+++ b/Source/RadiativeTransfer/CD_EBHelmholtzLarsenEBBCFactory.H
@@ -58,7 +58,7 @@ public:
   /*!
     @brief Default constructor
   */
-  ~EBHelmholtzLarsenEBBCFactory();
+  virtual ~EBHelmholtzLarsenEBBCFactory();
 
   /*!
     @brief No copy assignment

--- a/Source/RadiativeTransfer/CD_EBHelmholtzLarsenEBBCFactory.cpp
+++ b/Source/RadiativeTransfer/CD_EBHelmholtzLarsenEBBCFactory.cpp
@@ -39,28 +39,28 @@ void EBHelmholtzLarsenEBBCFactory::setRobinCoefficients(){
   //       the "Larsen coefficients". 
 
   // Using our formulation of the Helmholtz operator, The A-coefficient is 1.5*kappa*kappa*(1+3*r2)/(1-2*r1)
-  m_functionA = [&species=this->m_species, r1=this->m_r1, r2=this->m_r2](const RealVect& a_position){
-    Real val = species->getKappa(a_position);
+  m_functionA = [this](const RealVect& a_position) -> Real {
+    Real val = m_species->getKappa(a_position);
 
     val *= val;
     val *= 3./2.;
-    val *= (1 + 3*r1)/(1 - 2*r2);
+    val *= (1 + 3*m_r1)/(1 - 2*m_r2);
 
     return val;
   };
 
-  m_functionB = [species=this->m_species](const RealVect& a_position){
-    return -species->getKappa(a_position);
+  m_functionB = [this](const RealVect& a_position){
+    return -m_species->getKappa(a_position);
   };
 
   // This is the right-hand side of the Robin BC, i.e. the source function. Time is a dummy parameter, and the user should
   // have captured some external time (e.g., RtSolver::m_time) by reference in the function that was passed into the full constructor. 
-  m_functionC = [source=this->m_source](const RealVect& a_position){
-    return source;
+  m_functionC = [this](const RealVect& a_position){
+    return m_source;
   };
 
-  // Call parent function
-  this->setCoefficients(m_functionA, m_functionB, m_functionC);
+  m_useConstant = false;
+  m_useFunction = true;
 }
 
 #include <CD_NamespaceFooter.H>

--- a/Source/RadiativeTransfer/CD_EBHelmholtzLarsenEBBCFactory.cpp
+++ b/Source/RadiativeTransfer/CD_EBHelmholtzLarsenEBBCFactory.cpp
@@ -39,24 +39,24 @@ void EBHelmholtzLarsenEBBCFactory::setRobinCoefficients(){
   //       the "Larsen coefficients". 
 
   // Using our formulation of the Helmholtz operator, The A-coefficient is 1.5*kappa*kappa*(1+3*r2)/(1-2*r1)
-  m_functionA = [this](const RealVect& a_position) -> Real {
-    Real val = m_species->getKappa(a_position);
+  m_functionA = [&species=this->m_species, r1=this->m_r1, r2=this->m_r2](const RealVect& a_position) -> Real {
+    Real val = species->getKappa(a_position);
 
     val *= val;
     val *= 3./2.;
-    val *= (1 + 3*m_r1)/(1 - 2*m_r2);
+    val *= (1 + 3*r1)/(1 - 2*r2);
 
     return val;
   };
 
-  m_functionB = [this](const RealVect& a_position){
-    return -m_species->getKappa(a_position);
+  m_functionB = [&species=this->m_species](const RealVect& a_position){
+    return -species->getKappa(a_position);
   };
 
   // This is the right-hand side of the Robin BC, i.e. the source function. Time is a dummy parameter, and the user should
   // have captured some external time (e.g., RtSolver::m_time) by reference in the function that was passed into the full constructor. 
-  m_functionC = [this](const RealVect& a_position){
-    return m_source;
+  m_functionC = [source=this->m_source](const RealVect& a_position){
+    return source;
   };
 
   m_useConstant = false;


### PR DESCRIPTION
This PR fixes memory leaks due to an omission of a virtual destructor for the base BC classes in EBHelmholtzOp/MFHelmholtzOp. 

