### PR TITLE
Add run-time profiling to ScanShop

### DIFF
--- a/Source/Geometry/CD_ComputationalGeometry.cpp
+++ b/Source/Geometry/CD_ComputationalGeometry.cpp
@@ -185,14 +185,18 @@ void ComputationalGeometry::buildGasGeometry(GeometryService*&   a_geoserver,
 
   // Build the EBIS geometry. Use either ScanShop or Chombo here. 
   if(m_useScanShop){
-    a_geoserver = static_cast<GeometryService*> (new ScanShop(*m_implicitFunctionGas,
-							      0,
-							      a_finestDx,
-							      a_probLo,
-							      a_finestDomain,
-							      m_scanDomain,
-							      m_maxGhostEB,
-							      s_thresh));
+    ScanShop* scanShop = new ScanShop(*m_implicitFunctionGas,
+				      0,
+				      a_finestDx,
+				      a_probLo,
+				      a_finestDomain,
+				      m_scanDomain,
+				      m_maxGhostEB,
+				      s_thresh);
+
+    scanShop->setProfileFileName("ScanShopReportGasPhase.dat");
+
+    a_geoserver = static_cast<GeometryService*> (scanShop);
   }
   else{ // Chombo geometry generation
     a_geoserver = static_cast<GeometryService*> (new GeometryShop(*m_implicitFunctionGas, 0, a_finestDx*RealVect::Unit, s_thresh));
@@ -240,14 +244,18 @@ void ComputationalGeometry::buildSolidGeometry(GeometryService*&   a_geoserver,
 
     // Build the EBIS geometry. Use either ScanShop or Chombo here. 
     if(m_useScanShop){
-      a_geoserver = static_cast<GeometryService*> (new ScanShop(*m_implicitFunctionSolid,
-								0,
-								a_finestDx,
-								a_probLo,
-								a_finestDomain,
-								m_scanDomain,
-								m_maxGhostEB,
-								s_thresh));
+      ScanShop* scanShop = new ScanShop(*m_implicitFunctionSolid,
+					0,
+					a_finestDx,
+					a_probLo,
+					a_finestDomain,
+					m_scanDomain,
+					m_maxGhostEB,
+					s_thresh);
+
+      scanShop->setProfileFileName("ScanShopReportSolidPhase.dat");
+
+      a_geoserver = static_cast<GeometryService*> (scanShop);
     }
     else{ // Chombo geometry generation
       a_geoserver = static_cast<GeometryService*> (new GeometryShop(*m_implicitFunctionSolid, 0, a_finestDx*RealVect::Unit, s_thresh));

--- a/Source/Geometry/CD_ScanShop.H
+++ b/Source/Geometry/CD_ScanShop.H
@@ -18,6 +18,7 @@
 
 // Our includes
 #include <CD_BoxType.H>
+#include <CD_Timer.H>
 #include <CD_NamespaceHeader.H>
 
 /*!
@@ -58,6 +59,11 @@ public:
   ~ScanShop();
 
   /*!
+    @brief If doing profiling, set the output name.
+  */
+  void setProfileFileName(const std::string a_fileName);
+
+  /*!
     @brief This grid generation method is called by EBISLevel when using distributed data. 
     @param[in] a_domain Problem domain on level
     @param[out] a_grids Load-balanced grids. 
@@ -86,8 +92,44 @@ public:
 				       const Real&          a_dx,
 				       const DataIndex&     a_dit) const override;
 
+  /*!
+    @brief Override of GeometryShop's fillGraph.
+    @details This just wraps a timer around the base version to spot load imbalance.
+    @param[inout] a_regIrregCovered Regular/Covered/Irregular cells
+    @param[inout] a_nodes           Nodes
+    @param[in]    a_validRegion     Grid region
+    @param[in]    a_ghostRegion     Grid region, including ghost cells
+    @param[in]    a_domain          Domain
+    @param[in]    a_probLo          Lower-left corner of computational domain
+    @param[in]    a_dx              Grid resolution
+    @param[in]    a_di              Grid index
+  */
+  virtual void fillGraph(BaseFab<int>&        a_regIrregCovered,
+                         Vector<IrregNode>&   a_nodes,
+                         const Box&           a_validRegion,
+                         const Box&           a_ghostRegion,
+                         const ProblemDomain& a_domain,
+                         const RealVect&      a_probLo,
+                         const Real&          a_dx,
+                         const DataIndex&     a_di) const override;
+
 
 protected:
+
+  /*!
+    @brief Set output file name (if doing profiling)
+  */
+  std::string m_fileName;
+
+  /*!
+    @brief Timer for when we use run-time profiling
+  */
+  mutable Timer m_timer;
+
+  /*!
+    @brief Bool for run-time profiling of ScanShop
+  */
+  bool m_profile;
 
   /*!
     @brief Scan level where we first begin to break up boxes. This is relative the EBIS level. 

--- a/Source/Utilities/CD_Timer.H
+++ b/Source/Utilities/CD_Timer.H
@@ -106,6 +106,14 @@ public:
   inline
   void eventReport(std::ostream& a_outputStream, const bool a_localReportOnly = false) const noexcept;
 
+  /*!
+    @brief Print all timed events to a file.
+    @details This routine prints a header row consisting of the event names. The remaining rows are the timings for the various ranks.
+    @param[in] a_localReportOnly If true, no reduction over mpi
+  */
+  inline
+  void writeReportToFile(const std::string a_fileName) const noexcept;
+
 protected:
 
   /*!

--- a/Source/Utilities/CD_TimerImplem.H
+++ b/Source/Utilities/CD_TimerImplem.H
@@ -15,6 +15,7 @@
 // Std includes
 #include <sstream>
 #include <iostream>
+#include <fstream>
 
 // Chombo includes
 #ifdef CH_MPI
@@ -284,6 +285,63 @@ std::pair<Real, Real> Timer::computeTotalElapsedTime(const bool a_localReportOnl
 #endif        
 
   return std::make_pair(elapsedTimeLocal, elapsedTimeGlobal);
+}
+
+inline
+void Timer::writeReportToFile(const std::string a_fileName) const noexcept {
+
+  // First, go through all events and gather the times on the master rank.
+  std::vector<std::string> headerRow;
+  headerRow.emplace_back("# MPI rank");
+
+  // These are all the times for the finished events. We organize this is a 2D vector which is M x numRank long. Here,
+  // finishedEvents[0] contains the elapsed times for one of the events. The length of finishedEvents[0] is exactly
+  // numRank long
+  std::vector<std::vector<Real> > finishedEvents;
+
+  for (const auto& e : m_events){
+    const std::string&                           eventName = e.first;
+    const std::tuple<bool, TimePoint, Duration>& eventData = e.second;
+
+    const bool finishedEvent = std::get<StoppedEvent>(eventData);
+
+    // If we had an event that finished, we gather all the data on the master rank.
+    if(finishedEvent){
+
+      const Real localEventDuration = std::get<ElapsedTime>(eventData).count();
+      Vector<Real> allTimes(numProc(), 0.0);
+#ifdef CH_MPI
+      constexpr int srcRank = 0;
+      gather(allTimes, localEventDuration, srcRank);
+#else
+      allTimes[0] = localEventDuration;
+#endif
+
+      finishedEvents.emplace_back(allTimes.stdVector());
+      headerRow.     emplace_back(eventName);
+    }
+  }
+
+  // Open a file and start writing.
+  std::ofstream f;
+  f.open(a_fileName, std::ios_base::trunc);
+
+  const int width = 12;
+  for (int col = 0; col < headerRow.size(); col++){
+    f << std::left << std::setw(width) << headerRow[col] << "\t";
+  }
+  f << "\n";
+
+  // Write the data for rank = 0 etc
+  for (int irank = 0; irank < numProc(); irank++){
+    f << std::left << std::setw(width) << irank << "\t";
+    for (int event = 0; event < finishedEvents.size(); event++){
+      f << std::left << std::setw(width) << finishedEvents[event][irank] << "\t";
+    }
+    f << "\n";
+  }
+
+  f.close();
 }
  
 #include <CD_NamespaceFooter.H>


### PR DESCRIPTION
This adds capabilities for spotting load imbalance. 

It also improves Timer by letting it write the report to a file (which is very useful at large scales)