### PR TITLE
Explicit number of ghost cells to ScanShop

### DIFF
--- a/Source/AmrMesh/CD_LoadBalancingImplem.H
+++ b/Source/AmrMesh/CD_LoadBalancingImplem.H
@@ -149,20 +149,29 @@ LoadBalancing::sort(Vector<Box>& a_boxes, Vector<T>& a_loads, const BoxSorting a
   CH_TIME("LoadBalancing::sort");
 
   switch (a_which) {
-  case BoxSorting::None:
+  case BoxSorting::None: {
     break;
-  case BoxSorting::Std:
+  }
+  case BoxSorting::Std: {
     LoadBalancing::standardSort(a_boxes, a_loads);
+
     break;
-  case BoxSorting::Shuffle:
+  }
+  case BoxSorting::Shuffle: {
     LoadBalancing::shuffleSort(a_boxes, a_loads);
+
     break;
-  case BoxSorting::Morton:
+  }
+  case BoxSorting::Morton: {
     LoadBalancing::mortonSort(a_boxes, a_loads);
+
     break;
-  default:
+  }
+  default: {
     MayDay::Abort("LoadBalancing::sort_boxes - unknown algorithm requested");
+
     break;
+  }
   }
 }
 
@@ -217,7 +226,7 @@ LoadBalancing::mortonSort(Vector<Box>& a_boxes, Vector<T>& a_loads)
   std::vector<Box>& b    = a_boxes.stdVector();
   int               bits = maxBits(b.begin(), b.end());
 
-  // Morton sort that motherfucker.
+  // Morton sort.
   std::sort(std::begin(vec), std::end(vec), [bits](const std::pair<Box, T>& v1, const std::pair<Box, T>& v2) -> bool {
     return mortonComparator(bits, v1, v2);
   });
@@ -230,8 +239,6 @@ template <class T>
 bool
 LoadBalancing::mortonComparator(const int a_maxBits, const std::pair<Box, T>& a_lhs, const std::pair<Box, T>& a_rhs)
 {
-  CH_TIME("LoadBalancing::mortonComparator");
-
   const Box& lbox = a_lhs.first;
   const Box& rbox = a_rhs.first;
 
@@ -239,13 +246,17 @@ LoadBalancing::mortonComparator(const int a_maxBits, const std::pair<Box, T>& a_
   const IntVect r = rbox.smallEnd();
 
   for (int i = a_maxBits; i > 0; i--) {
-    const int N = (1 << i); // march from most significant bit to least.
+
+    // March from most significant bit to least.
+    const int N = (1 << i);
 
     for (int dir = CH_SPACEDIM - 1; dir >= 0; dir--) {
-      if ((l[dir] / N) < (r[dir] / N))
+      if ((l[dir] / N) < (r[dir] / N)) {
         return true;
-      else if ((l[dir] / N) > (r[dir] / N))
+      }
+      else if ((l[dir] / N) > (r[dir] / N)) {
         return false;
+      }
     }
   }
 

--- a/Source/Geometry/CD_ComputationalGeometry.cpp
+++ b/Source/Geometry/CD_ComputationalGeometry.cpp
@@ -207,8 +207,14 @@ ComputationalGeometry::buildGasGeometry(GeometryService*&   a_geoserver,
 
   // Build the EBIS geometry. Use either ScanShop or Chombo here.
   if (m_useScanShop) {
-    ScanShop* scanShop =
-      new ScanShop(*m_implicitFunctionGas, 0, a_finestDx, a_probLo, a_finestDomain, m_scanDomain, s_thresh);
+    ScanShop* scanShop = new ScanShop(*m_implicitFunctionGas,
+                                      0,
+                                      a_finestDx,
+                                      a_probLo,
+                                      a_finestDomain,
+                                      m_scanDomain,
+                                      m_maxGhostEB,
+                                      s_thresh);
 
     scanShop->setProfileFileName("ScanShopReportGasPhase.dat");
 
@@ -266,8 +272,14 @@ ComputationalGeometry::buildSolidGeometry(GeometryService*&   a_geoserver,
 
     // Build the EBIS geometry. Use either ScanShop or Chombo here.
     if (m_useScanShop) {
-      ScanShop* scanShop =
-        new ScanShop(*m_implicitFunctionSolid, 0, a_finestDx, a_probLo, a_finestDomain, m_scanDomain, s_thresh);
+      ScanShop* scanShop = new ScanShop(*m_implicitFunctionSolid,
+                                        0,
+                                        a_finestDx,
+                                        a_probLo,
+                                        a_finestDomain,
+                                        m_scanDomain,
+                                        m_maxGhostEB,
+                                        s_thresh);
 
       scanShop->setProfileFileName("ScanShopReportSolidPhase.dat");
 

--- a/Source/Geometry/CD_ScanShop.H
+++ b/Source/Geometry/CD_ScanShop.H
@@ -42,6 +42,7 @@ public:
     @param[in] a_probLo        Physical coordinates of the lower-left corner of simulation domain
     @param[in] a_finestDomain  Finest grid level
     @param[in] a_scanLevel     Scan level, i.e. on which level to initiate the load balancing sequence. 
+    @param[in] a_ebGhost       Number of EB ghost cells
     @param[in] a_thsdhVoF      Threshold for GeometryShop
   */
   ScanShop(const BaseIF&       a_geometry,
@@ -50,6 +51,7 @@ public:
            const RealVect      a_probLo,
            const ProblemDomain a_finestDomain,
            const ProblemDomain a_scanLevel,
+           const int           a_ebGhost   = 4,
            const Real          a_thrshdVoF = 1.0e-16);
 
   /*!

--- a/Source/Geometry/CD_ScanShop.cpp
+++ b/Source/Geometry/CD_ScanShop.cpp
@@ -29,6 +29,7 @@ ScanShop::ScanShop(const BaseIF&       a_localGeom,
                    const RealVect      a_probLo,
                    const ProblemDomain a_finestDomain,
                    const ProblemDomain a_scanLevel,
+                   const int           a_ebGhost,
                    const Real          a_thrshdVoF)
   : GeometryShop(a_localGeom, a_verbosity, a_dx * RealVect::Unit, a_thrshdVoF)
 {
@@ -38,7 +39,7 @@ ScanShop::ScanShop(const BaseIF&       a_localGeom,
   m_baseIF       = &a_localGeom;
   m_hasScanLevel = false;
   m_profile      = false;
-  m_ebGhost      = 4;
+  m_ebGhost      = a_ebGhost;
   m_fileName     = "ScanShopReport.dat";
   m_boxSorting   = BoxSorting::Morton;
 


### PR DESCRIPTION
## Summary

Let ScanShop use a specified number of ghost cells.

## Background

ScanShop used a default number of EB ghosts = 4 when sweeping domains for cut-cells. But this should be an input parameter. 

## Intent

- [x] Fix a bug or incorrect behavior.
- [ ] Add new capabilities.

## Checklist

- [ ] If relevant, add Sphinx documentation in the rst files. 
- [ ] Add doxygen documentation. 
