### PR TITLE
Restructure averaging methods.

### DIFF
--- a/Exec/Convergence/AdvectionDiffusion/C1/program.cpp
+++ b/Exec/Convergence/AdvectionDiffusion/C1/program.cpp
@@ -93,7 +93,7 @@ main(int argc, char* argv[])
       fineEBISL = amr->getEBISLayout("primal", phase::gas)[0];
 
       // Coarsen the fine-grid solution onto the coarse-grid layout
-      EbCoarAve aveOp(fineDBL,
+      EBCoarAve aveOp(fineDBL,
                       coarDBL,
                       fineEBISL,
                       coarEBISL,

--- a/Exec/Convergence/AdvectionDiffusion/C1/program.cpp
+++ b/Exec/Convergence/AdvectionDiffusion/C1/program.cpp
@@ -99,9 +99,8 @@ main(int argc, char* argv[])
                       coarEBISL,
                       coarDomain,
                       refRat,
-                      nComp,
                       &(*(amr->getEBIndexSpace(phase::gas))));
-      aveOp.average(*finePhi[0], *(solver->getPhi()[0]), Interval(0, 0));
+      aveOp.averageData(*finePhi[0], *(solver->getPhi()[0]), Interval(0, 0), Average::Conservative);
 
       // Compute the error average(phi_fine) - coar_phi
       DataOps::incr(finePhi, coarPhi, -1.0);

--- a/Exec/Convergence/AdvectionDiffusion/C1/program.cpp
+++ b/Exec/Convergence/AdvectionDiffusion/C1/program.cpp
@@ -93,13 +93,8 @@ main(int argc, char* argv[])
       fineEBISL = amr->getEBISLayout("primal", phase::gas)[0];
 
       // Coarsen the fine-grid solution onto the coarse-grid layout
-      EBCoarAve aveOp(fineDBL,
-                      coarDBL,
-                      fineEBISL,
-                      coarEBISL,
-                      coarDomain,
-                      refRat,
-                      &(*(amr->getEBIndexSpace(phase::gas))));
+      EBCoarAve
+        aveOp(fineDBL, coarDBL, fineEBISL, coarEBISL, coarDomain, refRat, &(*(amr->getEBIndexSpace(phase::gas))));
       aveOp.averageData(*finePhi[0], *(solver->getPhi()[0]), Interval(0, 0), Average::Conservative);
 
       // Compute the error average(phi_fine) - coar_phi

--- a/Exec/Convergence/CdrPlasma/C1/program.cpp
+++ b/Exec/Convergence/CdrPlasma/C1/program.cpp
@@ -134,13 +134,8 @@ main(int argc, char* argv[])
       fineEBISL = amr->getEBISLayout("primal", phase::gas)[0];
 
       // Coarsen the fine-grid solution onto the coarse-grid layout
-      EBCoarAve aveOp(fineDBL,
-                      coarDBL,
-                      fineEBISL,
-                      coarEBISL,
-                      coarDomain,
-                      refRat,
-                      &(*(amr->getEBIndexSpace(phase::gas))));
+      EBCoarAve
+        aveOp(fineDBL, coarDBL, fineEBISL, coarEBISL, coarDomain, refRat, &(*(amr->getEBIndexSpace(phase::gas))));
       aveOp.averageData(*finePhi[0], *(*cdr->getPhis()[0])[0], Interval(0, 0), Average::Conservative);
 
       // Compute the error average(phi_fine) - coar_phi

--- a/Exec/Convergence/CdrPlasma/C1/program.cpp
+++ b/Exec/Convergence/CdrPlasma/C1/program.cpp
@@ -134,7 +134,7 @@ main(int argc, char* argv[])
       fineEBISL = amr->getEBISLayout("primal", phase::gas)[0];
 
       // Coarsen the fine-grid solution onto the coarse-grid layout
-      EbCoarAve aveOp(fineDBL,
+      EBCoarAve aveOp(fineDBL,
                       coarDBL,
                       fineEBISL,
                       coarEBISL,

--- a/Exec/Convergence/CdrPlasma/C1/program.cpp
+++ b/Exec/Convergence/CdrPlasma/C1/program.cpp
@@ -140,9 +140,8 @@ main(int argc, char* argv[])
                       coarEBISL,
                       coarDomain,
                       refRat,
-                      nComp,
                       &(*(amr->getEBIndexSpace(phase::gas))));
-      aveOp.average(*finePhi[0], *(*cdr->getPhis()[0])[0], Interval(0, 0));
+      aveOp.averageData(*finePhi[0], *(*cdr->getPhis()[0])[0], Interval(0, 0), Average::Conservative);
 
       // Compute the error average(phi_fine) - coar_phi
       DataOps::incr(finePhi, coarPhi, -1.0);

--- a/Exec/Convergence/Electrostatics/C1/program.cpp
+++ b/Exec/Convergence/Electrostatics/C1/program.cpp
@@ -99,9 +99,8 @@ main(int argc, char* argv[])
                       coarEBISL,
                       coarDomain,
                       refRat,
-                      nComp,
                       &(*(amr->getEBIndexSpace(phase::gas))));
-      aveOp.average(*finePhi[0], *(amr->alias(phase::gas, timestepper->getPotential()))[0], Interval(0, 0));
+      aveOp.averageData(*finePhi[0], *(amr->alias(phase::gas, timestepper->getPotential()))[0], Interval(0, 0), Average::Conservative);
 
       // Compute the error average(phi_fine) - coar_phi
       DataOps::incr(finePhi, coarPhi, -1.0);

--- a/Exec/Convergence/Electrostatics/C1/program.cpp
+++ b/Exec/Convergence/Electrostatics/C1/program.cpp
@@ -93,7 +93,7 @@ main(int argc, char* argv[])
       fineEBISL = amr->getEBISLayout("primal", phase::gas)[0];
 
       // Coarsen the fine-grid solution onto the coarse-grid layout
-      EbCoarAve aveOp(fineDBL,
+      EBCoarAve aveOp(fineDBL,
                       coarDBL,
                       fineEBISL,
                       coarEBISL,

--- a/Exec/Convergence/Electrostatics/C1/program.cpp
+++ b/Exec/Convergence/Electrostatics/C1/program.cpp
@@ -93,14 +93,12 @@ main(int argc, char* argv[])
       fineEBISL = amr->getEBISLayout("primal", phase::gas)[0];
 
       // Coarsen the fine-grid solution onto the coarse-grid layout
-      EBCoarAve aveOp(fineDBL,
-                      coarDBL,
-                      fineEBISL,
-                      coarEBISL,
-                      coarDomain,
-                      refRat,
-                      &(*(amr->getEBIndexSpace(phase::gas))));
-      aveOp.averageData(*finePhi[0], *(amr->alias(phase::gas, timestepper->getPotential()))[0], Interval(0, 0), Average::Conservative);
+      EBCoarAve
+        aveOp(fineDBL, coarDBL, fineEBISL, coarEBISL, coarDomain, refRat, &(*(amr->getEBIndexSpace(phase::gas))));
+      aveOp.averageData(*finePhi[0],
+                        *(amr->alias(phase::gas, timestepper->getPotential()))[0],
+                        Interval(0, 0),
+                        Average::Conservative);
 
       // Compute the error average(phi_fine) - coar_phi
       DataOps::incr(finePhi, coarPhi, -1.0);

--- a/Exec/Convergence/Electrostatics/C2/program.cpp
+++ b/Exec/Convergence/Electrostatics/C2/program.cpp
@@ -98,14 +98,12 @@ main(int argc, char* argv[])
       fineEBISL = amr->getEBISLayout("primal", phase::gas)[0];
 
       // Coarsen the fine-grid solution onto the coarse-grid layout
-      EBCoarAve aveOp(fineDBL,
-                      coarDBL,
-                      fineEBISL,
-                      coarEBISL,
-                      coarDomain,
-                      refRat,
-                      &(*(amr->getEBIndexSpace(phase::gas))));
-      aveOp.averageData(*finePhi[0], *(amr->alias(phase::gas, timestepper->getPotential()))[0], Interval(0, 0), Average::Conservative);
+      EBCoarAve
+        aveOp(fineDBL, coarDBL, fineEBISL, coarEBISL, coarDomain, refRat, &(*(amr->getEBIndexSpace(phase::gas))));
+      aveOp.averageData(*finePhi[0],
+                        *(amr->alias(phase::gas, timestepper->getPotential()))[0],
+                        Interval(0, 0),
+                        Average::Conservative);
 
       // Compute the error average(phi_fine) - coar_phi
       DataOps::incr(finePhi, coarPhi, -1.0);

--- a/Exec/Convergence/Electrostatics/C2/program.cpp
+++ b/Exec/Convergence/Electrostatics/C2/program.cpp
@@ -98,7 +98,7 @@ main(int argc, char* argv[])
       fineEBISL = amr->getEBISLayout("primal", phase::gas)[0];
 
       // Coarsen the fine-grid solution onto the coarse-grid layout
-      EbCoarAve aveOp(fineDBL,
+      EBCoarAve aveOp(fineDBL,
                       coarDBL,
                       fineEBISL,
                       coarEBISL,

--- a/Exec/Convergence/Electrostatics/C2/program.cpp
+++ b/Exec/Convergence/Electrostatics/C2/program.cpp
@@ -104,9 +104,8 @@ main(int argc, char* argv[])
                       coarEBISL,
                       coarDomain,
                       refRat,
-                      nComp,
                       &(*(amr->getEBIndexSpace(phase::gas))));
-      aveOp.average(*finePhi[0], *(amr->alias(phase::gas, timestepper->getPotential()))[0], Interval(0, 0));
+      aveOp.averageData(*finePhi[0], *(amr->alias(phase::gas, timestepper->getPotential()))[0], Interval(0, 0), Average::Conservative);
 
       // Compute the error average(phi_fine) - coar_phi
       DataOps::incr(finePhi, coarPhi, -1.0);

--- a/Exec/Convergence/Electrostatics/C3/program.cpp
+++ b/Exec/Convergence/Electrostatics/C3/program.cpp
@@ -103,9 +103,8 @@ main(int argc, char* argv[])
                       coarEBISL,
                       coarDomain,
                       refRat,
-                      nComp,
                       &(*(amr->getEBIndexSpace(phase::gas))));
-      aveOp.average(*finePhi[0], *(amr->alias(phase::gas, timestepper->getPotential()))[0], Interval(0, 0));
+      aveOp.averageData(*finePhi[0], *(amr->alias(phase::gas, timestepper->getPotential()))[0], Interval(0, 0), Average::Conservative);
 
       // Compute the error average(phi_fine) - coar_phi
       DataOps::incr(finePhi, coarPhi, -1.0);

--- a/Exec/Convergence/Electrostatics/C3/program.cpp
+++ b/Exec/Convergence/Electrostatics/C3/program.cpp
@@ -97,7 +97,7 @@ main(int argc, char* argv[])
       fineEBISL = amr->getEBISLayout("primal", phase::gas)[0];
 
       // Coarsen the fine-grid solution onto the coarse-grid layout
-      EbCoarAve aveOp(fineDBL,
+      EBCoarAve aveOp(fineDBL,
                       coarDBL,
                       fineEBISL,
                       coarEBISL,

--- a/Exec/Convergence/Electrostatics/C3/program.cpp
+++ b/Exec/Convergence/Electrostatics/C3/program.cpp
@@ -97,14 +97,12 @@ main(int argc, char* argv[])
       fineEBISL = amr->getEBISLayout("primal", phase::gas)[0];
 
       // Coarsen the fine-grid solution onto the coarse-grid layout
-      EBCoarAve aveOp(fineDBL,
-                      coarDBL,
-                      fineEBISL,
-                      coarEBISL,
-                      coarDomain,
-                      refRat,
-                      &(*(amr->getEBIndexSpace(phase::gas))));
-      aveOp.averageData(*finePhi[0], *(amr->alias(phase::gas, timestepper->getPotential()))[0], Interval(0, 0), Average::Conservative);
+      EBCoarAve
+        aveOp(fineDBL, coarDBL, fineEBISL, coarEBISL, coarDomain, refRat, &(*(amr->getEBIndexSpace(phase::gas))));
+      aveOp.averageData(*finePhi[0],
+                        *(amr->alias(phase::gas, timestepper->getPotential()))[0],
+                        Interval(0, 0),
+                        Average::Conservative);
 
       // Compute the error average(phi_fine) - coar_phi
       DataOps::incr(finePhi, coarPhi, -1.0);

--- a/Exec/Convergence/RadiativeTransfer/C1/program.cpp
+++ b/Exec/Convergence/RadiativeTransfer/C1/program.cpp
@@ -99,9 +99,8 @@ main(int argc, char* argv[])
                       coarEBISL,
                       coarDomain,
                       refRat,
-                      nComp,
                       &(*(amr->getEBIndexSpace(phase::gas))));
-      aveOp.average(*finePhi[0], *timestepper->getPhi()[0], Interval(0, 0));
+      aveOp.averageData(*finePhi[0], *timestepper->getPhi()[0], Interval(0, 0), Average::Conservative);
 
       // Compute the error average(phi_fine) - coar_phi
       DataOps::incr(finePhi, coarPhi, -1.0);

--- a/Exec/Convergence/RadiativeTransfer/C1/program.cpp
+++ b/Exec/Convergence/RadiativeTransfer/C1/program.cpp
@@ -93,7 +93,7 @@ main(int argc, char* argv[])
       fineEBISL = amr->getEBISLayout("primal", phase::gas)[0];
 
       // Coarsen the fine-grid solution onto the coarse-grid layout
-      EbCoarAve aveOp(fineDBL,
+      EBCoarAve aveOp(fineDBL,
                       coarDBL,
                       fineEBISL,
                       coarEBISL,

--- a/Exec/Convergence/RadiativeTransfer/C1/program.cpp
+++ b/Exec/Convergence/RadiativeTransfer/C1/program.cpp
@@ -93,13 +93,8 @@ main(int argc, char* argv[])
       fineEBISL = amr->getEBISLayout("primal", phase::gas)[0];
 
       // Coarsen the fine-grid solution onto the coarse-grid layout
-      EBCoarAve aveOp(fineDBL,
-                      coarDBL,
-                      fineEBISL,
-                      coarEBISL,
-                      coarDomain,
-                      refRat,
-                      &(*(amr->getEBIndexSpace(phase::gas))));
+      EBCoarAve
+        aveOp(fineDBL, coarDBL, fineEBISL, coarEBISL, coarDomain, refRat, &(*(amr->getEBIndexSpace(phase::gas))));
       aveOp.averageData(*finePhi[0], *timestepper->getPhi()[0], Interval(0, 0), Average::Conservative);
 
       // Compute the error average(phi_fine) - coar_phi

--- a/Exec/Examples/AdvectionDiffusion/PipeFlow/example.inputs
+++ b/Exec/Examples/AdvectionDiffusion/PipeFlow/example.inputs
@@ -64,10 +64,10 @@ Driver.refine_dielectrics              = 0                # Refine dielectric su
 # CdrCTU solver settings. 
 # ====================================================================================================
 CdrCTU.seed                 = -1                      # Seed. Random seed with seed < 0
-CdrCTU.bc.x.lo              = wall                    # 'data', 'function', 'wall', 'outflow', or 'solver'
-CdrCTU.bc.x.hi              = wall                    # 'data', 'function', 'wall', 'outflow', or 'solver'
-CdrCTU.bc.y.lo              = wall                    # 'data', 'function', 'wall', 'outflow', or 'solver'
-CdrCTU.bc.y.hi              = wall                    # 'data', 'function', 'wall', 'outflow', or 'solver'
+CdrCTU.bc.x.lo              = solver                    # 'data', 'function', 'wall', 'outflow', or 'solver'
+CdrCTU.bc.x.hi              = solver                    # 'data', 'function', 'wall', 'outflow', or 'solver'
+CdrCTU.bc.y.lo              = solver                    # 'data', 'function', 'wall', 'outflow', or 'solver'
+CdrCTU.bc.y.hi              = solver                    # 'data', 'function', 'wall', 'outflow', or 'solver'
 CdrCTU.bc.z.lo              = wall                    # 'data', 'function', 'wall', 'outflow', or 'solver'
 CdrCTU.bc.z.hi              = wall                    # 'data', 'function', 'wall', 'outflow', or 'solver'
 CdrCTU.slope_limiter        = minmod                  # Slope limiter. 'none', 'minmod', 'mc', or 'superbee'
@@ -153,7 +153,7 @@ AdvectionDiffusion.diffco         = 1.E-1   # Diffusion coefficient
 
 # Time step settings
 # ------------------
-AdvectionDiffusion.cfl            = 0.5     # CFL number
+AdvectionDiffusion.cfl            = 0.8     # CFL number
 AdvectionDiffusion.min_dt         = 0.0     # Smallest acceptable time step
 AdvectionDiffusion.max_dt         = 1.E99   # Largest acceptable time step
 

--- a/Physics/AdvectionDiffusion/CD_AdvectionDiffusionStepper.cpp
+++ b/Physics/AdvectionDiffusion/CD_AdvectionDiffusionStepper.cpp
@@ -437,7 +437,7 @@ AdvectionDiffusionStepper::advance(const Real a_dt)
     break;
   }
 
-  m_amr->averageDown(state, m_realm, m_phase);
+  m_amr->conservativeAverage(state, m_realm, m_phase);
   m_amr->interpGhost(state, m_realm, m_phase);
 
   // Compute final mass.

--- a/Physics/BrownianWalker/CD_BrownianWalkerStepper.cpp
+++ b/Physics/BrownianWalker/CD_BrownianWalkerStepper.cpp
@@ -171,7 +171,7 @@ BrownianWalkerStepper::setVelocity()
   DataOps::setValue(vel, veloFunc, m_amr->getProbLo(), m_amr->getDx());
 
   // Coarsen and update ghost cells.
-  m_amr->averageDown(vel, m_realm, m_phase);
+  m_amr->conservativeAverage(vel, m_realm, m_phase);
   m_amr->interpGhostMG(vel, m_realm, m_phase);
 
   DataOps::setCoveredValue(vel, 0, 0.0);

--- a/Physics/CdrPlasma/CD_CdrPlasmaFieldTagger.cpp
+++ b/Physics/CdrPlasma/CD_CdrPlasmaFieldTagger.cpp
@@ -74,7 +74,7 @@ CdrPlasmaFieldTagger::computeElectricField(EBAMRCellData& a_electricField, EBAMR
   // Now compute grad(|E|).
   m_amr->computeGradient(a_gradElectricField, m_scratch, m_realm, phase::gas);
 
-  m_amr->averageDown(a_gradElectricField, m_realm, m_phase);
+  m_amr->conservativeAverage(a_gradElectricField, m_realm, m_phase);
   m_amr->interpGhost(a_gradElectricField, m_realm, m_phase);
 
   // Interpolate everything to centroids since that is the only place where things make sense.
@@ -205,14 +205,14 @@ CdrPlasmaFieldTagger::computeTracers() const
 
   // Coarsen the data.
   for (int i = 0; i < m_numTracers; i++) {
-    m_amr->averageDown(m_tracers[i], m_realm, m_phase);
+    m_amr->conservativeAverage(m_tracers[i], m_realm, m_phase);
     m_amr->interpGhost(m_tracers[i], m_realm, m_phase);
   }
 
   // Compute gradients.
   for (int i = 0; i < m_numTracers; i++) {
     m_amr->computeGradient(m_gradTracers[i], m_tracers[i], m_realm, phase::gas);
-    m_amr->averageDown(m_gradTracers[i], m_realm, m_phase);
+    m_amr->conservativeAverage(m_gradTracers[i], m_realm, m_phase);
   }
 
   // No need to keep this transient storage lying around so we delete it.

--- a/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
+++ b/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
@@ -251,7 +251,7 @@ CdrPlasmaStepper::computeFaceConductivity(EBAMRFluxData&       a_conductivityFac
 #endif
 
   // Coarsen coefficients.
-  m_amr->averageFaces(a_conductivityFace, m_realm, phase::gas);
+  m_amr->arithmeticAverage(a_conductivityFace, m_realm, phase::gas);
   m_amr->conservativeAverage(a_conductivityEB, m_realm, phase::gas);
 }
 
@@ -319,7 +319,7 @@ CdrPlasmaStepper::setupSemiImplicitPoisson(const EBAMRFluxData& a_conductivityFa
   DataOps::incr(permEBGas, a_conductivityEB, a_factor);
 
   // Coarsen coefficients.
-  m_amr->averageFaces(permFaceGas, m_realm, phase::gas);
+  m_amr->arithmeticAverage(permFaceGas, m_realm, phase::gas);
   m_amr->conservativeAverage(permEBGas, m_realm, phase::gas);
 
   // Set up the solver with the new "permittivities".
@@ -4723,7 +4723,7 @@ CdrPlasmaStepper::writePhysics(EBAMRCellData& a_output, int& a_icomp) const
 
         fineAlias.exchange();
 
-        m_amr->conservativeAverage(coarAlias, fineAlias, lvl, m_realm, phase::gas);
+	m_amr->conservativeAverage(coarAlias, fineAlias, lvl, m_realm, phase::gas);
 
         coarAlias.exchange();
       }

--- a/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
+++ b/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
@@ -4723,7 +4723,7 @@ CdrPlasmaStepper::writePhysics(EBAMRCellData& a_output, int& a_icomp) const
 
         fineAlias.exchange();
 
-	m_amr->conservativeAverage(coarAlias, fineAlias, lvl, m_realm, phase::gas);
+        //	m_amr->conservativeAverage(coarAlias, fineAlias, lvl, m_realm, phase::gas);
 
         coarAlias.exchange();
       }

--- a/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
+++ b/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
@@ -4708,30 +4708,8 @@ CdrPlasmaStepper::writePhysics(EBAMRCellData& a_output, int& a_icomp) const
     }
 
     // I want to coarsen and interpolate this data because it might otherwise contain bogus values.
-    for (int comp = 0; comp < numVars; comp++) {
-
-      const Interval interv(a_icomp + comp, a_icomp + comp);
-
-      // Coarsen loop
-      for (int lvl = m_amr->getFinestLevel(); lvl > 0; lvl--) {
-
-        LevelData<EBCellFAB> fineAlias;
-        LevelData<EBCellFAB> coarAlias;
-
-        aliasLevelData(fineAlias, &(*a_output[lvl]), interv);
-        aliasLevelData(coarAlias, &(*a_output[lvl - 1]), interv);
-
-        fineAlias.exchange();
-
-#if 1 // Development code
-        MayDay::Error("CD_CdrPlamaStepper.cpp -- fix the coarsening with the new signatures");
-#else // Original code
-        m_amr->conservativeAverage(coarAlias, fineAlias, lvl, m_realm, phase::gas);
-#endif
-
-        coarAlias.exchange();
-      }
-    }
+    const Interval interv(a_icomp, a_icomp + numVars - 1);
+    m_amr->conservativeAverage(a_output, m_realm, phase::gas, interv);
 
     // Need to let the outside world know that we've written to some of the variables.
     a_icomp += numVars;

--- a/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
+++ b/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
@@ -4723,7 +4723,11 @@ CdrPlasmaStepper::writePhysics(EBAMRCellData& a_output, int& a_icomp) const
 
         fineAlias.exchange();
 
-        //	m_amr->conservativeAverage(coarAlias, fineAlias, lvl, m_realm, phase::gas);
+#if 1 // Development code
+	MayDay::Error("CD_CdrPlamaStepper.cpp -- fix the coarsening with the new signatures");
+#else // Original code
+	m_amr->conservativeAverage(coarAlias, fineAlias, lvl, m_realm, phase::gas);
+#endif
 
         coarAlias.exchange();
       }

--- a/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
+++ b/Physics/CdrPlasma/CD_CdrPlasmaStepper.cpp
@@ -4724,9 +4724,9 @@ CdrPlasmaStepper::writePhysics(EBAMRCellData& a_output, int& a_icomp) const
         fineAlias.exchange();
 
 #if 1 // Development code
-	MayDay::Error("CD_CdrPlamaStepper.cpp -- fix the coarsening with the new signatures");
+        MayDay::Error("CD_CdrPlamaStepper.cpp -- fix the coarsening with the new signatures");
 #else // Original code
-	m_amr->conservativeAverage(coarAlias, fineAlias, lvl, m_realm, phase::gas);
+        m_amr->conservativeAverage(coarAlias, fineAlias, lvl, m_realm, phase::gas);
 #endif
 
         coarAlias.exchange();

--- a/Physics/CdrPlasma/Timesteppers/CdrPlasmaGodunovStepper/CD_CdrPlasmaGodunovStepper.cpp
+++ b/Physics/CdrPlasma/Timesteppers/CdrPlasmaGodunovStepper/CD_CdrPlasmaGodunovStepper.cpp
@@ -422,10 +422,10 @@ CdrPlasmaGodunovStepper::regrid(const int a_lmin, const int a_oldFinestLevel, co
                             m_regridSlopes);
 
     // Coarsen the conductivity and space charge from the last step and update ghost cells.
-    m_amr->averageDown(m_conductivityFactorCell, m_realm, m_phase);
+    m_amr->conservativeAverage(m_conductivityFactorCell, m_realm, m_phase);
     m_amr->interpGhostMG(m_conductivityFactorCell, m_realm, m_phase);
 
-    m_amr->averageDown(m_semiImplicitRho, m_realm, m_phase);
+    m_amr->conservativeAverage(m_semiImplicitRho, m_realm, m_phase);
     m_amr->interpGhostMG(m_semiImplicitRho, m_realm, m_phase);
 
     // Set up the semi-implicit Poisson equation and solve it.
@@ -503,10 +503,10 @@ CdrPlasmaGodunovStepper::postCheckpointSetup()
 
     // When we enter this routine we will already have called read the checkpoint data into the conductivityFactor and semiimplicit space charge. We need
     // to set up the field solver with those quantities rather than the regular space charge.
-    m_amr->averageDown(m_conductivityFactorCell, m_realm, m_phase);
+    m_amr->conservativeAverage(m_conductivityFactorCell, m_realm, m_phase);
     m_amr->interpGhostMG(m_conductivityFactorCell, m_realm, m_phase);
 
-    m_amr->averageDown(m_semiImplicitRho, m_realm, m_phase);
+    m_amr->conservativeAverage(m_semiImplicitRho, m_realm, m_phase);
     m_amr->interpGhostMG(m_semiImplicitRho, m_realm, m_phase);
 
     this->computeFaceConductivity(m_conductivityFactorFace, m_conductivityFactorEB, m_conductivityFactorCell);
@@ -562,7 +562,7 @@ CdrPlasmaGodunovStepper::solveSemiImplicitPoisson()
   DataOps::setValue(rho, 0.0);
   DataOps::copy(rhoPhase, m_semiImplicitRho);
 
-  m_amr->averageDown(rho, m_realm);
+  m_amr->conservativeAverage(rho, m_realm);
   m_amr->interpGhostMG(rho, m_realm);
 
   m_amr->interpToCentroids(rhoPhase, m_realm, m_phase);
@@ -714,13 +714,13 @@ CdrPlasmaGodunovStepper::computeCdrGradients()
     // Update the ghost cells so we can compute the gradient.
     scratch.copy(solver->getPhi());
 
-    m_amr->averageDown(scratch, m_realm, m_phase);
+    m_amr->conservativeAverage(scratch, m_realm, m_phase);
     m_amr->interpGhostMG(scratch, m_realm, m_phase);
 
     // Compute the gradient, coarsen it, and update the ghost cells.
     m_amr->computeGradient(grad, scratch, m_realm, phase::gas);
 
-    m_amr->averageDown(grad, m_realm, m_cdr->getPhase());
+    m_amr->conservativeAverage(grad, m_realm, m_cdr->getPhase());
     m_amr->interpGhost(grad, m_realm, m_cdr->getPhase());
   }
 }
@@ -1165,7 +1165,7 @@ CdrPlasmaGodunovStepper::advanceTransportExplicitField(const Real a_dt)
       }
 
       // Coarsen the solution and update ghost cells.
-      m_amr->averageDown(phi, m_realm, m_cdr->getPhase());
+      m_amr->conservativeAverage(phi, m_realm, m_cdr->getPhase());
       m_amr->interpGhost(phi, m_realm, m_cdr->getPhase());
     }
 
@@ -1207,7 +1207,7 @@ CdrPlasmaGodunovStepper::advanceTransportExplicitField(const Real a_dt)
     }
 
     // Coarsen the solution and update ghost cells.
-    m_amr->averageDown(phi, m_realm, m_cdr->getPhase());
+    m_amr->conservativeAverage(phi, m_realm, m_cdr->getPhase());
     m_amr->interpGhost(phi, m_realm, m_cdr->getPhase());
   }
   m_timer->stopEvent("Transport advance");
@@ -1233,7 +1233,7 @@ CdrPlasmaGodunovStepper::advanceTransportSemiImplicit(const Real a_dt)
   this->computeCellConductivity(m_conductivityFactorCell);
   DataOps::scale(m_conductivityFactorCell, a_dt / Units::eps0);
 
-  m_amr->averageDown(m_conductivityFactorCell, m_realm, m_phase);
+  m_amr->conservativeAverage(m_conductivityFactorCell, m_realm, m_phase);
   m_amr->interpGhostMG(m_conductivityFactorCell, m_realm, m_phase);
 
   // Average conductivity to faces and set up the semi-implicit poisson equation.

--- a/Physics/CdrPlasma/Timesteppers/CdrPlasmaImExSdcStepper/CD_CdrPlasmaImExSdcStepper.cpp
+++ b/Physics/CdrPlasma/Timesteppers/CdrPlasmaImExSdcStepper/CD_CdrPlasmaImExSdcStepper.cpp
@@ -699,7 +699,7 @@ CdrPlasmaImExSdcStepper::computeFD0()
         solver->computeDivD(FD_0, phi_0, false, false, false); // Domain fluxes always come in through advection terms.
 
         // Shouldn't be necesary
-        m_amr->averageDown(FD_0, m_realm, m_cdr->getPhase());
+        m_amr->conservativeAverage(FD_0, m_realm, m_cdr->getPhase());
         m_amr->interpGhost(FD_0, m_realm, m_cdr->getPhase());
       }
       else {
@@ -871,7 +871,7 @@ CdrPlasmaImExSdcStepper::integrateAdvectionReaction(const Real a_dt, const int a
       DataOps::incr(phi_m1, src, m_dtm[a_m]); // phi_(m+1) = phi_m + dtm*(FA_m + FR_m)
 
       // This shouldn't be necessary
-      m_amr->averageDown(phi_m1, m_realm, m_cdr->getPhase());
+      m_amr->conservativeAverage(phi_m1, m_realm, m_cdr->getPhase());
       m_amr->interpGhost(phi_m1, m_realm, m_cdr->getPhase());
 
       if (a_lagged_terms) { // Back up the old slope first, we will need it for the lagged term
@@ -884,7 +884,7 @@ CdrPlasmaImExSdcStepper::integrateAdvectionReaction(const Real a_dt, const int a
       DataOps::scale(FAR_m, 1. / m_dtm[a_m]); // :
 
       // Shouldn't be necessary
-      m_amr->averageDown(FAR_m, m_realm, m_cdr->getPhase());
+      m_amr->conservativeAverage(FAR_m, m_realm, m_cdr->getPhase());
       m_amr->interpGhost(FAR_m, m_realm, m_cdr->getPhase());
     }
 
@@ -966,7 +966,7 @@ CdrPlasmaImExSdcStepper::integrateAdvection(const Real a_dt, const int a_m, cons
       DataOps::copy(phi_m1, phi_m);
       DataOps::incr(phi_m1, scratch, -m_dtm[a_m]);
       DataOps::floor(phi_m1, 0.0);
-      m_amr->averageDown(phi_m1, m_realm, m_cdr->getPhase());
+      m_amr->conservativeAverage(phi_m1, m_realm, m_cdr->getPhase());
       m_amr->interpGhost(phi_m1, m_realm, m_cdr->getPhase());
     }
     else {
@@ -1014,7 +1014,7 @@ CdrPlasmaImExSdcStepper::integrateDiffusion(const Real a_dt, const int a_m, cons
         const EBAMRCellData& FD_m1k = storage->getFD()[a_m + 1]; // FD_(m+1)^k. Lagged term.
         DataOps::incr(init_soln, FD_m1k, -m_dtm[a_m]);
       }
-      m_amr->averageDown(init_soln, m_realm, m_cdr->getPhase());
+      m_amr->conservativeAverage(init_soln, m_realm, m_cdr->getPhase());
       m_amr->interpGhost(init_soln, m_realm, m_cdr->getPhase());
       DataOps::copy(phi_m1, phi_m);
 
@@ -1025,7 +1025,7 @@ CdrPlasmaImExSdcStepper::integrateDiffusion(const Real a_dt, const int a_m, cons
       else {
         solver->advanceEuler(phi_m1, init_soln, source, m_dtm[a_m]); // No source.
       }
-      m_amr->averageDown(phi_m1, m_realm, m_cdr->getPhase());
+      m_amr->conservativeAverage(phi_m1, m_realm, m_cdr->getPhase());
       m_amr->interpGhost(phi_m1, m_realm, m_cdr->getPhase());
       DataOps::floor(phi_m1, 0.0);
 
@@ -1036,7 +1036,7 @@ CdrPlasmaImExSdcStepper::integrateDiffusion(const Real a_dt, const int a_m, cons
       DataOps::incr(FD_m1k, init_soln, -1.0);
       DataOps::scale(FD_m1k, 1. / m_dtm[a_m]);
 
-      m_amr->averageDown(FD_m1k, m_realm, m_cdr->getPhase());
+      m_amr->conservativeAverage(FD_m1k, m_realm, m_cdr->getPhase());
       m_amr->interpGhost(FD_m1k, m_realm, m_cdr->getPhase());
     }
     else {
@@ -1102,7 +1102,7 @@ CdrPlasmaImExSdcStepper::reconcileIntegrands()
       }
 
       // Shouldn't be necessary
-      m_amr->averageDown(F_m, m_realm, m_cdr->getPhase());
+      m_amr->conservativeAverage(F_m, m_realm, m_cdr->getPhase());
       m_amr->interpGhost(F_m, m_realm, m_cdr->getPhase());
     }
   }
@@ -1513,7 +1513,7 @@ CdrPlasmaImExSdcStepper::computeCdrGradients(const Vector<EBAMRCellData*>& a_phi
     RefCountedPtr<CdrStorage>& storage = CdrPlasmaImExSdcStepper::getCdrStorage(solver_it);
     EBAMRCellData&             grad    = storage->getGradient();
     m_amr->computeGradient(grad, *a_phis[idx], m_realm, m_cdr->getPhase());
-    //    m_amr->averageDown(grad, m_realm, m_cdr->getPhase());
+    //    m_amr->conservativeAverage(grad, m_realm, m_cdr->getPhase());
     m_amr->interpGhost(grad, m_realm, m_cdr->getPhase());
   }
 }

--- a/Physics/ItoPlasma/CD_ItoPlasmaFieldTagger.cpp
+++ b/Physics/ItoPlasma/CD_ItoPlasmaFieldTagger.cpp
@@ -69,7 +69,7 @@ ItoPlasmaFieldTagger::computeElectricField(EBAMRCellData& a_E, EBAMRCellData& a_
   DataOps::vectorLength(m_scratch, a_E);
   m_amr->computeGradient(a_grad_E, m_scratch, m_realm, phase::gas);
 
-  m_amr->averageDown(a_grad_E, m_realm, m_phase);
+  m_amr->conservativeAverage(a_grad_E, m_realm, m_phase);
   m_amr->interpGhost(a_grad_E, m_realm, m_phase);
 
   // Interpolate to centroids
@@ -160,14 +160,14 @@ ItoPlasmaFieldTagger::computeTracers()
   }
 
   for (int i = 0; i < m_num_tracers; i++) {
-    m_amr->averageDown(m_tracer[i], m_realm, m_phase);
+    m_amr->conservativeAverage(m_tracer[i], m_realm, m_phase);
     m_amr->interpGhost(m_tracer[i], m_realm, m_phase);
   }
 
   // Compute gradient of tracers
   for (int i = 0; i < m_num_tracers; i++) {
     m_amr->computeGradient(m_grad_tracer[i], m_tracer[i], m_realm, m_phase);
-    m_amr->averageDown(m_grad_tracer[i], m_realm, m_phase);
+    m_amr->conservativeAverage(m_grad_tracer[i], m_realm, m_phase);
   }
 
   this->deallocateStorage(); // No reason to keep the extra storage lying around...

--- a/Physics/ItoPlasma/CD_ItoPlasmaStepper.cpp
+++ b/Physics/ItoPlasma/CD_ItoPlasmaStepper.cpp
@@ -246,7 +246,7 @@ ItoPlasmaStepper::initialSigma()
     }
   }
 
-  m_amr->averageDown(sigma, m_fluid_Realm, phase::gas);
+  m_amr->conservativeAverage(sigma, m_fluid_Realm, phase::gas);
   m_sigma->resetCells(sigma);
 }
 
@@ -283,7 +283,7 @@ ItoPlasmaStepper::postCheckpointPoisson()
   // Do ghost cells and then compute E
   MFAMRCellData& state = m_fieldSolver->getPotential();
 
-  m_amr->averageDown(state, m_fluid_Realm);
+  m_amr->conservativeAverage(state, m_fluid_Realm);
   m_amr->interpGhost(state, m_fluid_Realm);
 
   m_fieldSolver->computeElectricField(); // Solver checkpoints the potential. Now compute the field.
@@ -295,13 +295,13 @@ ItoPlasmaStepper::postCheckpointPoisson()
 
   // Fluid Realm
   m_fluid_E.copy(E);
-  m_amr->averageDown(m_fluid_E, m_fluid_Realm, m_phase);
+  m_amr->conservativeAverage(m_fluid_E, m_fluid_Realm, m_phase);
   m_amr->interpGhostPwl(m_fluid_E, m_fluid_Realm, m_phase);
   m_amr->interpToCentroids(m_fluid_E, m_fluid_Realm, m_phase);
 
   // Particle Realm
   m_particle_E.copy(E);
-  m_amr->averageDown(m_particle_E, m_particleRealm, m_phase);
+  m_amr->conservativeAverage(m_particle_E, m_particleRealm, m_phase);
   m_amr->interpGhostPwl(m_particle_E, m_particleRealm, m_phase);
   m_amr->interpToCentroids(m_particle_E, m_particleRealm, m_phase);
 
@@ -986,7 +986,7 @@ ItoPlasmaStepper::computeElectricField(MFAMRCellData& a_E, const MFAMRCellData& 
 
   m_fieldSolver->computeElectricField(a_E, a_potential);
 
-  m_amr->averageDown(a_E, m_fluid_Realm);
+  m_amr->conservativeAverage(a_E, m_fluid_Realm);
   m_amr->interpGhost(a_E, m_fluid_Realm);
 }
 
@@ -1013,7 +1013,7 @@ ItoPlasmaStepper::computeElectricField(EBAMRCellData&           a_E,
 
   m_fieldSolver->computeElectricField(a_E, a_phase, a_potential);
 
-  m_amr->averageDown(a_E, m_fluid_Realm, a_phase);
+  m_amr->conservativeAverage(a_E, m_fluid_Realm, a_phase);
   m_amr->interpGhost(a_E, m_fluid_Realm, a_phase);
 }
 
@@ -1117,7 +1117,7 @@ ItoPlasmaStepper::computeSpaceChargeDensity(MFAMRCellData& a_rho, const Vector<E
 
   DataOps::scale(a_rho, Units::Qe);
 
-  m_amr->averageDown(a_rho, m_fluid_Realm);
+  m_amr->conservativeAverage(a_rho, m_fluid_Realm);
   m_amr->interpGhost(a_rho, m_fluid_Realm);
 
   // Add potential filters.
@@ -1133,7 +1133,7 @@ ItoPlasmaStepper::computeSpaceChargeDensity(MFAMRCellData& a_rho, const Vector<E
         DataOps::setCoveredValue(m_fluid_scratch1, 0.0, 0);
         DataOps::filterSmooth(rhoPhase, m_fluid_scratch1, stride, alpha);
 
-        m_amr->averageDown(rhoPhase, m_fluid_Realm, m_phase);
+        m_amr->conservativeAverage(rhoPhase, m_fluid_Realm, m_phase);
         m_amr->interpGhost(rhoPhase, m_fluid_Realm, m_phase);
       }
     }
@@ -1185,7 +1185,7 @@ ItoPlasmaStepper::computeConductivity(EBAMRCellData&                            
 
   DataOps::scale(a_conductivity, Units::Qe);
 
-  m_amr->averageDown(a_conductivity, m_fluid_Realm, m_phase);
+  m_amr->conservativeAverage(a_conductivity, m_fluid_Realm, m_phase);
   m_amr->interpGhostPwl(a_conductivity, m_fluid_Realm, m_phase);
 
   // See if this helps....
@@ -1323,13 +1323,13 @@ ItoPlasmaStepper::solvePoisson()
 
   // Fluid Realm
   m_fluid_E.copy(E);
-  m_amr->averageDown(m_fluid_E, m_fluid_Realm, m_phase);
+  m_amr->conservativeAverage(m_fluid_E, m_fluid_Realm, m_phase);
   m_amr->interpGhostPwl(m_fluid_E, m_fluid_Realm, m_phase);
   m_amr->interpToCentroids(m_fluid_E, m_fluid_Realm, m_phase);
 
   // Particle Realm
   m_particle_E.copy(E);
-  m_amr->averageDown(m_particle_E, m_particleRealm, m_phase);
+  m_amr->conservativeAverage(m_particle_E, m_particleRealm, m_phase);
   m_amr->interpGhostPwl(m_particle_E, m_particleRealm, m_phase);
   m_amr->interpToCentroids(m_particle_E, m_particleRealm, m_phase);
 
@@ -1840,7 +1840,7 @@ ItoPlasmaStepper::computeItoMobilitiesLFA(Vector<EBAMRCellData*>& a_meshMobiliti
 
 #if 0 // In principle, we should be able to average down and interpolate on the fluid Realm and then copy directly to the particle Realm. \
       // But we need to make sure that EBAMRData::copy also gets ghost cells 
-      m_amr->averageDown(m_fscratch1[idx], m_fluid_Realm, m_phase);
+      m_amr->conservativeAverage(m_fscratch1[idx], m_fluid_Realm, m_phase);
       m_amr->interpGhost(m_fscratch1[idx], m_fluid_Realm, m_phase);
 
       a_meshMobilities[idx]->copy(m_fscratch1[idx]);
@@ -1848,7 +1848,7 @@ ItoPlasmaStepper::computeItoMobilitiesLFA(Vector<EBAMRCellData*>& a_meshMobiliti
       // Copy to particle Realm, build ghost cells and the interpolate the mobilities to particle positions.
       a_meshMobilities[idx]->copy(m_fscratch1[idx]);
 
-      m_amr->averageDown(*a_meshMobilities[idx], m_particleRealm, m_phase);
+      m_amr->conservativeAverage(*a_meshMobilities[idx], m_particleRealm, m_phase);
       m_amr->interpGhost(*a_meshMobilities[idx], m_particleRealm, m_phase);
 #endif
 
@@ -2014,13 +2014,13 @@ ItoPlasmaStepper::computeItoDiffusionLFA(Vector<EBAMRCellData*>&       a_diffusi
     if (solver->isDiffusive()) {
 
 #if 0 // In principle, we should be able to average down and interpolate ghost cells on the fluid Realm, and copy the entire result over to the particle Realm.
-      m_amr->averageDown(m_fscratch1[idx], m_fluid_Realm, m_phase);
+      m_amr->conservativeAverage(m_fscratch1[idx], m_fluid_Realm, m_phase);
       m_amr->interpGhost(m_fscratch2[idx], m_fluid_Realm, m_phase);
       a_diffusionCoefficient_funcs[idx]->copy(m_fluid_scratch1[idx]);
 #else // Instead, we copy to the particle Realm and average down there, then interpolate.
       a_diffusionCoefficient_funcs[idx]->copy(m_fscratch1[idx]);
 
-      m_amr->averageDown(*a_diffusionCoefficient_funcs[idx], m_particleRealm, m_phase);
+      m_amr->conservativeAverage(*a_diffusionCoefficient_funcs[idx], m_particleRealm, m_phase);
       m_amr->interpGhost(*a_diffusionCoefficient_funcs[idx], m_particleRealm, m_phase);
 #endif
 
@@ -3552,7 +3552,7 @@ ItoPlasmaStepper::computeEdotJSourceNWO()
       DataOps::dotProduct(m_fluid_scratch1, m_fluid_E, m_fluid_scratchD); // m_particle_scratch1 = E.dot.(E*mu*n)
       DataOps::scale(m_fluid_scratch1, Abs(q) * Units::Qe);               // m_particle_scratch1 = Z*e*mu*n*E*E
 
-      m_amr->averageDown(m_fluid_scratch1, m_fluid_Realm, m_phase);
+      m_amr->conservativeAverage(m_fluid_scratch1, m_fluid_Realm, m_phase);
       m_amr->interpGhost(m_fluid_scratch1, m_fluid_Realm, m_phase);
       DataOps::plus(m_EdotJ, m_fluid_scratch1, 0, idx, 1); // a_source[idx] += Z*e*mu*n*E*E
     }
@@ -3568,7 +3568,7 @@ ItoPlasmaStepper::computeEdotJSourceNWO()
       DataOps::dotProduct(m_fluid_scratch1, m_fluid_scratchD, m_fluid_E);                 // scratch1 = -E.dot.grad(D*n)
       DataOps::scale(m_fluid_scratch1, Abs(q) * Units::Qe);                               // scratch1 = -Z*e*E*grad(D*n)
 
-      m_amr->averageDown(m_fluid_scratch1, m_fluid_Realm, m_phase);
+      m_amr->conservativeAverage(m_fluid_scratch1, m_fluid_Realm, m_phase);
       m_amr->interpGhost(m_fluid_scratch1, m_fluid_Realm, m_phase);
 
       DataOps::plus(m_EdotJ, m_fluid_scratch1, 0, idx, 1); // source  += -Z*e*E*grad(D*n)

--- a/Physics/ItoPlasma/TimeSteppers/ItoPlasmaGodunovStepper/CD_ItoPlasmaGodunovStepper.cpp
+++ b/Physics/ItoPlasma/TimeSteppers/ItoPlasmaGodunovStepper/CD_ItoPlasmaGodunovStepper.cpp
@@ -1019,7 +1019,7 @@ ItoPlasmaGodunovStepper::compute_cell_conductivity(
         DataOps::setCoveredValue(m_fluid_scratch1, 0.0, 0);
         DataOps::filterSmooth(a_conductivity, m_fluid_scratch1, stride, alpha);
 
-        m_amr->averageDown(a_conductivity, m_fluid_Realm, m_phase);
+        m_amr->conservativeAverage(a_conductivity, m_fluid_Realm, m_phase);
         m_amr->interpGhost(a_conductivity, m_fluid_Realm, m_phase);
       }
     }
@@ -1027,7 +1027,7 @@ ItoPlasmaGodunovStepper::compute_cell_conductivity(
 
   DataOps::scale(a_conductivity, Units::Qe);
 
-  m_amr->averageDown(a_conductivity, m_fluid_Realm, m_phase);
+  m_amr->conservativeAverage(a_conductivity, m_fluid_Realm, m_phase);
   m_amr->interpGhostPwl(a_conductivity, m_fluid_Realm, m_phase);
 
   // See if this helps....
@@ -1093,8 +1093,8 @@ ItoPlasmaGodunovStepper::setupSemiImplicitPoisson(const Real a_dt)
   DataOps::incr(bco_gas, m_conduct_face, 1.0);
   DataOps::incr(bco_irr_gas, m_conduct_eb, 1.0);
 
-  m_amr->averageDown(bco_gas, m_fluid_Realm, phase::gas);
-  m_amr->averageDown(bco_irr_gas, m_fluid_Realm, phase::gas);
+  m_amr->conservativeAverage(bco_gas, m_fluid_Realm, phase::gas);
+  m_amr->conservativeAverage(bco_irr_gas, m_fluid_Realm, phase::gas);
 
   // Set up the solver
   m_fieldSolver->setupSolver();

--- a/Physics/TracerParticle/CD_TracerParticleStepperImplem.H
+++ b/Physics/TracerParticle/CD_TracerParticleStepperImplem.H
@@ -402,7 +402,7 @@ TracerParticleStepper<P>::setVelocity()
 
   DataOps::setValue(m_velocity, velFunc, m_amr->getProbLo(), m_amr->getDx());
 
-  m_amr->averageDown(m_velocity, m_realm, m_phase);
+  m_amr->conservativeAverage(m_velocity, m_realm, m_phase);
   m_amr->interpGhost(m_velocity, m_realm, m_phase);
 }
 

--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -659,6 +659,21 @@ public:
 
   /*!
     @brief Average down on specific realm and phase. 
+    @param[inout] a_data      Data to be coarsened.
+    @param[in]    a_realm     Realm
+    @param[in]    a_phase     Phase (gas or solid)
+    @param[in]    a_variables Variables to average
+    @param[in]    a_average   Averaging method
+  */
+  void
+  average(EBAMRCellData&           a_data,
+          const std::string        a_realm,
+          const phase::which_phase a_phase,
+          const Average&           a_average,
+          const Interval&          a_variables) const;
+
+  /*!
+    @brief Arithmetic average of data. Does all components. 
     @param[inout] a_data  Data to be coarsened.
     @param[in]    a_realm Realm name
     @param[in]    a_phase Phase (gas or solid)
@@ -667,7 +682,20 @@ public:
   arithmeticAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
 
   /*!
-    @brief Average down on specific realm and phase. 
+    @brief Arithmetic average of data. 
+    @param[inout] a_data      Data to be coarsened.
+    @param[in]    a_realm     Realm name
+    @param[in]    a_phase     Phase (gas or solid)
+    @param[in]    a_variables Variables
+  */
+  void
+  arithmeticAverage(EBAMRCellData&           a_data,
+                    const std::string        a_realm,
+                    const phase::which_phase a_phase,
+                    const Interval&          a_variables) const;
+
+  /*!
+    @brief Harmonic average of data. Does all components. 
     @param[inout] a_data  Data to be coarsened.
     @param[in]    a_realm Realm name
     @param[in]    a_phase Phase (gas or solid)
@@ -676,13 +704,39 @@ public:
   harmonicAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
 
   /*!
-    @brief Average down on specific realm and phase. 
+    @brief Harmonic average of data. Does all components. 
+    @param[inout] a_data      Data to be coarsened.
+    @param[in]    a_realm     Realm name
+    @param[in]    a_phase     Phase (gas or solid)
+    @param[in]    a_variables Variables
+  */
+  void
+  harmonicAverage(EBAMRCellData&           a_data,
+                  const std::string        a_realm,
+                  const phase::which_phase a_phase,
+                  const Interval&          a_variables) const;
+
+  /*!
+    @brief Conseratively average data. Does all components. 
     @param[inout] a_data  Data to be coarsened.
     @param[in]    a_realm Realm name
     @param[in]    a_phase Phase (gas or solid)
   */
   void
   conservativeAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
+
+  /*!
+    @brief Conseratively average data. Does all components. 
+    @param[inout] a_data      Data to be coarsened.
+    @param[in]    a_realm     Realm name
+    @param[in]    a_phase     Phase (gas or solid)
+    @param[in]    a_variables Variables
+  */
+  void
+  conservativeAverage(EBAMRCellData&           a_data,
+                      const std::string        a_realm,
+                      const phase::which_phase a_phase,
+                      const Interval&          a_variables) const;
 
   /*!
     @brief Average down on specific realm and phase. 

--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -575,13 +575,66 @@ public:
   */
   void
   reallocate(MFAMRIVData& a_data, const int a_lmin) const;
+
   /*!
-    @brief Average down multifluid data over a realm. 
+    @brief Average multifluid data over a specified realm
+    @param[inout] a_data    Data to be coarsened.
+    @param[in]    a_realm   Realm name
+    @param[in]    a_average Averaging method
+  */
+  void
+  average(MFAMRCellData& a_data, const std::string a_realm, const Average& a_average) const;
+
+  /*!
+    @brief Arithmetic coarsening of multifluid data.
+    @param[inout] a_data  Data to be coarsened.
+    @param[in]    a_realm Realm name
+  */
+  void
+  arithmeticAverage(MFAMRCellData& a_data, const std::string a_realm) const;
+
+  /*!
+    @brief Harmonic coarsening of multifluid data.
+    @param[inout] a_data  Data to be coarsened.
+    @param[in]    a_realm Realm name
+  */
+  void
+  harmonicAverage(MFAMRCellData& a_data, const std::string a_realm) const;      
+  
+  /*!
+    @brief Conservative coarsening of multifluid data.
     @param[inout] a_data  Data to be coarsened.
     @param[in]    a_realm Realm name
   */
   void
   conservativeAverage(MFAMRCellData& a_data, const std::string a_realm) const;
+
+    /*!
+    @brief Average multifluid data over a specified realm
+    @param[inout] a_data    Data to be coarsened.
+    @param[in]    a_realm   Realm name
+    @param[in]    a_average Averaging method
+  */
+  void
+  average(MFAMRFluxData& a_data, const std::string a_realm, const Average& a_average) const;
+  
+  /*!
+    @brief Average multifluid data over a realm. 
+    @details This computes an arithmetic average of the face data. Data on coarse faces is replaced by the arithmetic average of the fine face data. 
+    @param[inout] a_data  Data to be coarsened.
+    @param[in]    a_realm Realm name
+  */
+  void
+  arithmeticAverage(MFAMRFluxData& a_data, const std::string a_realm) const;
+  
+  /*!
+    @brief Average multifluid data over a realm. 
+    @details This computes an arithmetic average of the face data. Data on coarse faces is replaced by the arithmetic average of the fine face data. 
+    @param[inout] a_data  Data to be coarsened.
+    @param[in]    a_realm Realm name
+  */
+  void
+  harmonicAverage(MFAMRFluxData& a_data, const std::string a_realm) const;    
 
   /*!
     @brief Average down multifluid data over a realm. 
@@ -592,13 +645,32 @@ public:
   conservativeAverage(MFAMRFluxData& a_data, const std::string a_realm) const;
 
   /*!
-    @brief Average multifluid data over a realm. 
-    @details This computes an arithmetic average of the face data. Data on coarse faces is replaced by the arithmetic average of the fine face data. 
+    @brief Average down on specific realm and phase. 
     @param[inout] a_data  Data to be coarsened.
     @param[in]    a_realm Realm name
+    @param[in]    a_phase Phase (gas or solid)
+    @param[in]    a_average Averaging method
   */
   void
-  averageFaces(MFAMRFluxData& a_data, const std::string a_realm) const;
+  average(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase, const Average& a_average) const;
+
+  /*!
+    @brief Average down on specific realm and phase. 
+    @param[inout] a_data  Data to be coarsened.
+    @param[in]    a_realm Realm name
+    @param[in]    a_phase Phase (gas or solid)
+  */
+  void
+  arithmeticAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
+
+  /*!
+    @brief Average down on specific realm and phase. 
+    @param[inout] a_data  Data to be coarsened.
+    @param[in]    a_realm Realm name
+    @param[in]    a_phase Phase (gas or solid)
+  */
+  void
+  harmonicAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;    
 
   /*!
     @brief Average down on specific realm and phase. 
@@ -614,29 +686,30 @@ public:
     @param[inout] a_data  Data to be coarsened.
     @param[in]    a_realm Realm name
     @param[in]    a_phase Phase (gas or solid)
-    @param[in]    a_level The coarse level.
-    @details This coarsens data from level a_lvl+1 to level a_lvl
+    @param[in]    a_average Averaging method
   */
   void
-  conservativeAverage(EBAMRCellData&           a_data,
-                      const std::string        a_realm,
-                      const phase::which_phase a_phase,
-                      const int                a_lvl) const;
+  average(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase, const Average& a_average) const;
 
   /*!
-    @brief Coarsen cells over a realm. This does a specific level. 
-    @param[inout] a_coarData Coarse grid data
-    @param[inout] a_fineData Fine grid data
-    @param[in]    a_level    The grid level corresponding to a_fineData
-    @param[in]    a_realm    Realm name
-    @param[in]    a_phase    Phase (gas or solid)
+    @brief Average down on specific realm and phase. 
+    @details This computes an arithmetic average of the face data. Data on coarse faces is replaced by the arithmetic average of the fine face data. 
+    @param[inout] a_data  Data to be average.
+    @param[in]    a_realm Realm name
+    @param[in]    a_phase Phase (gas or solid)
   */
   void
-  conservativeAverage(LevelData<EBCellFAB>&       a_coarData,
-                      const LevelData<EBCellFAB>& a_fineData,
-                      const int                   a_level,
-                      const std::string           a_realm,
-                      const phase::which_phase    a_phase) const;
+  arithmeticAverage(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
+
+  /*!
+    @brief Average down on specific realm and phase. 
+    @details This computes an arithmetic average of the face data. Data on coarse faces is replaced by the arithmetic average of the fine face data. 
+    @param[inout] a_data  Data to be average.
+    @param[in]    a_realm Realm name
+    @param[in]    a_phase Phase (gas or solid)
+  */
+  void
+  harmonicAverage(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;    
 
   /*!
     @brief Average down on specific realm and phase. 
@@ -649,31 +722,40 @@ public:
 
   /*!
     @brief Average down on specific realm and phase. 
-    @details This computes an arithmetic average of the face data. Data on coarse faces is replaced by the arithmetic average of the fine face data. 
-    @param[inout] a_data  Data to be average.
+    @param[inout] a_data  Data to be coarsened.
+    @param[in]    a_realm Realm name
+    @param[in]    a_phase Phase (gas or solid)
+    @param[in]    a_average Averaging method
+  */
+  void
+  average(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase, const Average& a_average) const;  
+
+  /*!
+    @brief Arithmetic average on specific realm and phase. 
+    @param[inout] a_data  Data to be coarsened.
     @param[in]    a_realm Realm name
     @param[in]    a_phase Phase (gas or solid)
   */
   void
-  averageFaces(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
+  arithmeticAverage(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
 
   /*!
-    @brief Average down on specific realm and phase. 
+    @brief Harmonic average on specific realm and phase. 
+    @param[inout] a_data  Data to be coarsened.
+    @param[in]    a_realm Realm name
+    @param[in]    a_phase Phase (gas or solid)
+  */
+  void
+  harmonicAverage(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;  
+
+  /*!
+    @brief Conservative averaging on specific realm and phase.
     @param[inout] a_data  Data to be coarsened.
     @param[in]    a_realm Realm name
     @param[in]    a_phase Phase (gas or solid)
   */
   void
   conservativeAverage(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
-
-  /*!
-    @brief Do conservative coarsening for data defined on cut-cells. 
-    @param[inout] a_data  Data to be coarsened.
-    @param[in]    a_realm Realm name
-    @param[in]    a_phase Phase (gas or solid)
-  */
-  void
-  conservativeAverage(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase);
 
   /*!
     @brief Deposit scalar particle quantities on the mesh. 

--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -599,8 +599,8 @@ public:
     @param[in]    a_realm Realm name
   */
   void
-  harmonicAverage(MFAMRCellData& a_data, const std::string a_realm) const;      
-  
+  harmonicAverage(MFAMRCellData& a_data, const std::string a_realm) const;
+
   /*!
     @brief Conservative coarsening of multifluid data.
     @param[inout] a_data  Data to be coarsened.
@@ -609,7 +609,7 @@ public:
   void
   conservativeAverage(MFAMRCellData& a_data, const std::string a_realm) const;
 
-    /*!
+  /*!
     @brief Average multifluid data over a specified realm
     @param[inout] a_data    Data to be coarsened.
     @param[in]    a_realm   Realm name
@@ -617,7 +617,7 @@ public:
   */
   void
   average(MFAMRFluxData& a_data, const std::string a_realm, const Average& a_average) const;
-  
+
   /*!
     @brief Average multifluid data over a realm. 
     @details This computes an arithmetic average of the face data. Data on coarse faces is replaced by the arithmetic average of the fine face data. 
@@ -626,7 +626,7 @@ public:
   */
   void
   arithmeticAverage(MFAMRFluxData& a_data, const std::string a_realm) const;
-  
+
   /*!
     @brief Average multifluid data over a realm. 
     @details This computes an arithmetic average of the face data. Data on coarse faces is replaced by the arithmetic average of the fine face data. 
@@ -634,7 +634,7 @@ public:
     @param[in]    a_realm Realm name
   */
   void
-  harmonicAverage(MFAMRFluxData& a_data, const std::string a_realm) const;    
+  harmonicAverage(MFAMRFluxData& a_data, const std::string a_realm) const;
 
   /*!
     @brief Average down multifluid data over a realm. 
@@ -652,7 +652,10 @@ public:
     @param[in]    a_average Averaging method
   */
   void
-  average(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase, const Average& a_average) const;
+  average(EBAMRCellData&           a_data,
+          const std::string        a_realm,
+          const phase::which_phase a_phase,
+          const Average&           a_average) const;
 
   /*!
     @brief Average down on specific realm and phase. 
@@ -670,7 +673,7 @@ public:
     @param[in]    a_phase Phase (gas or solid)
   */
   void
-  harmonicAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;    
+  harmonicAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
 
   /*!
     @brief Average down on specific realm and phase. 
@@ -689,7 +692,10 @@ public:
     @param[in]    a_average Averaging method
   */
   void
-  average(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase, const Average& a_average) const;
+  average(EBAMRFluxData&           a_data,
+          const std::string        a_realm,
+          const phase::which_phase a_phase,
+          const Average&           a_average) const;
 
   /*!
     @brief Average down on specific realm and phase. 
@@ -709,7 +715,7 @@ public:
     @param[in]    a_phase Phase (gas or solid)
   */
   void
-  harmonicAverage(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;    
+  harmonicAverage(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
 
   /*!
     @brief Average down on specific realm and phase. 
@@ -728,7 +734,10 @@ public:
     @param[in]    a_average Averaging method
   */
   void
-  average(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase, const Average& a_average) const;  
+  average(EBAMRIVData&             a_data,
+          const std::string        a_realm,
+          const phase::which_phase a_phase,
+          const Average&           a_average) const;
 
   /*!
     @brief Arithmetic average on specific realm and phase. 
@@ -746,7 +755,7 @@ public:
     @param[in]    a_phase Phase (gas or solid)
   */
   void
-  harmonicAverage(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;  
+  harmonicAverage(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
 
   /*!
     @brief Conservative averaging on specific realm and phase.

--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -581,7 +581,7 @@ public:
     @param[in]    a_realm Realm name
   */
   void
-  averageDown(MFAMRCellData& a_data, const std::string a_realm) const;
+  conservativeAverage(MFAMRCellData& a_data, const std::string a_realm) const;
 
   /*!
     @brief Average down multifluid data over a realm. 
@@ -589,7 +589,7 @@ public:
     @param[in]    a_realm Realm name
   */
   void
-  averageDown(MFAMRFluxData& a_data, const std::string a_realm) const;
+  conservativeAverage(MFAMRFluxData& a_data, const std::string a_realm) const;
 
   /*!
     @brief Average multifluid data over a realm. 
@@ -607,7 +607,7 @@ public:
     @param[in]    a_phase Phase (gas or solid)
   */
   void
-  averageDown(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
+  conservativeAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
 
   /*!
     @brief Average down on specific realm and phase. 
@@ -618,10 +618,10 @@ public:
     @details This coarsens data from level a_lvl+1 to level a_lvl
   */
   void
-  averageDown(EBAMRCellData&           a_data,
-              const std::string        a_realm,
-              const phase::which_phase a_phase,
-              const int                a_lvl) const;
+  conservativeAverage(EBAMRCellData&           a_data,
+                      const std::string        a_realm,
+                      const phase::which_phase a_phase,
+                      const int                a_lvl) const;
 
   /*!
     @brief Coarsen cells over a realm. This does a specific level. 
@@ -632,11 +632,11 @@ public:
     @param[in]    a_phase    Phase (gas or solid)
   */
   void
-  averageDown(LevelData<EBCellFAB>&       a_coarData,
-              const LevelData<EBCellFAB>& a_fineData,
-              const int                   a_level,
-              const std::string           a_realm,
-              const phase::which_phase    a_phase) const;
+  conservativeAverage(LevelData<EBCellFAB>&       a_coarData,
+                      const LevelData<EBCellFAB>& a_fineData,
+                      const int                   a_level,
+                      const std::string           a_realm,
+                      const phase::which_phase    a_phase) const;
 
   /*!
     @brief Average down on specific realm and phase. 
@@ -645,7 +645,7 @@ public:
     @param[in]    a_phase Phase (gas or solid)
   */
   void
-  averageDown(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
+  conservativeAverage(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
 
   /*!
     @brief Average down on specific realm and phase. 
@@ -664,7 +664,7 @@ public:
     @param[in]    a_phase Phase (gas or solid)
   */
   void
-  averageDown(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
+  conservativeAverage(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase) const;
 
   /*!
     @brief Do conservative coarsening for data defined on cut-cells. 

--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -27,7 +27,7 @@
 
 // Our includes
 #include <CD_EBAMRData.H>
-#include <CD_EbCoarAve.H>
+#include <CD_EBCoarAve.H>
 #include <CD_ComputationalGeometry.H>
 #include <CD_MultiFluidIndexSpace.H>
 #include <CD_IrregAmrStencil.H>
@@ -1454,7 +1454,7 @@ public:
   /*!
     @brief Get the coarsening utility
   */
-  Vector<RefCountedPtr<EbCoarAve>>&
+  Vector<RefCountedPtr<EBCoarAve>>&
   getCoarseAverage(const std::string a_realm, const phase::which_phase a_phase) const;
 
   /*!

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -1161,7 +1161,7 @@ AmrMesh::computeGradient(EBAMRFluxData&           a_gradient,
   }
 
   // Coarsen the faces.
-  this->averageFaces(a_gradient, a_realm, a_phase);
+  this->arithmeticAverage(a_gradient, a_realm, a_phase);
 }
 
 void
@@ -1229,87 +1229,16 @@ AmrMesh::computeGradient(MFAMRFluxData& a_gradient, const MFAMRCellData& a_phi, 
 }
 
 void
-AmrMesh::conservativeAverage(MFAMRFluxData& a_data, const std::string a_realm) const
+AmrMesh::average(MFAMRCellData& a_data, const std::string a_realm, const Average& a_average) const
 {
-  CH_TIME("AmrMesh::conservativeAverage(MFAMRFluxData, string)");
+  CH_TIME("AmrMesh::average(MFAMRCellData, string, Average)");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::conservativeAverage(MFAMRFluxData, string)" << endl;
+    pout() << "AmrMesh::average(MFAMRCellData, string,Average)" << endl;
   }
 
   if (!this->queryRealm(a_realm)) {
-    std::string str = "AmrMesh::conservativeAverage(MFAMRFluxData, string) - could not find realm '" + a_realm + "'";
-    MayDay::Abort(str.c_str());
-  }
-
-  const RefCountedPtr<EBIndexSpace>& ebisGas = m_realms[a_realm]->getEBIndexSpace(phase::gas);
-  const RefCountedPtr<EBIndexSpace>& ebisSol = m_realms[a_realm]->getEBIndexSpace(phase::solid);
-
-  // Alias the data to regular EBFluxFABs
-  EBAMRFluxData aliasGas(1 + m_finestLevel);
-  EBAMRFluxData aliasSol(1 + m_finestLevel);
-
-  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    aliasGas[lvl] = RefCountedPtr<LevelData<EBFluxFAB>>(new LevelData<EBFluxFAB>());
-    aliasSol[lvl] = RefCountedPtr<LevelData<EBFluxFAB>>(new LevelData<EBFluxFAB>());
-
-    if (!ebisGas.isNull())
-      MultifluidAlias::aliasMF(*aliasGas[lvl], phase::gas, *a_data[lvl]);
-    if (!ebisSol.isNull())
-      MultifluidAlias::aliasMF(*aliasSol[lvl], phase::solid, *a_data[lvl]);
-  }
-
-  if (!ebisGas.isNull())
-    this->conservativeAverage(aliasGas, a_realm, phase::gas);
-  if (!ebisSol.isNull())
-    this->conservativeAverage(aliasSol, a_realm, phase::solid);
-}
-
-void
-AmrMesh::averageFaces(MFAMRFluxData& a_data, const std::string a_realm) const
-{
-  CH_TIME("AmrMesh::averageFaces(MFAMRFluxData, string)");
-  if (m_verbosity > 3) {
-    pout() << "AmrMesh::averageFaces(MFAMRFluxData, string)" << endl;
-  }
-
-  if (!this->queryRealm(a_realm)) {
-    std::string str = "AmrMesh::conservativeAverage(MFAMRFluxData, string) - could not find realm '" + a_realm + "'";
-    MayDay::Abort(str.c_str());
-  }
-
-  const RefCountedPtr<EBIndexSpace>& ebisGas = m_realms[a_realm]->getEBIndexSpace(phase::gas);
-  const RefCountedPtr<EBIndexSpace>& ebisSol = m_realms[a_realm]->getEBIndexSpace(phase::solid);
-
-  // Alias the data to regular EBFluxFABs
-  EBAMRFluxData aliasGas(1 + m_finestLevel);
-  EBAMRFluxData aliasSol(1 + m_finestLevel);
-
-  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    aliasGas[lvl] = RefCountedPtr<LevelData<EBFluxFAB>>(new LevelData<EBFluxFAB>());
-    aliasSol[lvl] = RefCountedPtr<LevelData<EBFluxFAB>>(new LevelData<EBFluxFAB>());
-
-    if (!ebisGas.isNull())
-      MultifluidAlias::aliasMF(*aliasGas[lvl], phase::gas, *a_data[lvl]);
-    if (!ebisSol.isNull())
-      MultifluidAlias::aliasMF(*aliasSol[lvl], phase::solid, *a_data[lvl]);
-  }
-
-  if (!ebisGas.isNull())
-    this->averageFaces(aliasGas, a_realm, phase::gas);
-  if (!ebisSol.isNull())
-    this->averageFaces(aliasSol, a_realm, phase::solid);
-}
-
-void
-AmrMesh::conservativeAverage(MFAMRCellData& a_data, const std::string a_realm) const
-{
-  CH_TIME("AmrMesh::conservativeAverage(MFAMRCellData, string)");
-  if (m_verbosity > 3) {
-    pout() << "AmrMesh::conservativeAverage(MFAMRCellData, string)" << endl;
-  }
-
-  if (!this->queryRealm(a_realm)) {
-    std::string str = "AmrMesh::conservativeAverage(MFAMRCellData, string) - could not find realm '" + a_realm + "'";
+    const std::string str = "AmrMesh::average(MFAMRCellData) - could not find realm '" + a_realm + "'";
+    
     MayDay::Abort(str.c_str());
   }
 
@@ -1323,16 +1252,177 @@ AmrMesh::conservativeAverage(MFAMRCellData& a_data, const std::string a_realm) c
     aliasGas[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
     aliasSol[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
 
-    if (!ebisGas.isNull())
+    if (!ebisGas.isNull()) {
       MultifluidAlias::aliasMF(*aliasGas[lvl], phase::gas, *a_data[lvl]);
-    if (!ebisSol.isNull())
+    }
+    if (!ebisSol.isNull()) {
       MultifluidAlias::aliasMF(*aliasSol[lvl], phase::solid, *a_data[lvl]);
+    }
   }
 
-  if (!ebisGas.isNull())
-    this->conservativeAverage(aliasGas, a_realm, phase::gas);
-  if (!ebisSol.isNull())
-    this->conservativeAverage(aliasSol, a_realm, phase::solid);
+  if (!ebisGas.isNull()) {
+    this->average(aliasGas, a_realm, phase::gas, a_average);
+  }
+  if (!ebisSol.isNull()) {
+    this->average(aliasGas, a_realm, phase::solid, a_average);
+  }  
+}
+
+void
+AmrMesh::arithmeticAverage(MFAMRCellData& a_data, const std::string a_realm) const
+{
+  CH_TIME("AmrMesh::arithmeticAverage(MFAMRCellData, string)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::arithmeticAverage(MFAMRCellData, string)" << endl;
+  }
+
+  this->average(a_data, a_realm, Average::Arithmetic);
+}
+
+void
+AmrMesh::harmonicAverage(MFAMRCellData& a_data, const std::string a_realm) const
+{
+  CH_TIME("AmrMesh::harmonic(MFAMRCellData, string)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::harmonic(MFAMRCellData, string)" << endl;
+  }
+
+  this->average(a_data, a_realm, Average::Harmonic);
+}
+
+void
+AmrMesh::conservativeAverage(MFAMRCellData& a_data, const std::string a_realm) const
+{
+  CH_TIME("AmrMesh::conservativeAverage(MFAMRCellData, string)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::conservativeAverage(MFAMRCellData, string)" << endl;
+  }
+
+  this->average(a_data, a_realm, Average::Conservative);
+}
+
+void
+AmrMesh::average(MFAMRFluxData& a_data, const std::string a_realm, const Average& a_average) const
+{
+  CH_TIME("AmrMesh::average(MFAMRFluxData, string)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::average(MFAMRFluxData, string)" << endl;
+  }
+
+  if (!this->queryRealm(a_realm)) {
+    std::string str = "AmrMesh::average(MFAMRFluxData, string) - could not find realm '" + a_realm + "'";
+    
+    MayDay::Abort(str.c_str());
+  }
+
+  const RefCountedPtr<EBIndexSpace>& ebisGas = m_realms[a_realm]->getEBIndexSpace(phase::gas);
+  const RefCountedPtr<EBIndexSpace>& ebisSol = m_realms[a_realm]->getEBIndexSpace(phase::solid);
+
+  // Alias the data to regular EBFluxFABs
+  EBAMRFluxData aliasGas(1 + m_finestLevel);
+  EBAMRFluxData aliasSol(1 + m_finestLevel);
+
+  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
+    aliasGas[lvl] = RefCountedPtr<LevelData<EBFluxFAB>>(new LevelData<EBFluxFAB>());
+    aliasSol[lvl] = RefCountedPtr<LevelData<EBFluxFAB>>(new LevelData<EBFluxFAB>());
+
+    if (!ebisGas.isNull()) {
+      MultifluidAlias::aliasMF(*aliasGas[lvl], phase::gas, *a_data[lvl]);
+    }
+    if (!ebisSol.isNull()) {
+      MultifluidAlias::aliasMF(*aliasSol[lvl], phase::solid, *a_data[lvl]);
+    }
+  }
+
+  if (!ebisGas.isNull()) {
+    this->average(aliasGas, a_realm, phase::gas, a_average);
+  }
+  if (!ebisSol.isNull()) {
+    this->average(aliasSol, a_realm, phase::solid, a_average);
+  }
+}
+void
+AmrMesh::arithmeticAverage(MFAMRFluxData& a_data, const std::string a_realm) const
+{
+  CH_TIME("AmrMesh::arithmeticAverage(MFAMRFluxData, string)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::arithmeticAverage(MFAMRFluxData, string)" << endl;
+  }
+  
+  this->average(a_data, a_realm, Average::Arithmetic);
+}
+
+void
+AmrMesh::harmonicAverage(MFAMRFluxData& a_data, const std::string a_realm) const
+{
+  CH_TIME("AmrMesh::harmonicAverage(MFAMRFluxData, string)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::harmonicAverage(MFAMRFluxData, string)" << endl;
+  }
+  
+  this->average(a_data, a_realm, Average::Harmonic);
+}
+
+void
+AmrMesh::conservativeAverage(MFAMRFluxData& a_data, const std::string a_realm) const
+{
+  CH_TIME("AmrMesh::conservativeAverage(MFAMRFluxData, string)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::conservativeAverage(MFAMRFluxData, string)" << endl;
+  }
+  
+  this->average(a_data, a_realm, Average::Conservative);
+}
+
+void
+AmrMesh::average(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase, const Average& a_average) const
+{
+  CH_TIME("AmrMesh::average(EBAMRCellData, string, phase::which_phase)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::average(EBAMRCellData, string, phase::which_phase)" << endl;
+  }
+
+  if (!this->queryRealm(a_realm)) {
+    std::string str = "AmrMesh::average(EBAMRCellData) - could not find realm '" + a_realm + "'";
+    MayDay::Abort(str.c_str());
+  }
+
+  for (int lvl = m_finestLevel; lvl > 0; lvl--) {
+    const int      nComps = a_data[lvl]->nComp();
+    const Interval interv(0, nComps - 1);
+
+    EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
+
+    aveOp.averageData(*a_data[lvl-1], *a_data[lvl], interv, a_average);
+
+    a_data[lvl]->exchange();    
+  }
+
+  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
+    a_data[lvl]->exchange();
+  }
+}
+
+void
+AmrMesh::arithmeticAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
+{
+  CH_TIME("AmrMesh::average(EBAMRCellData, string, phase::which_phase)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::average(EBAMRCellData, string, phase::which_phase)" << endl;
+  }
+
+  this->average(a_data, a_realm, a_phase, Average::Arithmetic);
+}
+
+void
+AmrMesh::harmonicAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
+{
+  CH_TIME("AmrMesh::harmonicAverage(EBAMRCellData, string, phase::which_phase)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::harmonicAverage(EBAMRCellData, string, phase::which_phase)" << endl;
+  }
+
+  this->average(a_data, a_realm, a_phase, Average::Harmonic);
 }
 
 void
@@ -1343,15 +1433,30 @@ AmrMesh::conservativeAverage(EBAMRCellData& a_data, const std::string a_realm, c
     pout() << "AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase)" << endl;
   }
 
+  this->average(a_data, a_realm, a_phase, Average::Conservative);
+}
+
+void
+AmrMesh::average(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase, const Average& a_average) const
+{
+  CH_TIME("AmrMesh::arithmeticAverage(EBAMRFluxData, string, phase::which_phase");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::arithmeticAverage(EBAMRFluxData, string, phase::which_phase)" << endl;
+  }
+
   if (!this->queryRealm(a_realm)) {
     std::string str =
-      "AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase) - could not find realm '" + a_realm +
-      "'";
+      "AmrMesh::average(EBAMRFluxData) - could not find realm '" + a_realm + "'";
     MayDay::Abort(str.c_str());
   }
 
   for (int lvl = m_finestLevel; lvl > 0; lvl--) {
-    this->conservativeAverage(a_data, a_realm, a_phase, lvl - 1);
+    const int      nComps = a_data[lvl]->nComp();
+    const Interval interv(0, nComps - 1);
+
+    EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
+    
+    aveOp.averageData(*a_data[lvl - 1], *a_data[lvl], interv, a_average);
   }
 
   for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
@@ -1360,55 +1465,25 @@ AmrMesh::conservativeAverage(EBAMRCellData& a_data, const std::string a_realm, c
 }
 
 void
-AmrMesh::conservativeAverage(EBAMRCellData&           a_data,
-                             const std::string        a_realm,
-                             const phase::which_phase a_phase,
-                             const int                a_lvl) const
+AmrMesh::arithmeticAverage(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
 {
-  CH_TIME("AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase, int)");
+  CH_TIME("AmrMesh::arithmeticAverage(EBAMRFluxData, string, phase::which_phase");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase, int)" << endl;
+    pout() << "AmrMesh::arithmeticAverage(EBAMRFluxData, string, phase::which_phase)" << endl;
   }
 
-  if (!this->queryRealm(a_realm)) {
-    std::string str =
-      "AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase, int) - could not find realm '" +
-      a_realm + "'";
-    MayDay::Abort(str.c_str());
-  }
-
-  const int      nComps = a_data[a_lvl]->nComp();
-  const Interval interv(0, nComps - 1);
-
-  EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[a_lvl + 1];
-
-  aveOp.average(*a_data[a_lvl], *a_data[a_lvl + 1], interv);
-
-  a_data[a_lvl]->exchange();
+  this->average(a_data, a_realm, a_phase, Average::Arithmetic);
 }
 
 void
-AmrMesh::conservativeAverage(LevelData<EBCellFAB>&       a_coarData,
-                             const LevelData<EBCellFAB>& a_fineData,
-                             const int                   a_lvl,
-                             const std::string           a_realm,
-                             const phase::which_phase    a_phase) const
+AmrMesh::harmonicAverage(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
 {
-  CH_TIME("AmrMesh::conservativeAverage(LD<EBCellFAB>, LD<EBCellFAB>, int, string, phase)");
+  CH_TIME("AmrMesh::harmonicAverage(EBAMRFluxData, string, phase::which_phase");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::conservativeAverage(LD<EBCellFAB>, LD<EBCellFAB>, int, string, phase)" << endl;
+    pout() << "AmrMesh::harmonicAverage(EBAMRFluxData, string, phase::which_phase)" << endl;
   }
 
-  if (!this->queryRealm(a_realm)) {
-    std::string str =
-      "AmrMesh::conservativeAverage(LD<EBCellFAB>, LD<EBCellFAB>, int, string, phase) - could not find realm '" +
-      a_realm + "'";
-    MayDay::Abort(str.c_str());
-  }
-
-  EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[a_lvl];
-
-  aveOp.average(a_coarData, a_fineData, a_coarData.interval());
+  this->average(a_data, a_realm, a_phase, Average::Harmonic);
 }
 
 void
@@ -1419,10 +1494,20 @@ AmrMesh::conservativeAverage(EBAMRFluxData& a_data, const std::string a_realm, c
     pout() << "AmrMesh::conservativeAverage(EBAMRFluxData, string, phase::which_phase)" << endl;
   }
 
+  this->average(a_data, a_realm, a_phase, Average::Conservative);
+}
+
+void
+AmrMesh::average(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase, const Average& a_average) const
+{
+  CH_TIME("AmrMesh::arithmeticAverage(EBAMRIVData, string, phase::which_phase");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::arithmeticAverage(EBAMRIVData, string, phase::which_phase)" << endl;
+  }
+
   if (!this->queryRealm(a_realm)) {
     std::string str =
-      "AmrMesh::conservativeAverage(EBAMRFluxData, string, phase::which_phase) - could not find realm '" + a_realm +
-      "'";
+      "AmrMesh::average(EBAMRIVData) - could not find realm '" + a_realm + "'";
     MayDay::Abort(str.c_str());
   }
 
@@ -1431,7 +1516,8 @@ AmrMesh::conservativeAverage(EBAMRFluxData& a_data, const std::string a_realm, c
     const Interval interv(0, nComps - 1);
 
     EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
-    aveOp.average(*a_data[lvl - 1], *a_data[lvl], interv);
+    
+    aveOp.averageData(*a_data[lvl - 1], *a_data[lvl], interv, a_average);
   }
 
   for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
@@ -1440,85 +1526,36 @@ AmrMesh::conservativeAverage(EBAMRFluxData& a_data, const std::string a_realm, c
 }
 
 void
-AmrMesh::averageFaces(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
+AmrMesh::arithmeticAverage(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
 {
-  CH_TIME("AmrMesh::averageFaces(EBAMRFluxData, string, phase::which_phase");
+  CH_TIME("AmrMesh::arithmeticAverage(EBAMRIVData, string, phase::which_phase");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::averageFaces(EBAMRFluxData, string, phase::which_phase)" << endl;
+    pout() << "AmrMesh::arithmeticAverage(EBAMRIVData, string, phase::which_phase)" << endl;
   }
 
-  if (!this->queryRealm(a_realm)) {
-    std::string str =
-      "AmrMesh::averageFaces(EBAMRFluxData, string, phase::which_phase) - could not find realm '" + a_realm + "'";
-    MayDay::Abort(str.c_str());
+  this->average(a_data, a_realm, a_phase, Average::Arithmetic);
+}
+
+void
+AmrMesh::harmonicAverage(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
+{
+  CH_TIME("AmrMesh::harmonicAverage(EBAMRIVData, string, phase::which_phase");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::harmonicAverage(EBAMRIVData, string, phase::which_phase)" << endl;
   }
 
-  for (int lvl = m_finestLevel; lvl > 0; lvl--) {
-    const int      nComps = a_data[lvl]->nComp();
-    const Interval interv(0, nComps - 1);
-
-    EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
-    aveOp.averageFaceData(*a_data[lvl - 1], *a_data[lvl], interv);
-  }
-
-  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    a_data[lvl]->exchange();
-  }
+  this->average(a_data, a_realm, a_phase, Average::Harmonic);
 }
 
 void
 AmrMesh::conservativeAverage(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
 {
-  CH_TIME("AmrMesh::conservativeAverage(EBAMRIVData, string, phase::which_phase)");
+  CH_TIME("AmrMesh::conservativeAverage(EBAMRFluxData, string, phase::which_phase");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::conservativeAverage(EBAMRIVData, string, phase::which_phase)" << endl;
+    pout() << "AmrMesh::conservativeAverage(EBAMRFluxData, string, phase::which_phase)" << endl;
   }
 
-  if (!this->queryRealm(a_realm)) {
-    std::string str =
-      "AmrMesh::conservativeAverage(EBAMRIVData, string, phase::which_phase) - could not find realm '" + a_realm + "'";
-    MayDay::Abort(str.c_str());
-  }
-
-  for (int lvl = m_finestLevel; lvl > 0; lvl--) {
-    const int      nComps = a_data[lvl]->nComp();
-    const Interval interv(0, nComps - 1);
-
-    EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
-    aveOp.average(*a_data[lvl - 1], *a_data[lvl], interv);
-  }
-
-  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    a_data[lvl]->exchange();
-  }
-}
-
-void
-AmrMesh::conservativeAverage(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase)
-{
-  CH_TIME("AmrMesh::conservativeAverage(EBAMRIVData, string, phase::which_phase)");
-  if (m_verbosity > 3) {
-    pout() << "AmrMesh::conservativeAverage(EBAMRIVData, string, phase::which_phase)" << endl;
-  }
-
-  if (!this->queryRealm(a_realm)) {
-    std::string str =
-      "AmrMesh::conservativeAverage(EBAMRIVData, string, phase::which_phase) - could not find realm '" + a_realm + "'";
-    MayDay::Abort(str.c_str());
-  }
-
-  for (int lvl = m_finestLevel; lvl > 0; lvl--) {
-    const int      nComps = a_data[lvl]->nComp();
-    const Interval interv(0, nComps - 1);
-
-    EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
-
-    aveOp.conservativeAverage(*a_data[lvl - 1], *a_data[lvl], interv);
-  }
-
-  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    a_data[lvl]->exchange();
-  }
+  this->average(a_data, a_realm, a_phase, Average::Conservative);
 }
 
 void

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -1395,7 +1395,7 @@ AmrMesh::average(EBAMRCellData&           a_data,
     const int      nComps = a_data[lvl]->nComp();
     const Interval interv(0, nComps - 1);
 
-    EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
+    EBCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
 
     aveOp.averageData(*a_data[lvl - 1], *a_data[lvl], interv, a_average);
   }
@@ -1458,7 +1458,7 @@ AmrMesh::average(EBAMRFluxData&           a_data,
     const int      nComps = a_data[lvl]->nComp();
     const Interval interv(0, nComps - 1);
 
-    EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
+    EBCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
 
     aveOp.averageData(*a_data[lvl - 1], *a_data[lvl], interv, a_average);
   }
@@ -1517,7 +1517,7 @@ AmrMesh::average(EBAMRIVData&             a_data,
     const int      nComps = a_data[lvl]->nComp();
     const Interval interv(0, nComps - 1);
 
-    EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
+    EBCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
 
     aveOp.averageData(*a_data[lvl - 1], *a_data[lvl], interv, a_average);
   }
@@ -2701,7 +2701,7 @@ AmrMesh::getParticleMesh(const std::string a_realm, const phase::which_phase a_p
   return m_realms[a_realm]->getParticleMesh(a_phase);
 }
 
-Vector<RefCountedPtr<EbCoarAve>>&
+Vector<RefCountedPtr<EBCoarAve>>&
 AmrMesh::getCoarseAverage(const std::string a_realm, const phase::which_phase a_phase) const
 {
   CH_TIME("AmrMesh::getCoarseAverage(string, phase::which_phase)");

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -1238,7 +1238,7 @@ AmrMesh::average(MFAMRCellData& a_data, const std::string a_realm, const Average
 
   if (!this->queryRealm(a_realm)) {
     const std::string str = "AmrMesh::average(MFAMRCellData) - could not find realm '" + a_realm + "'";
-    
+
     MayDay::Abort(str.c_str());
   }
 
@@ -1264,8 +1264,8 @@ AmrMesh::average(MFAMRCellData& a_data, const std::string a_realm, const Average
     this->average(aliasGas, a_realm, phase::gas, a_average);
   }
   if (!ebisSol.isNull()) {
-    this->average(aliasGas, a_realm, phase::solid, a_average);
-  }  
+    this->average(aliasSol, a_realm, phase::solid, a_average);
+  }
 }
 
 void
@@ -1311,7 +1311,7 @@ AmrMesh::average(MFAMRFluxData& a_data, const std::string a_realm, const Average
 
   if (!this->queryRealm(a_realm)) {
     std::string str = "AmrMesh::average(MFAMRFluxData, string) - could not find realm '" + a_realm + "'";
-    
+
     MayDay::Abort(str.c_str());
   }
 
@@ -1348,7 +1348,7 @@ AmrMesh::arithmeticAverage(MFAMRFluxData& a_data, const std::string a_realm) con
   if (m_verbosity > 3) {
     pout() << "AmrMesh::arithmeticAverage(MFAMRFluxData, string)" << endl;
   }
-  
+
   this->average(a_data, a_realm, Average::Arithmetic);
 }
 
@@ -1359,7 +1359,7 @@ AmrMesh::harmonicAverage(MFAMRFluxData& a_data, const std::string a_realm) const
   if (m_verbosity > 3) {
     pout() << "AmrMesh::harmonicAverage(MFAMRFluxData, string)" << endl;
   }
-  
+
   this->average(a_data, a_realm, Average::Harmonic);
 }
 
@@ -1370,12 +1370,15 @@ AmrMesh::conservativeAverage(MFAMRFluxData& a_data, const std::string a_realm) c
   if (m_verbosity > 3) {
     pout() << "AmrMesh::conservativeAverage(MFAMRFluxData, string)" << endl;
   }
-  
+
   this->average(a_data, a_realm, Average::Conservative);
 }
 
 void
-AmrMesh::average(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase, const Average& a_average) const
+AmrMesh::average(EBAMRCellData&           a_data,
+                 const std::string        a_realm,
+                 const phase::which_phase a_phase,
+                 const Average&           a_average) const
 {
   CH_TIME("AmrMesh::average(EBAMRCellData, string, phase::which_phase)");
   if (m_verbosity > 3) {
@@ -1393,9 +1396,7 @@ AmrMesh::average(EBAMRCellData& a_data, const std::string a_realm, const phase::
 
     EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
 
-    aveOp.averageData(*a_data[lvl-1], *a_data[lvl], interv, a_average);
-
-    a_data[lvl]->exchange();    
+    aveOp.averageData(*a_data[lvl - 1], *a_data[lvl], interv, a_average);
   }
 
   for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
@@ -1437,7 +1438,10 @@ AmrMesh::conservativeAverage(EBAMRCellData& a_data, const std::string a_realm, c
 }
 
 void
-AmrMesh::average(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase, const Average& a_average) const
+AmrMesh::average(EBAMRFluxData&           a_data,
+                 const std::string        a_realm,
+                 const phase::which_phase a_phase,
+                 const Average&           a_average) const
 {
   CH_TIME("AmrMesh::arithmeticAverage(EBAMRFluxData, string, phase::which_phase");
   if (m_verbosity > 3) {
@@ -1445,8 +1449,7 @@ AmrMesh::average(EBAMRFluxData& a_data, const std::string a_realm, const phase::
   }
 
   if (!this->queryRealm(a_realm)) {
-    std::string str =
-      "AmrMesh::average(EBAMRFluxData) - could not find realm '" + a_realm + "'";
+    std::string str = "AmrMesh::average(EBAMRFluxData) - could not find realm '" + a_realm + "'";
     MayDay::Abort(str.c_str());
   }
 
@@ -1455,12 +1458,8 @@ AmrMesh::average(EBAMRFluxData& a_data, const std::string a_realm, const phase::
     const Interval interv(0, nComps - 1);
 
     EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
-    
-    aveOp.averageData(*a_data[lvl - 1], *a_data[lvl], interv, a_average);
-  }
 
-  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    a_data[lvl]->exchange();
+    aveOp.averageData(*a_data[lvl - 1], *a_data[lvl], interv, a_average);
   }
 }
 
@@ -1498,7 +1497,10 @@ AmrMesh::conservativeAverage(EBAMRFluxData& a_data, const std::string a_realm, c
 }
 
 void
-AmrMesh::average(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase, const Average& a_average) const
+AmrMesh::average(EBAMRIVData&             a_data,
+                 const std::string        a_realm,
+                 const phase::which_phase a_phase,
+                 const Average&           a_average) const
 {
   CH_TIME("AmrMesh::arithmeticAverage(EBAMRIVData, string, phase::which_phase");
   if (m_verbosity > 3) {
@@ -1506,8 +1508,7 @@ AmrMesh::average(EBAMRIVData& a_data, const std::string a_realm, const phase::wh
   }
 
   if (!this->queryRealm(a_realm)) {
-    std::string str =
-      "AmrMesh::average(EBAMRIVData) - could not find realm '" + a_realm + "'";
+    std::string str = "AmrMesh::average(EBAMRIVData) - could not find realm '" + a_realm + "'";
     MayDay::Abort(str.c_str());
   }
 
@@ -1516,7 +1517,7 @@ AmrMesh::average(EBAMRIVData& a_data, const std::string a_realm, const phase::wh
     const Interval interv(0, nComps - 1);
 
     EbCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
-    
+
     aveOp.averageData(*a_data[lvl - 1], *a_data[lvl], interv, a_average);
   }
 

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -1149,7 +1149,7 @@ AmrMesh::computeGradient(EBAMRFluxData&           a_gradient,
   this->allocate(scratch, a_realm, a_phase, SpaceDim);
   this->computeGradient(scratch, a_phi, a_realm, a_phase);
 
-  this->averageDown(scratch, a_realm, a_phase);
+  this->conservativeAverage(scratch, a_realm, a_phase);
   this->interpGhost(scratch, a_realm, a_phase);
 
   // Average the cells to face and replace the normal derivative with a tighter stencil.
@@ -1229,15 +1229,15 @@ AmrMesh::computeGradient(MFAMRFluxData& a_gradient, const MFAMRCellData& a_phi, 
 }
 
 void
-AmrMesh::averageDown(MFAMRFluxData& a_data, const std::string a_realm) const
+AmrMesh::conservativeAverage(MFAMRFluxData& a_data, const std::string a_realm) const
 {
-  CH_TIME("AmrMesh::averageDown(MFAMRFluxData, string)");
+  CH_TIME("AmrMesh::conservativeAverage(MFAMRFluxData, string)");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::averageDown(MFAMRFluxData, string)" << endl;
+    pout() << "AmrMesh::conservativeAverage(MFAMRFluxData, string)" << endl;
   }
 
   if (!this->queryRealm(a_realm)) {
-    std::string str = "AmrMesh::averageDown(MFAMRFluxData, string) - could not find realm '" + a_realm + "'";
+    std::string str = "AmrMesh::conservativeAverage(MFAMRFluxData, string) - could not find realm '" + a_realm + "'";
     MayDay::Abort(str.c_str());
   }
 
@@ -1259,9 +1259,9 @@ AmrMesh::averageDown(MFAMRFluxData& a_data, const std::string a_realm) const
   }
 
   if (!ebisGas.isNull())
-    this->averageDown(aliasGas, a_realm, phase::gas);
+    this->conservativeAverage(aliasGas, a_realm, phase::gas);
   if (!ebisSol.isNull())
-    this->averageDown(aliasSol, a_realm, phase::solid);
+    this->conservativeAverage(aliasSol, a_realm, phase::solid);
 }
 
 void
@@ -1273,7 +1273,7 @@ AmrMesh::averageFaces(MFAMRFluxData& a_data, const std::string a_realm) const
   }
 
   if (!this->queryRealm(a_realm)) {
-    std::string str = "AmrMesh::averageDown(MFAMRFluxData, string) - could not find realm '" + a_realm + "'";
+    std::string str = "AmrMesh::conservativeAverage(MFAMRFluxData, string) - could not find realm '" + a_realm + "'";
     MayDay::Abort(str.c_str());
   }
 
@@ -1301,15 +1301,15 @@ AmrMesh::averageFaces(MFAMRFluxData& a_data, const std::string a_realm) const
 }
 
 void
-AmrMesh::averageDown(MFAMRCellData& a_data, const std::string a_realm) const
+AmrMesh::conservativeAverage(MFAMRCellData& a_data, const std::string a_realm) const
 {
-  CH_TIME("AmrMesh::averageDown(MFAMRCellData, string)");
+  CH_TIME("AmrMesh::conservativeAverage(MFAMRCellData, string)");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::averageDown(MFAMRCellData, string)" << endl;
+    pout() << "AmrMesh::conservativeAverage(MFAMRCellData, string)" << endl;
   }
 
   if (!this->queryRealm(a_realm)) {
-    std::string str = "AmrMesh::averageDown(MFAMRCellData, string) - could not find realm '" + a_realm + "'";
+    std::string str = "AmrMesh::conservativeAverage(MFAMRCellData, string) - could not find realm '" + a_realm + "'";
     MayDay::Abort(str.c_str());
   }
 
@@ -1330,27 +1330,28 @@ AmrMesh::averageDown(MFAMRCellData& a_data, const std::string a_realm) const
   }
 
   if (!ebisGas.isNull())
-    this->averageDown(aliasGas, a_realm, phase::gas);
+    this->conservativeAverage(aliasGas, a_realm, phase::gas);
   if (!ebisSol.isNull())
-    this->averageDown(aliasSol, a_realm, phase::solid);
+    this->conservativeAverage(aliasSol, a_realm, phase::solid);
 }
 
 void
-AmrMesh::averageDown(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
+AmrMesh::conservativeAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
 {
-  CH_TIME("AmrMesh::averageDown(EBAMRCellData, string, phase::which_phase)");
+  CH_TIME("AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase)");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::averageDown(EBAMRCellData, string, phase::which_phase)" << endl;
+    pout() << "AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase)" << endl;
   }
 
   if (!this->queryRealm(a_realm)) {
     std::string str =
-      "AmrMesh::averageDown(EBAMRCellData, string, phase::which_phase) - could not find realm '" + a_realm + "'";
+      "AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase) - could not find realm '" + a_realm +
+      "'";
     MayDay::Abort(str.c_str());
   }
 
   for (int lvl = m_finestLevel; lvl > 0; lvl--) {
-    this->averageDown(a_data, a_realm, a_phase, lvl - 1);
+    this->conservativeAverage(a_data, a_realm, a_phase, lvl - 1);
   }
 
   for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
@@ -1359,19 +1360,20 @@ AmrMesh::averageDown(EBAMRCellData& a_data, const std::string a_realm, const pha
 }
 
 void
-AmrMesh::averageDown(EBAMRCellData&           a_data,
-                     const std::string        a_realm,
-                     const phase::which_phase a_phase,
-                     const int                a_lvl) const
+AmrMesh::conservativeAverage(EBAMRCellData&           a_data,
+                             const std::string        a_realm,
+                             const phase::which_phase a_phase,
+                             const int                a_lvl) const
 {
-  CH_TIME("AmrMesh::averageDown(EBAMRCellData, string, phase::which_phase, int)");
+  CH_TIME("AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase, int)");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::averageDown(EBAMRCellData, string, phase::which_phase, int)" << endl;
+    pout() << "AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase, int)" << endl;
   }
 
   if (!this->queryRealm(a_realm)) {
     std::string str =
-      "AmrMesh::averageDown(EBAMRCellData, string, phase::which_phase, int) - could not find realm '" + a_realm + "'";
+      "AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase, int) - could not find realm '" +
+      a_realm + "'";
     MayDay::Abort(str.c_str());
   }
 
@@ -1386,20 +1388,21 @@ AmrMesh::averageDown(EBAMRCellData&           a_data,
 }
 
 void
-AmrMesh::averageDown(LevelData<EBCellFAB>&       a_coarData,
-                     const LevelData<EBCellFAB>& a_fineData,
-                     const int                   a_lvl,
-                     const std::string           a_realm,
-                     const phase::which_phase    a_phase) const
+AmrMesh::conservativeAverage(LevelData<EBCellFAB>&       a_coarData,
+                             const LevelData<EBCellFAB>& a_fineData,
+                             const int                   a_lvl,
+                             const std::string           a_realm,
+                             const phase::which_phase    a_phase) const
 {
-  CH_TIME("AmrMesh::averageDown(LD<EBCellFAB>, LD<EBCellFAB>, int, string, phase)");
+  CH_TIME("AmrMesh::conservativeAverage(LD<EBCellFAB>, LD<EBCellFAB>, int, string, phase)");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::averageDown(LD<EBCellFAB>, LD<EBCellFAB>, int, string, phase)" << endl;
+    pout() << "AmrMesh::conservativeAverage(LD<EBCellFAB>, LD<EBCellFAB>, int, string, phase)" << endl;
   }
 
   if (!this->queryRealm(a_realm)) {
     std::string str =
-      "AmrMesh::averageDown(LD<EBCellFAB>, LD<EBCellFAB>, int, string, phase) - could not find realm '" + a_realm + "'";
+      "AmrMesh::conservativeAverage(LD<EBCellFAB>, LD<EBCellFAB>, int, string, phase) - could not find realm '" +
+      a_realm + "'";
     MayDay::Abort(str.c_str());
   }
 
@@ -1409,16 +1412,17 @@ AmrMesh::averageDown(LevelData<EBCellFAB>&       a_coarData,
 }
 
 void
-AmrMesh::averageDown(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
+AmrMesh::conservativeAverage(EBAMRFluxData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
 {
-  CH_TIME("AmrMesh::averageDown(EBAMRFluxData, string, phase::which_phase");
+  CH_TIME("AmrMesh::conservativeAverage(EBAMRFluxData, string, phase::which_phase");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::averageDown(EBAMRFluxData, string, phase::which_phase)" << endl;
+    pout() << "AmrMesh::conservativeAverage(EBAMRFluxData, string, phase::which_phase)" << endl;
   }
 
   if (!this->queryRealm(a_realm)) {
     std::string str =
-      "AmrMesh::averageDown(EBAMRFluxData, string, phase::which_phase) - could not find realm '" + a_realm + "'";
+      "AmrMesh::conservativeAverage(EBAMRFluxData, string, phase::which_phase) - could not find realm '" + a_realm +
+      "'";
     MayDay::Abort(str.c_str());
   }
 
@@ -1463,16 +1467,16 @@ AmrMesh::averageFaces(EBAMRFluxData& a_data, const std::string a_realm, const ph
 }
 
 void
-AmrMesh::averageDown(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
+AmrMesh::conservativeAverage(EBAMRIVData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
 {
-  CH_TIME("AmrMesh::averageDown(EBAMRIVData, string, phase::which_phase)");
+  CH_TIME("AmrMesh::conservativeAverage(EBAMRIVData, string, phase::which_phase)");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::averageDown(EBAMRIVData, string, phase::which_phase)" << endl;
+    pout() << "AmrMesh::conservativeAverage(EBAMRIVData, string, phase::which_phase)" << endl;
   }
 
   if (!this->queryRealm(a_realm)) {
     std::string str =
-      "AmrMesh::averageDown(EBAMRIVData, string, phase::which_phase) - could not find realm '" + a_realm + "'";
+      "AmrMesh::conservativeAverage(EBAMRIVData, string, phase::which_phase) - could not find realm '" + a_realm + "'";
     MayDay::Abort(str.c_str());
   }
 

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -17,6 +17,7 @@
 #include <EBArith.H>
 #include <ParmParse.H>
 #include <BaseIFFactory.H>
+#include <BaseIVFactory.H>
 
 // Our includes
 #include <CD_AmrMesh.H>

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -1381,9 +1381,9 @@ AmrMesh::average(EBAMRCellData&           a_data,
                  const phase::which_phase a_phase,
                  const Average&           a_average) const
 {
-  CH_TIME("AmrMesh::average(EBAMRCellData, string, phase::which_phase)");
+  CH_TIME("AmrMesh::average(EBAMRCellData, string, phase::which_phase, Average)");
   if (m_verbosity > 3) {
-    pout() << "AmrMesh::average(EBAMRCellData, string, phase::which_phase)" << endl;
+    pout() << "AmrMesh::average(EBAMRCellData, string, phase::which_phase, Average)" << endl;
   }
 
   if (!this->queryRealm(a_realm)) {
@@ -1399,9 +1399,31 @@ AmrMesh::average(EBAMRCellData&           a_data,
 
     aveOp.averageData(*a_data[lvl - 1], *a_data[lvl], interv, a_average);
   }
+}
 
-  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    a_data[lvl]->exchange();
+void
+AmrMesh::average(EBAMRCellData&           a_data,
+                 const std::string        a_realm,
+                 const phase::which_phase a_phase,
+                 const Average&           a_average,
+                 const Interval&          a_variables) const
+{
+  CH_TIME("AmrMesh::average(EBAMRCellData, string, phase::which_phase, Average, Interval)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::average(EBAMRCellData, string, phase::which_phase, Average, Interval)" << endl;
+  }
+
+  if (!this->queryRealm(a_realm)) {
+    std::string str = "AmrMesh::average(EBAMRCellData) - could not find realm '" + a_realm + "'";
+    MayDay::Abort(str.c_str());
+  }
+
+  for (int lvl = m_finestLevel; lvl > 0; lvl--) {
+    CH_assert(a_variables.end() < a_data[lvl]->nComp());
+
+    EBCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
+
+    aveOp.averageData(*a_data[lvl - 1], *a_data[lvl], a_variables, a_average);
   }
 }
 
@@ -1417,6 +1439,20 @@ AmrMesh::arithmeticAverage(EBAMRCellData& a_data, const std::string a_realm, con
 }
 
 void
+AmrMesh::arithmeticAverage(EBAMRCellData&           a_data,
+                           const std::string        a_realm,
+                           const phase::which_phase a_phase,
+                           const Interval&          a_variables) const
+{
+  CH_TIME("AmrMesh::average(EBAMRCellData, string, phase::which_phase, Interval)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::average(EBAMRCellData, string, phase::which_phase, Interval)" << endl;
+  }
+
+  this->average(a_data, a_realm, a_phase, Average::Arithmetic, a_variables);
+}
+
+void
 AmrMesh::harmonicAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
 {
   CH_TIME("AmrMesh::harmonicAverage(EBAMRCellData, string, phase::which_phase)");
@@ -1428,6 +1464,20 @@ AmrMesh::harmonicAverage(EBAMRCellData& a_data, const std::string a_realm, const
 }
 
 void
+AmrMesh::harmonicAverage(EBAMRCellData&           a_data,
+                         const std::string        a_realm,
+                         const phase::which_phase a_phase,
+                         const Interval&          a_variables) const
+{
+  CH_TIME("AmrMesh::harmonicAverage(EBAMRCellData, string, phase::which_phase, Interval)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::harmonicAverage(EBAMRCellData, string, phase::which_phase, Interval)" << endl;
+  }
+
+  this->average(a_data, a_realm, a_phase, Average::Harmonic, a_variables);
+}
+
+void
 AmrMesh::conservativeAverage(EBAMRCellData& a_data, const std::string a_realm, const phase::which_phase a_phase) const
 {
   CH_TIME("AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase)");
@@ -1436,6 +1486,20 @@ AmrMesh::conservativeAverage(EBAMRCellData& a_data, const std::string a_realm, c
   }
 
   this->average(a_data, a_realm, a_phase, Average::Conservative);
+}
+
+void
+AmrMesh::conservativeAverage(EBAMRCellData&           a_data,
+                             const std::string        a_realm,
+                             const phase::which_phase a_phase,
+                             const Interval&          a_variables) const
+{
+  CH_TIME("AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase, Interval)");
+  if (m_verbosity > 3) {
+    pout() << "AmrMesh::conservativeAverage(EBAMRCellData, string, phase::which_phase, Interval)" << endl;
+  }
+
+  this->average(a_data, a_realm, a_phase, Average::Conservative, a_variables);
 }
 
 void
@@ -1520,10 +1584,6 @@ AmrMesh::average(EBAMRIVData&             a_data,
     EBCoarAve& aveOp = *m_realms[a_realm]->getCoarseAverage(a_phase)[lvl];
 
     aveOp.averageData(*a_data[lvl - 1], *a_data[lvl], interv, a_average);
-  }
-
-  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    a_data[lvl]->exchange();
   }
 }
 

--- a/Source/AmrMesh/CD_Average.H
+++ b/Source/AmrMesh/CD_Average.H
@@ -1,0 +1,33 @@
+/* chombo-discharge
+ * Copyright © 2021 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_Average.H
+  @brief  Declaration of averaging methods.
+  @author Robert Marskar
+*/
+
+#ifndef CD_Average_H
+#define CD_Average_H
+
+// Our includes
+#include <CD_NamespaceHeader.H>
+
+/*!
+  @brief Various averaging methods. 
+  @details 'Arithmetic'/'Harmonic' mean what you think, while 'Conservative' also incorporate volume, face, 
+  and EB face fractions such that the total quantity is conserved. 
+*/
+enum class Average
+{
+  Arithmetic,
+  Harmonic,
+  Conservative,
+  Geometric
+};
+
+#include <CD_NamespaceFooter.H>
+
+#endif

--- a/Source/AmrMesh/CD_EBCoarAve.H
+++ b/Source/AmrMesh/CD_EBCoarAve.H
@@ -4,13 +4,13 @@
  */
 
 /*!
-  @file   CD_EbCoarAve.H
+  @file   CD_EBCoarAve.H
   @brief  Declaration of conservative coarsening utility 
   @author Robert Marskar
 */
 
-#ifndef CD_EbCoarAve_H
-#define CD_EbCoarAve_H
+#ifndef CD_EBCoarAve_H
+#define CD_EBCoarAve_H
 
 // Chombo includes
 #include <EBLevelGrid.H>
@@ -35,18 +35,18 @@ enum class Average
   at fine level of refinement. Just like Chombo's EBCoarseAverage, but with an extra
   function. 
 */
-class EbCoarAve
+class EBCoarAve
 {
 public:
   /*!
     @brief Default constructor. Must call define afterwards. 
   */
-  EbCoarAve();
+  EBCoarAve();
 
   /*!
     @brief Copy constructor not allowed
   */
-  EbCoarAve(const EbCoarAve& a_other) = delete;
+  EBCoarAve(const EBCoarAve& a_other) = delete;
 
   /*!
     @brief Defining constructor.
@@ -59,7 +59,7 @@ public:
     @param[in] a_refRat     Refinement ratio
     @param[in] a_ebisPtr    EBIS pointer.
   */
-  EbCoarAve(const DisjointBoxLayout& a_dblFine,
+  EBCoarAve(const DisjointBoxLayout& a_dblFine,
             const DisjointBoxLayout& a_dblCoar,
             const EBISLayout&        a_ebislFine,
             const EBISLayout&        a_ebislCoar,
@@ -74,7 +74,7 @@ public:
     @param[in] a_eblgCoFi Coarsened fine grids
     @param[in] a_refRat   Refinement ratio between coarse and level
   */
-  EbCoarAve(const EBLevelGrid& a_eblgFine,
+  EBCoarAve(const EBLevelGrid& a_eblgFine,
             const EBLevelGrid& a_eblgCoar,
             const EBLevelGrid& a_eblgCoFi,
             const int&         a_refRat);
@@ -82,7 +82,7 @@ public:
   /*!
     @brief Destructor (does nothing)
   */
-  ~EbCoarAve();
+  ~EBCoarAve();
 
   /*!
     @brief Define function -- puts operator in usable state.
@@ -101,7 +101,7 @@ public:
     @brief Assignement not allowed.
   */
   void
-  operator=(const EbCoarAve& fabin) = delete;
+  operator=(const EBCoarAve& fabin) = delete;
 
   /*!
     @brief Do an average of cell data. 

--- a/Source/AmrMesh/CD_EBCoarAve.H
+++ b/Source/AmrMesh/CD_EBCoarAve.H
@@ -16,19 +16,8 @@
 #include <EBLevelGrid.H>
 
 // Our includes
+#include <CD_Average.H>
 #include <CD_NamespaceHeader.H>
-
-/*!
-  @brief Various averaging methods. 
-  @details 'Arithmetic'/'Harmonic' mean what you think, while 'Conservative' also incorporate volume, face, 
-  and EB face fractions such that the total quantity is conserved. 
-*/
-enum class Average
-{
-  Arithmetic,
-  Harmonic,
-  Conservative
-};
 
 /*!
   @brief Class which replaces data at coarse level of refinement with average

--- a/Source/AmrMesh/CD_EBCoarAve.H
+++ b/Source/AmrMesh/CD_EBCoarAve.H
@@ -32,8 +32,7 @@ enum class Average
 
 /*!
   @brief Class which replaces data at coarse level of refinement with average
-  at fine level of refinement. Just like Chombo's EBCoarseAverage, but with an extra
-  function. 
+  at fine level of refinement. 
 */
 class EBCoarAve
 {

--- a/Source/AmrMesh/CD_EBCoarAve.cpp
+++ b/Source/AmrMesh/CD_EBCoarAve.cpp
@@ -4,8 +4,8 @@
  */
 
 /*!
-  @file   CD_EbCoarAve.cpp
-  @brief  Implementation of CD_EbCoarAve.H
+  @file   CD_EBCoarAve.cpp
+  @brief  Implementation of CD_EBCoarAve.H
   @author Robert Marskar
 */
 
@@ -16,15 +16,15 @@
 #include <CH_Timer.H>
 
 // Our includes
-#include <CD_EbCoarAve.H>
+#include <CD_EBCoarAve.H>
 #include <CD_BoxLoops.H>
 #include <CD_NamespaceHeader.H>
 
-EbCoarAve::EbCoarAve() { m_isDefined = false; }
+EBCoarAve::EBCoarAve() { m_isDefined = false; }
 
-EbCoarAve::~EbCoarAve() {}
+EBCoarAve::~EBCoarAve() {}
 
-EbCoarAve::EbCoarAve(const DisjointBoxLayout& a_dblFine,
+EBCoarAve::EBCoarAve(const DisjointBoxLayout& a_dblFine,
                      const DisjointBoxLayout& a_dblCoar,
                      const EBISLayout&        a_ebislFine,
                      const EBISLayout&        a_ebislCoar,
@@ -32,7 +32,7 @@ EbCoarAve::EbCoarAve(const DisjointBoxLayout& a_dblFine,
                      const int&               a_refRat,
                      const EBIndexSpace*      a_ebisPtr)
 {
-  CH_TIME("EbCoarAve::EbCoarAve(DBL version)");
+  CH_TIME("EBCoarAve::EBCoarAve(DBL version)");
 
   CH_assert(a_ebisPtr->isDefined());
 
@@ -49,12 +49,12 @@ EbCoarAve::EbCoarAve(const DisjointBoxLayout& a_dblFine,
   this->define(eblgFine, eblgCoar, eblgCoFi, a_refRat);
 }
 
-EbCoarAve::EbCoarAve(const EBLevelGrid& a_eblgFine,
+EBCoarAve::EBCoarAve(const EBLevelGrid& a_eblgFine,
                      const EBLevelGrid& a_eblgCoar,
                      const EBLevelGrid& a_eblgCoFi,
                      const int&         a_refRat)
 {
-  CH_TIME("EbCoarAve::EbCoarAve(EBLevelGrid version)");
+  CH_TIME("EBCoarAve::EBCoarAve(EBLevelGrid version)");
 
   m_isDefined = false;
 
@@ -62,12 +62,12 @@ EbCoarAve::EbCoarAve(const EBLevelGrid& a_eblgFine,
 }
 
 void
-EbCoarAve::define(const EBLevelGrid& a_eblgFine,
+EBCoarAve::define(const EBLevelGrid& a_eblgFine,
                   const EBLevelGrid& a_eblgCoar,
                   const EBLevelGrid& a_eblgCoFi,
                   const int&         a_refRat)
 {
-  CH_TIME("EbCoarAve::define");
+  CH_TIME("EBCoarAve::define");
 
   m_eblgFine = a_eblgFine;
   m_eblgCoar = a_eblgCoar;
@@ -84,12 +84,12 @@ EbCoarAve::define(const EBLevelGrid& a_eblgFine,
 }
 
 void
-EbCoarAve::averageData(LevelData<EBCellFAB>&       a_coarData,
+EBCoarAve::averageData(LevelData<EBCellFAB>&       a_coarData,
                        const LevelData<EBCellFAB>& a_fineData,
                        const Interval&             a_variables,
                        const Average&              a_average)
 {
-  CH_TIME("EbCoarAve::averageData(LD<EBCellFAB>)");
+  CH_TIME("EBCoarAve::averageData(LD<EBCellFAB>)");
 
   CH_assert(m_isDefined);
 
@@ -124,7 +124,7 @@ EbCoarAve::averageData(LevelData<EBCellFAB>&       a_coarData,
       break;
     }
     default: {
-      MayDay::Error("EbCoarAve::averageData(LD<EBCellFAB>) - logic bust");
+      MayDay::Error("EBCoarAve::averageData(LD<EBCellFAB>) - logic bust");
 
       break;
     }
@@ -135,13 +135,13 @@ EbCoarAve::averageData(LevelData<EBCellFAB>&       a_coarData,
 }
 
 void
-EbCoarAve::arithmeticAverage(EBCellFAB&       a_coarData,
+EBCoarAve::arithmeticAverage(EBCellFAB&       a_coarData,
                              const EBCellFAB& a_fineData,
                              const DataIndex& a_datInd,
                              const Interval&  a_coarInterv,
                              const Interval&  a_fineInterv)
 {
-  CH_TIME("EbCoarAve::arithmeticAverage(EBCellFAB)");
+  CH_TIME("EBCoarAve::arithmeticAverage(EBCellFAB)");
 
   CH_assert(m_isDefined);
   CH_assert(a_fineInterv.size() == a_coarInterv.size());
@@ -202,14 +202,14 @@ EbCoarAve::arithmeticAverage(EBCellFAB&       a_coarData,
 }
 
 void
-EbCoarAve::harmonicAverage(EBCellFAB&       a_coarData,
+EBCoarAve::harmonicAverage(EBCellFAB&       a_coarData,
                            const EBCellFAB& a_fineData,
                            const DataIndex& a_datInd,
                            const Interval&  a_coarInterv,
                            const Interval&  a_fineInterv)
 
 {
-  CH_TIME("EbCoarAve::arithmeticAverage(EBCellFAB)");
+  CH_TIME("EBCoarAve::arithmeticAverage(EBCellFAB)");
 
   CH_assert(m_isDefined);
   CH_assert(a_fineInterv.size() == a_coarInterv.size());
@@ -270,13 +270,13 @@ EbCoarAve::harmonicAverage(EBCellFAB&       a_coarData,
 }
 
 void
-EbCoarAve::conservativeAverage(EBCellFAB&       a_coarData,
+EBCoarAve::conservativeAverage(EBCellFAB&       a_coarData,
                                const EBCellFAB& a_fineData,
                                const DataIndex& a_datInd,
                                const Interval&  a_coarInterv,
                                const Interval&  a_fineInterv)
 {
-  CH_TIME("EbCoarAve::conservativeAverage(EBCellFAB)");
+  CH_TIME("EBCoarAve::conservativeAverage(EBCellFAB)");
 
   CH_assert(m_isDefined);
   CH_assert(a_fineInterv.size() == a_coarInterv.size());
@@ -352,12 +352,12 @@ EbCoarAve::conservativeAverage(EBCellFAB&       a_coarData,
 }
 
 void
-EbCoarAve::averageData(LevelData<EBFluxFAB>&       a_coarData,
+EBCoarAve::averageData(LevelData<EBFluxFAB>&       a_coarData,
                        const LevelData<EBFluxFAB>& a_fineData,
                        const Interval&             a_variables,
                        const Average&              a_average)
 {
-  CH_TIME("EbCoarAve::averageData(LD<EBFluxFAB>)");
+  CH_TIME("EBCoarAve::averageData(LD<EBFluxFAB>)");
 
   CH_assert(m_isDefined);
 
@@ -395,7 +395,7 @@ EbCoarAve::averageData(LevelData<EBFluxFAB>&       a_coarData,
       break;
     }
     default: {
-      MayDay::Error("EbCoarAve::averageData(LD<EBFluxFAB>) - logic bust");
+      MayDay::Error("EBCoarAve::averageData(LD<EBFluxFAB>) - logic bust");
 
       break;
     }
@@ -407,14 +407,14 @@ EbCoarAve::averageData(LevelData<EBFluxFAB>&       a_coarData,
 }
 
 void
-EbCoarAve::arithmeticAverage(EBFaceFAB&       a_coarData,
+EBCoarAve::arithmeticAverage(EBFaceFAB&       a_coarData,
                              const EBFaceFAB& a_fineData,
                              const DataIndex& a_datInd,
                              const Interval&  a_fineInterv,
                              const Interval&  a_coarInterv,
                              const int&       a_dir)
 {
-  CH_TIME("EbCoarAve::arithmeticAverage");
+  CH_TIME("EBCoarAve::arithmeticAverage");
 
   CH_assert(m_isDefined);
   CH_assert(a_fineInterv.size() == a_coarInterv.size());
@@ -489,14 +489,14 @@ EbCoarAve::arithmeticAverage(EBFaceFAB&       a_coarData,
 }
 
 void
-EbCoarAve::harmonicAverage(EBFaceFAB&       a_coarData,
+EBCoarAve::harmonicAverage(EBFaceFAB&       a_coarData,
                            const EBFaceFAB& a_fineData,
                            const DataIndex& a_datInd,
                            const Interval&  a_fineInterv,
                            const Interval&  a_coarInterv,
                            const int&       a_dir)
 {
-  CH_TIME("EbCoarAve::harmonicAverage");
+  CH_TIME("EBCoarAve::harmonicAverage");
 
   CH_assert(m_isDefined);
   CH_assert(a_fineInterv.size() == a_coarInterv.size());
@@ -575,14 +575,14 @@ EbCoarAve::harmonicAverage(EBFaceFAB&       a_coarData,
 }
 
 void
-EbCoarAve::conservativeAverage(EBFaceFAB&       a_coarData,
+EBCoarAve::conservativeAverage(EBFaceFAB&       a_coarData,
                                const EBFaceFAB& a_fineData,
                                const DataIndex& a_datInd,
                                const Interval&  a_fineInterv,
                                const Interval&  a_coarInterv,
                                const int&       a_dir)
 {
-  CH_TIME("EbCoarAve::conservativeAverage");
+  CH_TIME("EBCoarAve::conservativeAverage");
 
   CH_assert(m_isDefined);
   CH_assert(a_fineInterv.size() == a_coarInterv.size());
@@ -674,12 +674,12 @@ EbCoarAve::conservativeAverage(EBFaceFAB&       a_coarData,
 }
 
 void
-EbCoarAve::averageData(LevelData<BaseIVFAB<Real>>&       a_coarData,
+EBCoarAve::averageData(LevelData<BaseIVFAB<Real>>&       a_coarData,
                        const LevelData<BaseIVFAB<Real>>& a_fineData,
                        const Interval&                   a_variables,
                        const Average&                    a_average)
 {
-  CH_TIME("EbCoarAve::averageData(LD<BaseIVFAB>)");
+  CH_TIME("EBCoarAve::averageData(LD<BaseIVFAB>)");
 
   CH_assert(m_isDefined);
 
@@ -713,7 +713,7 @@ EbCoarAve::averageData(LevelData<BaseIVFAB<Real>>&       a_coarData,
       break;
     }
     default: {
-      MayDay::Error("EbCoarAve::averageData(LD<BaseIVFAB>) - logic bust");
+      MayDay::Error("EBCoarAve::averageData(LD<BaseIVFAB>) - logic bust");
 
       break;
     }
@@ -724,13 +724,13 @@ EbCoarAve::averageData(LevelData<BaseIVFAB<Real>>&       a_coarData,
 }
 
 void
-EbCoarAve::arithmeticAverage(BaseIVFAB<Real>&       a_coarData,
+EBCoarAve::arithmeticAverage(BaseIVFAB<Real>&       a_coarData,
                              const BaseIVFAB<Real>& a_fineData,
                              const DataIndex&       a_datInd,
                              const Interval&        a_coarInterv,
                              const Interval&        a_fineInterv) const
 {
-  CH_TIME("EbCoarAve::arithmeticAverage(BaseIVFAB<Real>)");
+  CH_TIME("EBCoarAve::arithmeticAverage(BaseIVFAB<Real>)");
 
   CH_assert(m_isDefined);
   CH_assert(a_coarInterv.size() == a_fineInterv.size());
@@ -772,13 +772,13 @@ EbCoarAve::arithmeticAverage(BaseIVFAB<Real>&       a_coarData,
 }
 
 void
-EbCoarAve::harmonicAverage(BaseIVFAB<Real>&       a_coarData,
+EBCoarAve::harmonicAverage(BaseIVFAB<Real>&       a_coarData,
                            const BaseIVFAB<Real>& a_fineData,
                            const DataIndex&       a_datInd,
                            const Interval&        a_coarInterv,
                            const Interval&        a_fineInterv) const
 {
-  CH_TIME("EbCoarAve::harmonicAverage(BaseIVFAB<Real>)");
+  CH_TIME("EBCoarAve::harmonicAverage(BaseIVFAB<Real>)");
 
   CH_assert(m_isDefined);
   CH_assert(a_coarInterv.size() == a_fineInterv.size());
@@ -819,13 +819,13 @@ EbCoarAve::harmonicAverage(BaseIVFAB<Real>&       a_coarData,
 }
 
 void
-EbCoarAve::conservativeAverage(BaseIVFAB<Real>&       a_coarData,
+EBCoarAve::conservativeAverage(BaseIVFAB<Real>&       a_coarData,
                                const BaseIVFAB<Real>& a_fineData,
                                const DataIndex&       a_datInd,
                                const Interval&        a_coarInterv,
                                const Interval&        a_fineInterv) const
 {
-  CH_TIME("EbCoarAve::conservativeAverage(BaseIVFAB<Real>)");
+  CH_TIME("EBCoarAve::conservativeAverage(BaseIVFAB<Real>)");
 
   CH_assert(m_isDefined);
   CH_assert(a_coarInterv.size() == a_fineInterv.size());

--- a/Source/AmrMesh/CD_EbCoarAve.H
+++ b/Source/AmrMesh/CD_EbCoarAve.H
@@ -82,22 +82,6 @@ public:
             const int&         a_refRat,
             const int&         a_nComp);
 
-#if 1 // Development code
-  void
-  averageFaceData(LevelData<EBFluxFAB>&       a_coarData,
-                  const LevelData<EBFluxFAB>& a_fineData,
-                  const Interval&             a_variables);
-
-  void
-  conservativeAverage(LevelData<BaseIVFAB<Real>>&       a_coarData,
-                      const LevelData<BaseIVFAB<Real>>& a_fineData,
-                      const Interval&                   a_variables)
-  {
-    this->averageData(a_coarData, a_fineData, a_variables, Average::Conservative);
-  }
-
-#endif
-
   /*!
     @brief Destructor (does nothing)
   */

--- a/Source/AmrMesh/CD_EbCoarAve.H
+++ b/Source/AmrMesh/CD_EbCoarAve.H
@@ -19,15 +19,27 @@
 #include <CD_NamespaceHeader.H>
 
 /*!
-   @brief Class which replaces data at coarse level of refinement with average
-   at fine level of refinement. Just like Chombo's EBCoarseAverage, but with an extra
-   function. 
+  @brief Various averaging methods. 
+  @details 'Arithmetic'/'Harmonic' mean what you think, while 'Conservative' also incorporate volume, face, 
+  and EB face fractions such that the total quantity is conserved. 
+*/
+enum class Average
+{
+  Arithmetic,
+  Harmonic,
+  Conservative
+};
+
+/*!
+  @brief Class which replaces data at coarse level of refinement with average
+  at fine level of refinement. Just like Chombo's EBCoarseAverage, but with an extra
+  function. 
 */
 class EbCoarAve : public EBCoarseAverage
 {
 public:
   /*!
-     @brief Default constructor. Must call define afterwards. 
+    @brief Default constructor. Must call define afterwards. 
   */
   EbCoarAve();
 
@@ -37,15 +49,15 @@ public:
   EbCoarAve(const EbCoarAve& a_other) = delete;
 
   /*!
-     @brief Defining constructor. Calls the define function. 
-     @param[in] a_dblFine    Fine grids
-     @param[in] a_dblCoar    Coarse grids
-     @param[in] a_ebislFine  Fine EBISLayout
-     @param[in] a_ebislCoar  Coarse EBISLayout
-     @param[in] a_domainCoar Coarse-level domain
-     @param[in] a_refRat     Refinement ratio between fine and coarse
-     @param[in] a_nComp      Maximum number of variables to coarsen
-     @param[in] a_ebisPtr    EBIndexSpace
+    @brief Defining constructor. Calls the define function. 
+    @param[in] a_dblFine    Fine grids
+    @param[in] a_dblCoar    Coarse grids
+    @param[in] a_ebislFine  Fine EBISLayout
+    @param[in] a_ebislCoar  Coarse EBISLayout
+    @param[in] a_domainCoar Coarse-level domain
+    @param[in] a_refRat     Refinement ratio between fine and coarse
+    @param[in] a_nComp      Maximum number of variables to coarsen
+    @param[in] a_ebisPtr    EBIndexSpace
   */
   EbCoarAve(const DisjointBoxLayout& a_dblFine,
             const DisjointBoxLayout& a_dblCoar,
@@ -70,6 +82,22 @@ public:
             const int&         a_refRat,
             const int&         a_nComp);
 
+#if 1 // Development code
+  void
+  averageFaceData(LevelData<EBFluxFAB>&       a_coarData,
+                  const LevelData<EBFluxFAB>& a_fineData,
+                  const Interval&             a_variables);
+
+  void
+  conservativeAverage(LevelData<BaseIVFAB<Real>>&       a_coarData,
+                      const LevelData<BaseIVFAB<Real>>& a_fineData,
+                      const Interval&                   a_variables)
+  {
+    this->averageData(a_coarData, a_fineData, a_variables, Average::Conservative);
+  }
+
+#endif
+
   /*!
     @brief Destructor (does nothing)
   */
@@ -82,66 +110,187 @@ public:
   operator=(const EbCoarAve& fabin) = delete;
 
   /*!
-    @brief Conservatively average data defined on irregular cells
-    @details a_coarData will be replaced by a conservative coarsening of a_fineData in regions where the 
-    fine grid covers the coarse grid. 
+    @brief Do an average of cell data. 
     @param[inout] a_coarData  Coarse data
     @param[in]    a_fineData  Fine data
     @param[in]    a_variables Variables to coarsen
-  */
-  void
-  conservativeAverage(LevelData<BaseIVFAB<Real>>&       a_coarData,
-                      const LevelData<BaseIVFAB<Real>>& a_fineData,
-                      const Interval&                   a_variables);
-
-  /*!
-    @brief Do an arithmetic average of face data. 
-    @details a_coarData will be replaced by an arithmetic average of a_fineData in regions where the 
-    fine grid covers the coarse grid. 
-    @param[inout] a_coarData  Coarse data
-    @param[in]    a_fineData  Fine data
-    @param[in]    a_variables Variables to coarsen
+    @param[in]    a_average   Averaging method
     @note Input data holders should be defined over the input grids. 
   */
   void
-  averageFaceData(LevelData<EBFluxFAB>&       a_coarData,
-                  const LevelData<EBFluxFAB>& a_fineData,
-                  const Interval&             a_variables);
+  averageData(LevelData<EBCellFAB>&       a_coarData,
+              const LevelData<EBCellFAB>& a_fineData,
+              const Interval&             a_variables,
+              const Average&              a_average);
+
+  /*!
+    @brief Do an average of face data. 
+    @param[inout] a_coarData  Coarse data
+    @param[in]    a_fineData  Fine data
+    @param[in]    a_variables Variables to coarsen
+    @param[in]    a_average   Averaging method
+    @note Input data holders should be defined over the input grids. 
+  */
+  void
+  averageData(LevelData<EBFluxFAB>&       a_coarData,
+              const LevelData<EBFluxFAB>& a_fineData,
+              const Interval&             a_variables,
+              const Average&              a_average);
+
+  /*!
+    @brief Do an average of EB data. 
+    @param[inout] a_coarData  Coarse data
+    @param[in]    a_fineData  Fine data
+    @param[in]    a_variables Variables to coarsen
+    @param[in]    a_average   Averaging method
+    @note Input data holders should be defined over the input grids. 
+  */
+  void
+  averageData(LevelData<BaseIVFAB<Real>>&       a_coarData,
+              const LevelData<BaseIVFAB<Real>>& a_fineData,
+              const Interval&                   a_variables,
+              const Average&                    a_average);
 
 protected:
   /*!
-    @brief Conservatively average data defined on irregular cells
-    @details a_coarData will be replaced by a conservative coarsening of a_fineData in regions where the 
-    fine grid covers the coarse grid. 
-    @param[inout] a_coarData  Coarse data
-    @param[in]    a_fineData  Fine data
-    @param[in]    a_datInd    Grid index
-    @param[in]    a_variables Variables to coarsen
+    @brief Do an arithmetic average of cell-centered data when coarsening. 
+    @param[inout] a_coarData Coarse data
+    @param[in]    a_fineData    Fine data
+    @param[in]    a_datInd      Grid index
+    @param[in]    a_fineInterv  Fine interval
+    @param[in]    a_coarInterv  Coarse interval
   */
   void
-  conservativeAverageFAB(BaseIVFAB<Real>&       a_coarData,
-                         const BaseIVFAB<Real>& a_fineData,
-                         const DataIndex&       a_datInd,
-                         const Interval&        a_variables) const;
+  arithmeticAverage(EBCellFAB&       a_coarData,
+                    const EBCellFAB& a_fineData,
+                    const DataIndex& a_datInd,
+                    const Interval&  a_coarInterv,
+                    const Interval&  a_fineInterv);
+  /*!
+    @brief Do a harmonic average of cell-centered data when coarsening. 
+    @param[inout] a_coarData Coarse data
+    @param[in]    a_fineData    Fine data
+    @param[in]    a_datInd      Grid index
+    @param[in]    a_fineInterv  Fine interval
+    @param[in]    a_coarInterv  Coarse interval
+  */
+  void
+  harmonicAverage(EBCellFAB&       a_coarData,
+                  const EBCellFAB& a_fineData,
+                  const DataIndex& a_datInd,
+                  const Interval&  a_coarInterv,
+                  const Interval&  a_fineInterv);
+
+  /*!
+    @brief Do a conservative average of cell-centered data when coarsening. 
+    @param[inout] a_coarData Coarse data
+    @param[in]    a_fineData    Fine data
+    @param[in]    a_datInd      Grid index
+    @param[in]    a_fineInterv  Fine interval
+    @param[in]    a_coarInterv  Coarse interval
+  */
+  void
+  conservativeAverage(EBCellFAB&       a_coarData,
+                      const EBCellFAB& a_fineData,
+                      const DataIndex& a_datInd,
+                      const Interval&  a_coarInterv,
+                      const Interval&  a_fineInterv);
 
   /*!
     @brief Do an arithmetic average of face-centered data when coarsening. 
-    @details a_coarData will be replaced by an arithmetic average of a_fineData in regions where the 
-    fine grid covers the coarse grid. 
     @param[inout] a_coarData Coarse data
-    @param[in] a_fineData    Fine data
-    @param[in] a_datInd      Grid index
-    @param[in] a_fineInterv  Fine interval
-    @param[in] a_coarInterv  Coarse interval
-    @param[in] a_dir         Face direction
+    @param[in]    a_fineData    Fine data
+    @param[in]    a_datInd      Grid index
+    @param[in]    a_fineInterv  Fine interval
+    @param[in]    a_coarInterv  Coarse interval
+    @param[in]    a_dir         Face direction
   */
   void
-  averageFaces(EBFaceFAB&       a_coarData,
-               const EBFaceFAB& a_fineData,
-               const DataIndex& a_datInd,
-               const Interval&  a_fineInterv,
-               const Interval&  a_coarInterv,
-               const int&       a_dir);
+  arithmeticAverage(EBFaceFAB&       a_coarData,
+                    const EBFaceFAB& a_fineData,
+                    const DataIndex& a_datInd,
+                    const Interval&  a_fineInterv,
+                    const Interval&  a_coarInterv,
+                    const int&       a_dir);
+
+  /*!
+    @brief Do a harmonic average of face-centered data when coarsening. 
+    @param[inout] a_coarData Coarse data
+    @param[in]    a_fineData    Fine data
+    @param[in]    a_datInd      Grid index
+    @param[in]    a_coarInterv  Coarse interval
+    @param[in]    a_fineInterv  Fine interval
+    @param[in]    a_dir         Face direction
+  */
+  void
+  harmonicAverage(EBFaceFAB&       a_coarData,
+                  const EBFaceFAB& a_fineData,
+                  const DataIndex& a_datInd,
+                  const Interval&  a_coarInterv,
+                  const Interval&  a_fineInterv,
+                  const int&       a_dir);
+
+  /*!
+    @brief Do a conservative average of face-centered data when coarsening. 
+    @param[inout] a_coarData Coarse data
+    @param[in]    a_fineData    Fine data
+    @param[in]    a_datInd      Grid index
+    @param[in]    a_coarInterv  Coarse interval
+    @param[in]    a_fineInterv  Fine interval
+    @param[in]    a_dir         Face direction
+  */
+  void
+  conservativeAverage(EBFaceFAB&       a_coarData,
+                      const EBFaceFAB& a_fineData,
+                      const DataIndex& a_datInd,
+                      const Interval&  a_coarInterv,
+                      const Interval&  a_fineInterv,
+                      const int&       a_dir);
+
+  /*!
+    @brief Arithmetic average data defined on irregular cells
+    @param[inout] a_coarData   Coarse data
+    @param[in]    a_fineData   Fine data
+    @param[in]    a_datInd     Grid index
+    @param[in]    a_coarInterv Coarse variables
+    @param[in]    a_fineInterv Fine variables
+  */
+  void
+  arithmeticAverage(BaseIVFAB<Real>&       a_coarData,
+                    const BaseIVFAB<Real>& a_fineData,
+                    const DataIndex&       a_datInd,
+                    const Interval&        a_coarInterv,
+                    const Interval&        a_fineINterv) const;
+
+  /*!
+    @brief Harmonic average data defined on irregular cells
+    @param[inout] a_coarData   Coarse data
+    @param[in]    a_fineData   Fine data
+    @param[in]    a_datInd     Grid index
+    @param[in]    a_coarInterv Coarse variables
+    @param[in]    a_fineInterv Fine variables
+  */
+  void
+  harmonicAverage(BaseIVFAB<Real>&       a_coarData,
+                  const BaseIVFAB<Real>& a_fineData,
+                  const DataIndex&       a_datInd,
+                  const Interval&        a_coarInterv,
+                  const Interval&        a_fineInterv) const;
+
+  /*!
+    @brief Conservatively average data defined on irregular cells
+    @param[inout] a_coarData   Coarse data
+    @param[in]    a_fineData   Fine data
+    @param[in]    a_datInd     Grid index
+    @param[in]    a_coarInterv Coarse variables
+    @param[in]    a_fineInterv Fine variables
+  */
+  void
+  conservativeAverage(BaseIVFAB<Real>&       a_coarData,
+                      const BaseIVFAB<Real>& a_fineData,
+                      const DataIndex&       a_datInd,
+                      const Interval&        a_coarInterv,
+                      const Interval&        a_fineInterv) const;
 };
 
 #include <CD_NamespaceFooter.H>

--- a/Source/AmrMesh/CD_EbCoarAve.H
+++ b/Source/AmrMesh/CD_EbCoarAve.H
@@ -136,65 +136,87 @@ public:
               const Average&                    a_average);
 
 protected:
+
   /*!
-    @brief Do an arithmetic average of cell-centered data when coarsening. 
-    @param[inout] a_coarData Coarse data
-    @param[in]    a_fineData    Fine data
-    @param[in]    a_datInd      Grid index
-    @param[in]    a_fineInterv  Fine interval
-    @param[in]    a_coarInterv  Coarse interval
+    @brief Defined over m_eblgCoFi with one component
   */
-  void
+  LevelData<EBCellFAB> m_cellCoFi;
+
+  /*!
+    @brief Defined over m_eblgCoFi with one component
+  */
+  LevelData<EBFluxFAB> m_fluxCoFi;
+
+  /*!
+    @brief Defined over m_eblgCoFi with one component
+  */
+  LevelData<BaseIVFAB<Real> > m_baseivCoFi;    
+
+  /*!
+    @brief Define buffer storage
+  */
+  virtual
+  void defineBuffers();
+  
+  /*!
+    @brief Arithmetic average of cell-centered data.
+    @param[inout] a_coarData Coarse data
+    @param[in]    a_fineData Fine data
+    @param[in]    a_datInd   Grid index
+    @param[in]    a_coarVar  Coarse variables
+    @param[in]    a_fineVar  Fine variable
+  */
+  virtual void
   arithmeticAverage(EBCellFAB&       a_coarData,
                     const EBCellFAB& a_fineData,
                     const DataIndex& a_datInd,
-                    const Interval&  a_coarInterv,
-                    const Interval&  a_fineInterv);
+                    const int&       a_coarVar,
+                    const int&       a_fineVar);
   /*!
-    @brief Do a harmonic average of cell-centered data when coarsening. 
+    @brief Harmonic average of cell-centered data.
     @param[inout] a_coarData Coarse data
-    @param[in]    a_fineData    Fine data
-    @param[in]    a_datInd      Grid index
-    @param[in]    a_fineInterv  Fine interval
-    @param[in]    a_coarInterv  Coarse interval
+    @param[in]    a_fineData Fine data
+    @param[in]    a_datInd   Grid index
+    @param[in]    a_coarVar  Coarse variables
+    @param[in]    a_fineVar  Fine variable
   */
-  void
+  virtual void
   harmonicAverage(EBCellFAB&       a_coarData,
                   const EBCellFAB& a_fineData,
                   const DataIndex& a_datInd,
-                  const Interval&  a_coarInterv,
-                  const Interval&  a_fineInterv);
+                  const int&       a_coarVar,
+                  const int&       a_fineVar);
 
   /*!
-    @brief Do a conservative average of cell-centered data when coarsening. 
+    @brief Conservative average of cell-centered data.
     @param[inout] a_coarData Coarse data
-    @param[in]    a_fineData    Fine data
-    @param[in]    a_datInd      Grid index
-    @param[in]    a_fineInterv  Fine interval
-    @param[in]    a_coarInterv  Coarse interval
+    @param[in]    a_fineData Fine data
+    @param[in]    a_datInd   Grid index
+    @param[in]    a_coarVar  Coarse variables
+    @param[in]    a_fineVar  Fine variable
   */
-  void
+  virtual void
   conservativeAverage(EBCellFAB&       a_coarData,
                       const EBCellFAB& a_fineData,
                       const DataIndex& a_datInd,
-                      const Interval&  a_coarInterv,
-                      const Interval&  a_fineInterv);
+                      const int&       a_coarVar,
+                      const int&       a_fineVar);
 
   /*!
-    @brief Do an arithmetic average of face-centered data when coarsening. 
+    @brief Arithmetic average of face data. 
     @param[inout] a_coarData Coarse data
-    @param[in]    a_fineData    Fine data
-    @param[in]    a_datInd      Grid index
-    @param[in]    a_fineInterv  Fine interval
-    @param[in]    a_coarInterv  Coarse interval
-    @param[in]    a_dir         Face direction
+    @param[in]    a_fineData Fine data
+    @param[in]    a_datInd   Grid index
+    @param[in]    a_coarVar  Coarse variables
+    @param[in]    a_fineVar  Fine variable
+    @param[in]    a_dir      Face direction
   */
-  void
+  virtual void
   arithmeticAverage(EBFaceFAB&       a_coarData,
                     const EBFaceFAB& a_fineData,
                     const DataIndex& a_datInd,
-                    const Interval&  a_fineInterv,
-                    const Interval&  a_coarInterv,
+                    const int&       a_coarVar,
+                    const int&       a_fineVar,
                     const int&       a_dir);
 
   /*!
@@ -206,7 +228,7 @@ protected:
     @param[in]    a_fineInterv  Fine interval
     @param[in]    a_dir         Face direction
   */
-  void
+  virtual void
   harmonicAverage(EBFaceFAB&       a_coarData,
                   const EBFaceFAB& a_fineData,
                   const DataIndex& a_datInd,
@@ -223,7 +245,7 @@ protected:
     @param[in]    a_fineInterv  Fine interval
     @param[in]    a_dir         Face direction
   */
-  void
+  virtual void
   conservativeAverage(EBFaceFAB&       a_coarData,
                       const EBFaceFAB& a_fineData,
                       const DataIndex& a_datInd,
@@ -239,7 +261,7 @@ protected:
     @param[in]    a_coarInterv Coarse variables
     @param[in]    a_fineInterv Fine variables
   */
-  void
+  virtual void
   arithmeticAverage(BaseIVFAB<Real>&       a_coarData,
                     const BaseIVFAB<Real>& a_fineData,
                     const DataIndex&       a_datInd,
@@ -254,7 +276,7 @@ protected:
     @param[in]    a_coarInterv Coarse variables
     @param[in]    a_fineInterv Fine variables
   */
-  void
+  virtual void
   harmonicAverage(BaseIVFAB<Real>&       a_coarData,
                   const BaseIVFAB<Real>& a_fineData,
                   const DataIndex&       a_datInd,
@@ -269,7 +291,7 @@ protected:
     @param[in]    a_coarInterv Coarse variables
     @param[in]    a_fineInterv Fine variables
   */
-  void
+  virtual void
   conservativeAverage(BaseIVFAB<Real>&       a_coarData,
                       const BaseIVFAB<Real>& a_fineData,
                       const DataIndex&       a_datInd,

--- a/Source/AmrMesh/CD_EbCoarAve.H
+++ b/Source/AmrMesh/CD_EbCoarAve.H
@@ -13,7 +13,7 @@
 #define CD_EbCoarAve_H
 
 // Chombo includes
-#include <EBCoarseAverage.H>
+#include <EBLevelGrid.H>
 
 // Our includes
 #include <CD_NamespaceHeader.H>
@@ -35,7 +35,7 @@ enum class Average
   at fine level of refinement. Just like Chombo's EBCoarseAverage, but with an extra
   function. 
 */
-class EbCoarAve : public EBCoarseAverage
+class EbCoarAve
 {
 public:
   /*!
@@ -49,15 +49,15 @@ public:
   EbCoarAve(const EbCoarAve& a_other) = delete;
 
   /*!
-    @brief Defining constructor. Calls the define function. 
+    @brief Defining constructor.
+    @details This version creates it's own coarsened grids
     @param[in] a_dblFine    Fine grids
     @param[in] a_dblCoar    Coarse grids
-    @param[in] a_ebislFine  Fine EBISLayout
-    @param[in] a_ebislCoar  Coarse EBISLayout
-    @param[in] a_domainCoar Coarse-level domain
-    @param[in] a_refRat     Refinement ratio between fine and coarse
-    @param[in] a_nComp      Maximum number of variables to coarsen
-    @param[in] a_ebisPtr    EBIndexSpace
+    @param[in] a_ebislFine  Fine EBISL
+    @param[in] a_ebislCoar  Coarse EBISL
+    @param[in] a_domainCoar Coarse domain
+    @param[in] a_refRat     Refinement ratio
+    @param[in] a_ebisPtr    EBIS pointer.
   */
   EbCoarAve(const DisjointBoxLayout& a_dblFine,
             const DisjointBoxLayout& a_dblCoar,
@@ -65,7 +65,6 @@ public:
             const EBISLayout&        a_ebislCoar,
             const ProblemDomain&     a_domainCoar,
             const int&               a_refRat,
-            const int&               a_nComp,
             const EBIndexSpace*      a_ebisPtr);
 
   /*!
@@ -74,18 +73,29 @@ public:
     @param[in] a_eblgCoar Coarse grids
     @param[in] a_eblgCoFi Coarsened fine grids
     @param[in] a_refRat   Refinement ratio between coarse and level
-    @param[in] a_nComp    Maximum number of variables to coarsen
   */
   EbCoarAve(const EBLevelGrid& a_eblgFine,
             const EBLevelGrid& a_eblgCoar,
             const EBLevelGrid& a_eblgCoFi,
-            const int&         a_refRat,
-            const int&         a_nComp);
+            const int&         a_refRat);
 
   /*!
     @brief Destructor (does nothing)
   */
   ~EbCoarAve();
+
+  /*!
+    @brief Define function -- puts operator in usable state.
+    @param[in] a_eblgFine Fine grids
+    @param[in] a_eblgCoar Coarse grids
+    @param[in] a_eblgCoFi Coarsened fine grids
+    @param[in] a_refRat   Refinement ratio between coarse and level
+  */
+  void
+  define(const EBLevelGrid& a_eblgFine,
+         const EBLevelGrid& a_eblgCoar,
+         const EBLevelGrid& a_eblgCoFi,
+         const int&         a_refRat);
 
   /*!
     @brief Assignement not allowed.
@@ -136,6 +146,36 @@ public:
               const Average&                    a_average);
 
 protected:
+  /*!
+    @brief Fine grids
+  */
+  EBLevelGrid m_eblgFine;
+
+  /*!
+    @brief Coarse grids
+  */
+  EBLevelGrid m_eblgCoar;
+
+  /*!
+    @brief Coarsened fine grids
+  */
+  EBLevelGrid m_eblgCoFi;
+
+  /*!
+    @brief Irregular cells on the coarsened fine layout
+  */
+  LayoutData<IntVectSet> m_irregSetsCoFi;
+
+  /*!
+    @brief Refinement ratio
+  */
+  int m_refRat;
+
+  /*!
+    @brief Defined or not
+  */
+  bool m_isDefined;
+
   /*!
     @brief Do an arithmetic average of cell-centered data when coarsening. 
     @param[inout] a_coarData Coarse data

--- a/Source/AmrMesh/CD_EbCoarAve.H
+++ b/Source/AmrMesh/CD_EbCoarAve.H
@@ -136,87 +136,65 @@ public:
               const Average&                    a_average);
 
 protected:
-
   /*!
-    @brief Defined over m_eblgCoFi with one component
-  */
-  LevelData<EBCellFAB> m_cellCoFi;
-
-  /*!
-    @brief Defined over m_eblgCoFi with one component
-  */
-  LevelData<EBFluxFAB> m_fluxCoFi;
-
-  /*!
-    @brief Defined over m_eblgCoFi with one component
-  */
-  LevelData<BaseIVFAB<Real> > m_baseivCoFi;    
-
-  /*!
-    @brief Define buffer storage
-  */
-  virtual
-  void defineBuffers();
-  
-  /*!
-    @brief Arithmetic average of cell-centered data.
+    @brief Do an arithmetic average of cell-centered data when coarsening. 
     @param[inout] a_coarData Coarse data
-    @param[in]    a_fineData Fine data
-    @param[in]    a_datInd   Grid index
-    @param[in]    a_coarVar  Coarse variables
-    @param[in]    a_fineVar  Fine variable
+    @param[in]    a_fineData    Fine data
+    @param[in]    a_datInd      Grid index
+    @param[in]    a_fineInterv  Fine interval
+    @param[in]    a_coarInterv  Coarse interval
   */
-  virtual void
+  void
   arithmeticAverage(EBCellFAB&       a_coarData,
                     const EBCellFAB& a_fineData,
                     const DataIndex& a_datInd,
-                    const int&       a_coarVar,
-                    const int&       a_fineVar);
+                    const Interval&  a_coarInterv,
+                    const Interval&  a_fineInterv);
   /*!
-    @brief Harmonic average of cell-centered data.
+    @brief Do a harmonic average of cell-centered data when coarsening. 
     @param[inout] a_coarData Coarse data
-    @param[in]    a_fineData Fine data
-    @param[in]    a_datInd   Grid index
-    @param[in]    a_coarVar  Coarse variables
-    @param[in]    a_fineVar  Fine variable
+    @param[in]    a_fineData    Fine data
+    @param[in]    a_datInd      Grid index
+    @param[in]    a_fineInterv  Fine interval
+    @param[in]    a_coarInterv  Coarse interval
   */
-  virtual void
+  void
   harmonicAverage(EBCellFAB&       a_coarData,
                   const EBCellFAB& a_fineData,
                   const DataIndex& a_datInd,
-                  const int&       a_coarVar,
-                  const int&       a_fineVar);
+                  const Interval&  a_coarInterv,
+                  const Interval&  a_fineInterv);
 
   /*!
-    @brief Conservative average of cell-centered data.
+    @brief Do a conservative average of cell-centered data when coarsening. 
     @param[inout] a_coarData Coarse data
-    @param[in]    a_fineData Fine data
-    @param[in]    a_datInd   Grid index
-    @param[in]    a_coarVar  Coarse variables
-    @param[in]    a_fineVar  Fine variable
+    @param[in]    a_fineData    Fine data
+    @param[in]    a_datInd      Grid index
+    @param[in]    a_fineInterv  Fine interval
+    @param[in]    a_coarInterv  Coarse interval
   */
-  virtual void
+  void
   conservativeAverage(EBCellFAB&       a_coarData,
                       const EBCellFAB& a_fineData,
                       const DataIndex& a_datInd,
-                      const int&       a_coarVar,
-                      const int&       a_fineVar);
+                      const Interval&  a_coarInterv,
+                      const Interval&  a_fineInterv);
 
   /*!
-    @brief Arithmetic average of face data. 
+    @brief Do an arithmetic average of face-centered data when coarsening. 
     @param[inout] a_coarData Coarse data
-    @param[in]    a_fineData Fine data
-    @param[in]    a_datInd   Grid index
-    @param[in]    a_coarVar  Coarse variables
-    @param[in]    a_fineVar  Fine variable
-    @param[in]    a_dir      Face direction
+    @param[in]    a_fineData    Fine data
+    @param[in]    a_datInd      Grid index
+    @param[in]    a_fineInterv  Fine interval
+    @param[in]    a_coarInterv  Coarse interval
+    @param[in]    a_dir         Face direction
   */
-  virtual void
+  void
   arithmeticAverage(EBFaceFAB&       a_coarData,
                     const EBFaceFAB& a_fineData,
                     const DataIndex& a_datInd,
-                    const int&       a_coarVar,
-                    const int&       a_fineVar,
+                    const Interval&  a_fineInterv,
+                    const Interval&  a_coarInterv,
                     const int&       a_dir);
 
   /*!
@@ -228,7 +206,7 @@ protected:
     @param[in]    a_fineInterv  Fine interval
     @param[in]    a_dir         Face direction
   */
-  virtual void
+  void
   harmonicAverage(EBFaceFAB&       a_coarData,
                   const EBFaceFAB& a_fineData,
                   const DataIndex& a_datInd,
@@ -245,7 +223,7 @@ protected:
     @param[in]    a_fineInterv  Fine interval
     @param[in]    a_dir         Face direction
   */
-  virtual void
+  void
   conservativeAverage(EBFaceFAB&       a_coarData,
                       const EBFaceFAB& a_fineData,
                       const DataIndex& a_datInd,
@@ -261,7 +239,7 @@ protected:
     @param[in]    a_coarInterv Coarse variables
     @param[in]    a_fineInterv Fine variables
   */
-  virtual void
+  void
   arithmeticAverage(BaseIVFAB<Real>&       a_coarData,
                     const BaseIVFAB<Real>& a_fineData,
                     const DataIndex&       a_datInd,
@@ -276,7 +254,7 @@ protected:
     @param[in]    a_coarInterv Coarse variables
     @param[in]    a_fineInterv Fine variables
   */
-  virtual void
+  void
   harmonicAverage(BaseIVFAB<Real>&       a_coarData,
                   const BaseIVFAB<Real>& a_fineData,
                   const DataIndex&       a_datInd,
@@ -291,7 +269,7 @@ protected:
     @param[in]    a_coarInterv Coarse variables
     @param[in]    a_fineInterv Fine variables
   */
-  virtual void
+  void
   conservativeAverage(BaseIVFAB<Real>&       a_coarData,
                       const BaseIVFAB<Real>& a_fineData,
                       const DataIndex&       a_datInd,

--- a/Source/AmrMesh/CD_EbCoarAve.cpp
+++ b/Source/AmrMesh/CD_EbCoarAve.cpp
@@ -10,12 +10,25 @@
 */
 
 // Chombo includes
+#include <EBCellFactory.H>
 #include <EBFluxFactory.H>
+#include <BaseIVFactory.H>
 #include <EBAverageF_F.H>
 
 // Our includes
 #include <CD_EbCoarAve.H>
+#include <CD_BoxLoops.H>
 #include <CD_NamespaceHeader.H>
+
+#if 1 // Debug cod eto be removed
+void
+EbCoarAve::averageFaceData(LevelData<EBFluxFAB>&       a_coarData,
+                           const LevelData<EBFluxFAB>& a_fineData,
+                           const Interval&             a_variables)
+{
+  this->averageData(a_coarData, a_fineData, a_variables, Average::Conservative);
+}
+#endif
 
 EbCoarAve::EbCoarAve() { EBCoarseAverage::setDefaultValues(); }
 
@@ -49,110 +62,296 @@ EbCoarAve::EbCoarAve(const EBLevelGrid& a_eblgFine,
 }
 
 void
-EbCoarAve::conservativeAverage(LevelData<BaseIVFAB<Real>>&       a_coarData,
-                               const LevelData<BaseIVFAB<Real>>& a_fineData,
-                               const Interval&                   a_variables)
+EbCoarAve::averageData(LevelData<EBCellFAB>&       a_coarData,
+                       const LevelData<EBCellFAB>& a_fineData,
+                       const Interval&             a_variables,
+                       const Average&              a_average)
 {
-  CH_TIME("EbCoarAve::conservativeAverage(LD<BaseIVFAB>)");
-
-  LevelData<BaseIVFAB<Real>> coarFiData;
-  LevelData<BaseIVFAB<Real>> fineBuffer;
+  CH_TIME("EbCoarAve::averageData(LD<EBCellFAB>)");
 
   CH_assert(isDefined());
-  {
-    CH_TIME("buffer allocation");
-    BaseIVFactory<Real> factCoFi(m_eblgCoFi.getEBISL(), m_irregSetsCoFi);
-    coarFiData.define(m_eblgCoFi.getDBL(), m_nComp, IntVect::Zero, factCoFi);
-    if (m_useFineBuffer) {
-      BaseIVFactory<Real> factFine(m_eblgFine.getEBISL(), m_irregSetsFine);
-      coarFiData.define(m_eblgFine.getDBL(), m_nComp, IntVect::Zero, factFine);
-    }
+
+  LevelData<EBCellFAB> coarFiData;
+  LevelData<EBCellFAB> fineBuffer;
+
+  // Get input data onto the buffer if we must
+  const int     ncomp = a_variables.end() + 1;
+  EBCellFactory factCoFi(m_eblgCoFi.getEBISL());
+  coarFiData.define(m_eblgCoFi.getDBL(), ncomp, IntVect::Zero, factCoFi);
+  if (m_useFineBuffer) {
+    EBCellFactory factFine(m_eblgFine.getEBISL());
+    fineBuffer.define(m_eblgFine.getDBL(), ncomp, IntVect::Zero, factFine);
   }
 
   if (m_useFineBuffer) {
-    CH_TIME("fine_copy");
     a_fineData.copyTo(a_variables, fineBuffer, a_variables);
   }
 
-  {
-    CH_TIME("averaging");
-    for (DataIterator dit = m_eblgFine.getDBL().dataIterator(); dit.ok(); ++dit) {
-      const BaseIVFAB<Real>* fineFABPtr = NULL;
-      if (m_useFineBuffer) {
-        fineFABPtr = &fineBuffer[dit()];
-      }
-      else {
-        fineFABPtr = &a_fineData[dit()];
-      }
-      BaseIVFAB<Real>&       cofiFAB = coarFiData[dit()];
-      const BaseIVFAB<Real>& fineFAB = *fineFABPtr;
+  for (DataIterator dit = m_eblgFine.getDBL().dataIterator(); dit.ok(); ++dit) {
+    const EBCellFAB* fineFAB = nullptr;
+    if (m_useFineBuffer) {
+      fineFAB = &fineBuffer[dit()];
+    }
+    else {
+      fineFAB = &a_fineData[dit()];
+    }
 
-      this->conservativeAverageFAB(cofiFAB, fineFAB, dit(), a_variables);
+    // Switch between methods.
+    switch (a_average) {
+    case Average::Arithmetic: {
+      this->arithmeticAverage(coarFiData[dit()], *fineFAB, dit(), a_variables, a_variables);
+
+      break;
+    }
+    case Average::Harmonic: {
+      this->harmonicAverage(coarFiData[dit()], *fineFAB, dit(), a_variables, a_variables);
+
+      break;
+    }
+    case Average::Conservative: {
+      this->conservativeAverage(coarFiData[dit()], *fineFAB, dit(), a_variables, a_variables);
+
+      break;
+    }
+    default: {
+      MayDay::Error("EbCoarAve::averageData(LD<EBCellFAB>) - logic bust");
+
+      break;
+    }
     }
   }
-  {
-    CH_TIME("copy_coar");
-    coarFiData.copyTo(a_variables, a_coarData, a_variables);
-  }
+
+  coarFiData.copyTo(a_variables, a_coarData, a_variables);
 }
 
 void
-EbCoarAve::conservativeAverageFAB(BaseIVFAB<Real>&       a_coar,
-                                  const BaseIVFAB<Real>& a_fine,
-                                  const DataIndex&       a_datInd,
-                                  const Interval&        a_variables) const
+EbCoarAve::arithmeticAverage(EBCellFAB&       a_coarData,
+                             const EBCellFAB& a_fineData,
+                             const DataIndex& a_datInd,
+                             const Interval&  a_fineInterv,
+                             const Interval&  a_coarInterv)
 {
-  CH_assert(isDefined());
+  CH_TIME("EBCoarseAverage::arithmeticAverage(EBCellFAB)");
 
+  CH_assert(isDefined());
+  CH_assert(a_fineInterv.size() == a_coarInterv.size());
+
+  const Box& coarBox = m_eblgCoFi.getDBL()[a_datInd];
+  const Box  refiBox = Box(IntVect::Zero, (m_refRat - 1) * IntVect::Unit);
+
+  // Regular cells.
+  for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+    BaseFab<Real>&       coarDataReg = a_coarData.getSingleValuedFAB();
+    const BaseFab<Real>& fineDataReg = a_fineData.getSingleValuedFAB();
+
+    const int fineVar = a_fineInterv.begin() + ioff;
+    const int coarVar = a_coarInterv.begin() + ioff;
+
+    auto regularKernel = [&](const IntVect& iv) -> void {
+      Real coarVal = 0.0;
+
+      for (BoxIterator bit(refiBox); bit.ok(); ++bit) {
+        coarVal += fineDataReg(m_refRat * iv + bit(), fineVar);
+      }
+
+      coarDataReg(iv, coarVar) = coarVal / refiBox.numPts();
+    };
+
+    BoxLoops::loop(coarBox, regularKernel);
+  }
+
+  // Irregular cells -- recall that datInd is from the fine layout.
   const EBISBox& ebisBoxCoar = m_eblgCoFi.getEBISL()[a_datInd];
   const EBISBox& ebisBoxFine = m_eblgFine.getEBISL()[a_datInd];
 
-  const IntVectSet& coarIrregIVS = a_coar.getIVS();
-  const IntVectSet& fineIrregIVS = a_fine.getIVS();
+  const IntVectSet& coarIrregIVS = ebisBoxCoar.getIrregIVS(coarBox);
 
-  const int nref2 = std::pow(m_refRat, SpaceDim - 1);
-
-  // This loop computes phiCoar = sum(phiFine*areaFine)/areaCoar. If areaCoar == 0
-  // then we use a safety factor here.
   for (VoFIterator vofitCoar(coarIrregIVS, ebisBoxCoar.getEBGraph()); vofitCoar.ok(); ++vofitCoar) {
-    const VolIndex&        coarVoF  = vofitCoar();
+    const VolIndex& coarVoF = vofitCoar();
+
     const Vector<VolIndex> fineVoFs = m_eblgCoFi.getEBISL().refine(coarVoF, m_refRat, a_datInd);
 
-    for (int ivar = a_variables.begin(); ivar <= a_variables.end(); ivar++) {
-      int  numVoFs = 0;
-      Real areaTot = 0;
-      Real dataVal = 0;
+    const int numFineVoFs = fineVoFs.size();
 
-      for (int ifine = 0; ifine < fineVoFs.size(); ifine++) {
-        const VolIndex& fineVoF = fineVoFs[ifine];
+    for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+      const int fineVar = a_fineInterv.begin() + ioff;
+      const int coarVar = a_coarInterv.begin() + ioff;
 
-        if (fineIrregIVS.contains(fineVoF.gridIndex())) {
-          Real bndryArea = ebisBoxFine.bndryArea(fineVoF);
-          if (bndryArea > 0) {
-            areaTot += bndryArea;
-            numVoFs++;
-            dataVal += bndryArea * a_fine(fineVoF, ivar);
-          }
+      a_coarData(coarVoF, coarVar) = 0.0;
+
+      // Set phic = sum(phif)/numFine
+      if (numFineVoFs > 0) {
+        for (int ifine = 0; ifine < numFineVoFs; ifine++) {
+          const VolIndex& fineVoF = fineVoFs[ifine];
+
+          a_coarData(coarVoF, coarVar) += a_fineData(fineVoF, fineVar);
         }
+
+        a_coarData(coarVoF, coarVar) = a_coarData(coarVoF, coarVar) / numFineVoFs;
       }
-
-      constexpr Real safety = 1.E-8;
-
-      a_coar(coarVoF, ivar) = dataVal / (nref2 * (safety + ebisBoxCoar.bndryArea(coarVoF)));
     }
   }
 }
 
 void
-EbCoarAve::averageFaceData(LevelData<EBFluxFAB>&       a_coarData,
-                           const LevelData<EBFluxFAB>& a_fineData,
-                           const Interval&             a_variables)
+EbCoarAve::harmonicAverage(EBCellFAB&       a_coarData,
+                           const EBCellFAB& a_fineData,
+                           const DataIndex& a_datInd,
+                           const Interval&  a_fineInterv,
+                           const Interval&  a_coarInterv)
 {
-  CH_TIME("EbCoarAve::averageFaceData");
+  CH_TIME("EBCoarseAverage::arithmeticAverage(EBCellFAB)");
 
-  // TLDR: This routine computes the arithmetic average of the fine faces. This means that the coarse face value is
-  //
-  //          phi(coarFace) = sum[phi(fineFace)]/num(fineFaces)
+  CH_assert(isDefined());
+  CH_assert(a_fineInterv.size() == a_coarInterv.size());
+
+  const Box& coarBox = m_eblgCoFi.getDBL()[a_datInd];
+  const Box  refiBox = Box(IntVect::Zero, (m_refRat - 1) * IntVect::Unit);
+
+  // Regular cells.
+  for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+    BaseFab<Real>&       coarDataReg = a_coarData.getSingleValuedFAB();
+    const BaseFab<Real>& fineDataReg = a_fineData.getSingleValuedFAB();
+
+    const int fineVar = a_fineInterv.begin() + ioff;
+    const int coarVar = a_coarInterv.begin() + ioff;
+
+    auto regularKernel = [&](const IntVect& iv) -> void {
+      Real coarVal = 0.0;
+
+      for (BoxIterator bit(refiBox); bit.ok(); ++bit) {
+        coarVal += 1.0 / fineDataReg(m_refRat * iv + bit(), fineVar);
+      }
+
+      coarDataReg(iv, coarVar) *= refiBox.numPts() / coarVal;
+    };
+
+    BoxLoops::loop(coarBox, regularKernel);
+  }
+
+  // Irregular cells -- recall that datInd is from the fine layout.
+  const EBISBox& ebisBoxCoar = m_eblgCoFi.getEBISL()[a_datInd];
+  const EBISBox& ebisBoxFine = m_eblgFine.getEBISL()[a_datInd];
+
+  const IntVectSet& coarIrregIVS = ebisBoxCoar.getIrregIVS(coarBox);
+
+  for (VoFIterator vofitCoar(coarIrregIVS, ebisBoxCoar.getEBGraph()); vofitCoar.ok(); ++vofitCoar) {
+    const VolIndex& coarVoF = vofitCoar();
+
+    const Vector<VolIndex> fineVoFs = m_eblgCoFi.getEBISL().refine(coarVoF, m_refRat, a_datInd);
+
+    const int numFineVoFs = fineVoFs.size();
+
+    for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+      const int fineVar = a_fineInterv.begin() + ioff;
+      const int coarVar = a_coarInterv.begin() + ioff;
+
+      a_coarData(coarVoF, coarVar) = 0.0;
+
+      // Set phic = numFine/sum(1/phif)
+      if (numFineVoFs > 0) {
+        for (int ifine = 0; ifine < numFineVoFs; ifine++) {
+          const VolIndex& fineVoF = fineVoFs[ifine];
+
+          a_coarData(coarVoF, coarVar) += 1.0 / a_fineData(fineVoF, fineVar);
+        }
+
+        a_coarData(coarVoF, coarVar) = numFineVoFs / a_coarData(coarVoF, coarVar);
+      }
+    }
+  }
+}
+
+void
+EbCoarAve::conservativeAverage(EBCellFAB&       a_coarData,
+                               const EBCellFAB& a_fineData,
+                               const DataIndex& a_datInd,
+                               const Interval&  a_fineInterv,
+                               const Interval&  a_coarInterv)
+{
+  CH_TIME("EBCoarseAverage::conservativeAverage(EBCellFAB)");
+
+  CH_assert(isDefined());
+  CH_assert(a_fineInterv.size() == a_coarInterv.size());
+
+  const Real dxCoar = 1.0;
+  const Real dxFine = dxCoar / m_refRat;
+
+  const Box& coarBox = m_eblgCoFi.getDBL()[a_datInd];
+  const Box  refiBox = Box(IntVect::Zero, (m_refRat - 1) * IntVect::Unit);
+
+  // Regular cells.
+  for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+    BaseFab<Real>&       coarDataReg = a_coarData.getSingleValuedFAB();
+    const BaseFab<Real>& fineDataReg = a_fineData.getSingleValuedFAB();
+
+    const int fineVar = a_fineInterv.begin() + ioff;
+    const int coarVar = a_coarInterv.begin() + ioff;
+
+    auto regularKernel = [&](const IntVect& iv) -> void {
+      coarDataReg(iv, coarVar) = 0.0;
+
+      for (BoxIterator bit(refiBox); bit.ok(); ++bit) {
+        coarDataReg(iv, coarVar) += fineDataReg(m_refRat * iv + bit(), fineVar);
+      }
+
+      coarDataReg(iv, coarVar) *= std::pow(dxFine / dxCoar, SpaceDim);
+    };
+
+    BoxLoops::loop(coarBox, regularKernel);
+  }
+
+  // Irregular cells -- recall that datInd is from the fine layout.
+  const EBISBox& ebisBoxCoar = m_eblgCoFi.getEBISL()[a_datInd];
+  const EBISBox& ebisBoxFine = m_eblgFine.getEBISL()[a_datInd];
+
+  const IntVectSet& coarIrregIVS = ebisBoxCoar.getIrregIVS(coarBox);
+
+  for (VoFIterator vofitCoar(coarIrregIVS, ebisBoxCoar.getEBGraph()); vofitCoar.ok(); ++vofitCoar) {
+    const VolIndex& coarVoF = vofitCoar();
+    const Real      kappaC  = ebisBoxCoar.volFrac(coarVoF);
+
+    const Vector<VolIndex> fineVoFs = m_eblgCoFi.getEBISL().refine(coarVoF, m_refRat, a_datInd);
+
+    const int numFineVoFs = fineVoFs.size();
+
+    for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+      const int fineVar = a_fineInterv.begin() + ioff;
+      const int coarVar = a_coarInterv.begin() + ioff;
+
+      a_coarData(coarVoF, coarVar) = 0.0;
+
+      // Set phic = sum(kappaf * phif * dxf^D)/(kappac * dxc^D) if we can.
+      if (numFineVoFs > 0) {
+        if (kappaC > 0.0) {
+          for (int ifine = 0; ifine < numFineVoFs; ifine++) {
+            const VolIndex& fineVoF = fineVoFs[ifine];
+
+            a_coarData(coarVoF, coarVar) += ebisBoxFine.volFrac(fineVoF) * a_fineData(fineVoF, fineVar);
+          }
+
+          a_coarData(coarVoF, coarVar) = a_coarData(coarVoF, coarVar) * std::pow(dxFine / dxCoar, SpaceDim);
+        }
+        else {
+          // No real volume so take the arithmetic average.
+          for (int ifine = 0; ifine < numFineVoFs; ifine++) {
+            a_coarData(coarVoF, coarVar) += a_fineData(fineVoFs[ifine], fineVar);
+          }
+
+          a_coarData(coarVoF, coarVar) = a_coarData(coarVoF, coarVar) / numFineVoFs;
+        }
+      }
+    }
+  }
+}
+
+void
+EbCoarAve::averageData(LevelData<EBFluxFAB>&       a_coarData,
+                       const LevelData<EBFluxFAB>& a_fineData,
+                       const Interval&             a_variables,
+                       const Average&              a_average)
+{
+  CH_TIME("EbCoarAve::averageData(LD<EBFluxFAB>)");
 
   CH_assert(isDefined());
 
@@ -170,7 +369,6 @@ EbCoarAve::averageFaceData(LevelData<EBFluxFAB>&       a_coarData,
     a_fineData.copyTo(a_variables, fineBuffer, a_variables);
   }
 
-  // Grid loop. Switch between buffer data or not.
   for (DataIterator dit = m_eblgFine.getDBL().dataIterator(); dit.ok(); ++dit) {
     const EBFluxFAB* fineFABPtr = nullptr;
 
@@ -184,8 +382,33 @@ EbCoarAve::averageFaceData(LevelData<EBFluxFAB>&       a_coarData,
     EBFluxFAB&       cofiFAB = coarFiData[dit()];
     const EBFluxFAB& fineFAB = *fineFABPtr;
 
-    for (int idir = 0; idir < SpaceDim; idir++) {
-      this->averageFaces(cofiFAB[idir], fineFAB[idir], dit(), a_variables, a_variables, idir);
+    switch (a_average) {
+    case Average::Arithmetic: {
+      for (int idir = 0; idir < SpaceDim; idir++) {
+        this->arithmeticAverage(cofiFAB[idir], fineFAB[idir], dit(), a_variables, a_variables, idir);
+      }
+
+      break;
+    }
+    case Average::Harmonic: {
+      for (int idir = 0; idir < SpaceDim; idir++) {
+        this->harmonicAverage(cofiFAB[idir], fineFAB[idir], dit(), a_variables, a_variables, idir);
+      }
+
+      break;
+    }
+    case Average::Conservative: {
+      for (int idir = 0; idir < SpaceDim; idir++) {
+        this->conservativeAverage(cofiFAB[idir], fineFAB[idir], dit(), a_variables, a_variables, idir);
+      }
+
+      break;
+    }
+    default: {
+      MayDay::Error("EbCoarAve::averageData(LD<EBFluxFAB>) - logic bust");
+
+      break;
+    }
     }
   }
 
@@ -194,72 +417,495 @@ EbCoarAve::averageFaceData(LevelData<EBFluxFAB>&       a_coarData,
 }
 
 void
-EbCoarAve::averageFaces(EBFaceFAB&       a_coarData,
-                        const EBFaceFAB& a_fineData,
-                        const DataIndex& a_datInd,
-                        const Interval&  a_fineInterv,
-                        const Interval&  a_coarInterv,
-                        const int&       a_dir)
+EbCoarAve::arithmeticAverage(EBFaceFAB&       a_coarData,
+                             const EBFaceFAB& a_fineData,
+                             const DataIndex& a_datInd,
+                             const Interval&  a_fineInterv,
+                             const Interval&  a_coarInterv,
+                             const int&       a_dir)
 {
-  CH_TIME("EBCoarseAverage::averageFaces");
+  CH_TIME("EBCoarseAverage::arithmeticAverage");
 
   CH_assert(isDefined());
   CH_assert(a_fineInterv.size() == a_coarInterv.size());
 
-  // TLDR: This routine computes the arithmetic average of the fine faces. This means that the coarse face value is
-  //
-  //          phi(coarFace) = sum[phi(fineFace)]/num(fineFaces)
+  const int finePerCoar = std::pow(m_refRat, SpaceDim - 1);
 
-  //do all cells as if they were regular
-  BaseFab<Real>&       coarRegFAB = a_coarData.getSingleValuedFAB();
-  const BaseFab<Real>& fineRegFAB = a_fineData.getSingleValuedFAB();
+  const Box& coarBox = m_eblgCoFi.getDBL()[a_datInd];
 
-  const Box& coarDBLBox = m_eblgCoFi.getDBL().get(a_datInd);
-
-  Box refbox(IntVect::Zero, (m_refRat - 1) * IntVect::Unit);
-  Box coarFaceBox = coarDBLBox;
-
-  refbox.surroundingNodes(a_dir);
+  Box coarFaceBox = coarBox;
   coarFaceBox.surroundingNodes(a_dir);
 
+  const int xDoLoop = (a_dir == 0) ? 0 : 1;
+  const int yDoLoop = (a_dir == 1) ? 0 : 1;
+  const int zDoLoop = (a_dir == 2) ? 0 : 1;
+
+  // Regular cells.
   for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
-    const int ivarf = a_fineInterv.begin() + ioff;
-    const int ivarc = a_coarInterv.begin() + ioff;
-    FORT_EBAVERAGEFACE(CHF_FRA1(coarRegFAB, ivarc),
-                       CHF_CONST_FRA1(fineRegFAB, ivarf),
-                       CHF_BOX(coarFaceBox),
-                       CHF_CONST_INT(m_refRat),
-                       CHF_BOX(refbox),
-                       CHF_CONST_INT(a_dir));
+    const int fineVar = a_fineInterv.begin() + ioff;
+    const int coarVar = a_coarInterv.begin() + ioff;
+
+    BaseFab<Real>&       coarDataReg = a_coarData.getSingleValuedFAB();
+    const BaseFab<Real>& fineDataReg = a_fineData.getSingleValuedFAB();
+
+    auto regularKernel = [&](const IntVect& iv) -> void {
+      coarDataReg(iv, coarVar) = 0.0;
+
+#if CH_SPACEDIM == 3
+      for (int k = 0; k <= (m_refRat - 1) * zDoLoop; k++) {
+#endif
+        for (int j = 0; j <= (m_refRat - 1) * yDoLoop; j++) {
+          for (int i = 0; i <= (m_refRat - 1) * xDoLoop; i++) {
+            const IntVect ivFine = iv * m_refRat + IntVect(D_DECL(i, j, k));
+
+            coarDataReg(iv, coarVar) += fineDataReg(ivFine, fineVar);
+          }
+        }
+#if CH_SPACEDIM == 3
+      }
+#endif
+
+      coarDataReg(iv, coarVar) *= 1.0 / finePerCoar;
+    };
+
+    BoxLoops::loop(coarFaceBox, regularKernel);
   }
 
   // Now do the irregular faces.
   const EBISBox&   ebisBoxCoar  = m_eblgCoFi.getEBISL()[a_datInd];
   const EBGraph&   ebgraphCoar  = ebisBoxCoar.getEBGraph();
-  const IntVectSet coarIrregIVS = ebisBoxCoar.getIrregIVS(coarDBLBox);
+  const IntVectSet coarIrregIVS = ebisBoxCoar.getIrregIVS(coarBox);
 
-  for (FaceIterator faceItCoar(coarIrregIVS, ebgraphCoar, a_dir, FaceStop::SurroundingWithBoundary); faceItCoar.ok();
-       ++faceItCoar) {
-    const FaceIndex& coarFace = faceItCoar();
+  FaceIterator faceIt(coarIrregIVS, ebgraphCoar, a_dir, FaceStop::SurroundingWithBoundary);
+
+  for (faceIt.reset(); faceIt.ok(); ++faceIt) {
+    const FaceIndex& coarFace = faceIt();
 
     const std::vector<FaceIndex> fineFaces = m_eblgCoFi.getEBISL().refine(coarFace, m_refRat, a_datInd).stdVector();
 
     const int numFineFaces = fineFaces.size();
 
     for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
-      const int ivarf = a_fineInterv.begin() + ioff;
-      const int ivarc = a_coarInterv.begin() + ioff;
+      const int fineVar = a_fineInterv.begin() + ioff;
+      const int coarVar = a_coarInterv.begin() + ioff;
 
-      Real dataVal = 0.0;
+      a_coarData(coarFace, coarVar) = 0.0;
+
       if (numFineFaces > 0) {
         for (const auto& fineFace : fineFaces) {
-          dataVal += a_fineData(fineFace, ivarf);
+          a_coarData(coarFace, coarVar) += a_fineData(fineFace, fineVar);
         }
 
-        dataVal /= Real(fineFaces.size());
+        a_coarData(coarFace, coarVar) *= 1.0 / numFineFaces;
+      }
+    }
+  }
+}
+
+void
+EbCoarAve::harmonicAverage(EBFaceFAB&       a_coarData,
+                           const EBFaceFAB& a_fineData,
+                           const DataIndex& a_datInd,
+                           const Interval&  a_fineInterv,
+                           const Interval&  a_coarInterv,
+                           const int&       a_dir)
+{
+  CH_TIME("EBCoarseAverage::harmonicAverage");
+
+  CH_assert(isDefined());
+  CH_assert(a_fineInterv.size() == a_coarInterv.size());
+
+  const Real dxCoar      = 1.0;
+  const Real dxFine      = dxCoar / m_refRat;
+  const int  finePerCoar = std::pow(m_refRat, SpaceDim - 1);
+
+  const Box& coarBox = m_eblgCoFi.getDBL()[a_datInd];
+
+  Box coarFaceBox = coarBox;
+  coarFaceBox.surroundingNodes(a_dir);
+
+  const int xDoLoop = (a_dir == 0) ? 0 : 1;
+  const int yDoLoop = (a_dir == 1) ? 0 : 1;
+  const int zDoLoop = (a_dir == 2) ? 0 : 1;
+
+  // Regular cells.
+  for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+    const int fineVar = a_fineInterv.begin() + ioff;
+    const int coarVar = a_coarInterv.begin() + ioff;
+
+    BaseFab<Real>&       coarDataReg = a_coarData.getSingleValuedFAB();
+    const BaseFab<Real>& fineDataReg = a_fineData.getSingleValuedFAB();
+
+    auto regularKernel = [&](const IntVect& iv) -> void {
+      coarDataReg(iv, coarVar) = 0.0;
+
+#if CH_SPACEDIM == 3
+      for (int k = 0; k <= (m_refRat - 1) * zDoLoop; k++) {
+#endif
+        for (int j = 0; j <= (m_refRat - 1) * yDoLoop; j++) {
+          for (int i = 0; i <= (m_refRat - 1) * xDoLoop; i++) {
+            const IntVect ivFine = iv * m_refRat + IntVect(D_DECL(i, j, k));
+
+            coarDataReg(iv, coarVar) += 1.0 / fineDataReg(ivFine, fineVar);
+          }
+        }
+#if CH_SPACEDIM == 3
+      }
+#endif
+
+      coarDataReg(iv, coarVar) = finePerCoar / coarDataReg(iv, coarVar);
+      ;
+    };
+
+    BoxLoops::loop(coarFaceBox, regularKernel);
+  }
+
+  // Now do the irregular faces.
+  const EBISBox&   ebisBoxCoar  = m_eblgCoFi.getEBISL()[a_datInd];
+  const EBGraph&   ebgraphCoar  = ebisBoxCoar.getEBGraph();
+  const IntVectSet coarIrregIVS = ebisBoxCoar.getIrregIVS(coarBox);
+
+  FaceIterator faceIt(coarIrregIVS, ebgraphCoar, a_dir, FaceStop::SurroundingWithBoundary);
+
+  for (faceIt.reset(); faceIt.ok(); ++faceIt) {
+    const FaceIndex& coarFace = faceIt();
+
+    const std::vector<FaceIndex> fineFaces = m_eblgCoFi.getEBISL().refine(coarFace, m_refRat, a_datInd).stdVector();
+
+    const int numFineFaces = fineFaces.size();
+
+    for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+      const int fineVar = a_fineInterv.begin() + ioff;
+      const int coarVar = a_coarInterv.begin() + ioff;
+
+      a_coarData(coarFace, coarVar) = 0.0;
+
+      if (numFineFaces > 0) {
+        for (const auto& fineFace : fineFaces) {
+          a_coarData(coarFace, coarVar) += 1.0 / a_fineData(fineFace, fineVar);
+        }
+
+        a_coarData(coarFace, coarVar) = numFineFaces / a_coarData(coarFace, coarVar);
+      }
+    }
+  }
+}
+
+void
+EbCoarAve::conservativeAverage(EBFaceFAB&       a_coarData,
+                               const EBFaceFAB& a_fineData,
+                               const DataIndex& a_datInd,
+                               const Interval&  a_fineInterv,
+                               const Interval&  a_coarInterv,
+                               const int&       a_dir)
+{
+  CH_TIME("EBCoarseAverage::conservativeAverage");
+
+  CH_assert(isDefined());
+  CH_assert(a_fineInterv.size() == a_coarInterv.size());
+
+  const Real dxCoar = 1.0;
+  const Real dxFine = dxCoar / m_refRat;
+
+  const int finePerCoar = std::pow(m_refRat, SpaceDim - 1);
+
+  const Box& coarBox = m_eblgCoFi.getDBL()[a_datInd];
+
+  Box coarFaceBox = coarBox;
+  coarFaceBox.surroundingNodes(a_dir);
+
+  const int xDoLoop = (a_dir == 0) ? 0 : 1;
+  const int yDoLoop = (a_dir == 1) ? 0 : 1;
+  const int zDoLoop = (a_dir == 2) ? 0 : 1;
+
+  // Regular cells.
+  for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+    const int fineVar = a_fineInterv.begin() + ioff;
+    const int coarVar = a_coarInterv.begin() + ioff;
+
+    BaseFab<Real>&       coarDataReg = a_coarData.getSingleValuedFAB();
+    const BaseFab<Real>& fineDataReg = a_fineData.getSingleValuedFAB();
+
+    auto regularKernel = [&](const IntVect& iv) -> void {
+      coarDataReg(iv, coarVar) = 0.0;
+
+#if CH_SPACEDIM == 3
+      for (int k = 0; k <= (m_refRat - 1) * zDoLoop; k++) {
+#endif
+        for (int j = 0; j <= (m_refRat - 1) * yDoLoop; j++) {
+          for (int i = 0; i <= (m_refRat - 1) * xDoLoop; i++) {
+            const IntVect ivFine = iv * m_refRat + IntVect(D_DECL(i, j, k));
+
+            coarDataReg(iv, coarVar) += fineDataReg(ivFine, fineVar);
+          }
+        }
+#if CH_SPACEDIM == 3
+      }
+#endif
+
+      coarDataReg(iv, coarVar) = coarDataReg(iv, coarVar) / finePerCoar;
+    };
+
+    BoxLoops::loop(coarFaceBox, regularKernel);
+  }
+
+  // Now do the irregular faces.
+  const EBISBox&   ebisBoxCoar  = m_eblgCoFi.getEBISL()[a_datInd];
+  const EBISBox&   ebisBoxFine  = m_eblgFine.getEBISL()[a_datInd];
+  const EBGraph&   ebgraphCoar  = ebisBoxCoar.getEBGraph();
+  const IntVectSet coarIrregIVS = ebisBoxCoar.getIrregIVS(coarBox);
+
+  FaceIterator faceIt(coarIrregIVS, ebgraphCoar, a_dir, FaceStop::SurroundingWithBoundary);
+
+  for (faceIt.reset(); faceIt.ok(); ++faceIt) {
+    const FaceIndex& coarFace = faceIt();
+
+    const std::vector<FaceIndex> fineFaces = m_eblgCoFi.getEBISL().refine(coarFace, m_refRat, a_datInd).stdVector();
+
+    const Real areaCoar = ebisBoxCoar.areaFrac(coarFace);
+
+    for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+      const int fineVar = a_fineInterv.begin() + ioff;
+      const int coarVar = a_coarInterv.begin() + ioff;
+
+      a_coarData(coarFace, coarVar) = 0.0;
+
+      // Set phiCoar = sum(areaFine * phiFine) / areaCoar * (dxFine/dxCoar)^D-1
+      if (areaCoar > 0.0) {
+        for (const auto& fineFace : fineFaces) {
+          a_coarData(coarFace, coarVar) += ebisBoxFine.areaFrac(fineFace) * a_fineData(fineFace, fineVar);
+        }
+
+        a_coarData(coarFace, coarVar) = a_coarData(coarFace, coarVar) * std::pow(dxFine / dxCoar, SpaceDim - 1);
+        a_coarData(coarFace, coarVar) = a_coarData(coarFace, coarVar) / areaCoar;
+      }
+      else {
+        const int numFineFaces = fineFaces.size();
+
+        if (numFineFaces > 0) {
+          for (const auto& fineFace : fineFaces) {
+            a_coarData(coarFace, coarVar) += a_fineData(fineFace, fineVar);
+          }
+
+          a_coarData(coarFace, coarVar) = a_coarData(coarFace, coarVar) / numFineFaces;
+        }
+      }
+    }
+  }
+}
+
+void
+EbCoarAve::averageData(LevelData<BaseIVFAB<Real>>&       a_coarData,
+                       const LevelData<BaseIVFAB<Real>>& a_fineData,
+                       const Interval&                   a_variables,
+                       const Average&                    a_average)
+{
+  CH_TIME("EbCoarAve::averageData(LD<BaseIVFAB>)");
+
+  CH_assert(isDefined());
+
+  LevelData<BaseIVFAB<Real>> coarFiData;
+  LevelData<BaseIVFAB<Real>> fineBuffer;
+
+  BaseIVFactory<Real> factCoFi(m_eblgCoFi.getEBISL(), m_irregSetsCoFi);
+  coarFiData.define(m_eblgCoFi.getDBL(), m_nComp, IntVect::Zero, factCoFi);
+  if (m_useFineBuffer) {
+    BaseIVFactory<Real> factFine(m_eblgFine.getEBISL(), m_irregSetsFine);
+    coarFiData.define(m_eblgFine.getDBL(), m_nComp, IntVect::Zero, factFine);
+  }
+
+  if (m_useFineBuffer) {
+    a_fineData.copyTo(a_variables, fineBuffer, a_variables);
+  }
+
+  for (DataIterator dit = m_eblgFine.getDBL().dataIterator(); dit.ok(); ++dit) {
+    const BaseIVFAB<Real>* fineFABPtr = nullptr;
+    if (m_useFineBuffer) {
+      fineFABPtr = &fineBuffer[dit()];
+    }
+    else {
+      fineFABPtr = &a_fineData[dit()];
+    }
+    BaseIVFAB<Real>&       cofiFAB = coarFiData[dit()];
+    const BaseIVFAB<Real>& fineFAB = *fineFABPtr;
+
+    // Switch between averaging methods.
+    switch (a_average) {
+    case Average::Arithmetic: {
+      this->arithmeticAverage(a_coarData[dit()], a_fineData[dit()], dit(), a_variables, a_variables);
+
+      break;
+    }
+    case Average::Harmonic: {
+      this->harmonicAverage(a_coarData[dit()], a_fineData[dit()], dit(), a_variables, a_variables);
+
+      break;
+    }
+    case Average::Conservative: {
+      this->conservativeAverage(a_coarData[dit()], a_fineData[dit()], dit(), a_variables, a_variables);
+
+      break;
+    }
+    default: {
+      MayDay::Error("EbCoarAve::averageData(LD<BaseIVFAB>) - logic bust");
+
+      break;
+    }
+    }
+  }
+
+  coarFiData.copyTo(a_variables, a_coarData, a_variables);
+}
+
+void
+EbCoarAve::arithmeticAverage(BaseIVFAB<Real>&       a_coarData,
+                             const BaseIVFAB<Real>& a_fineData,
+                             const DataIndex&       a_datInd,
+                             const Interval&        a_coarInterv,
+                             const Interval&        a_fineInterv) const
+{
+  CH_assert(isDefined());
+
+  const EBISBox& ebisBoxCoar = m_eblgCoFi.getEBISL()[a_datInd];
+  const EBISBox& ebisBoxFine = m_eblgFine.getEBISL()[a_datInd];
+
+  const IntVectSet& coarIrregIVS = a_coarData.getIVS();
+  const IntVectSet& fineIrregIVS = a_fineData.getIVS();
+
+  for (VoFIterator vofitCoar(coarIrregIVS, ebisBoxCoar.getEBGraph()); vofitCoar.ok(); ++vofitCoar) {
+    const VolIndex&        coarVoF  = vofitCoar();
+    const Vector<VolIndex> fineVoFs = m_eblgCoFi.getEBISL().refine(coarVoF, m_refRat, a_datInd);
+
+    const int numFineVoFs = fineVoFs.size();
+
+    for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+      const int fineVar = a_fineInterv.begin() + ioff;
+      const int coarVar = a_coarInterv.begin() + ioff;
+
+      a_coarData(coarVoF, coarVar) = 0.0;
+
+      int numVoFs = 0;
+
+      for (int ifine = 0; ifine < fineVoFs.size(); ifine++) {
+        const VolIndex& fineVoF = fineVoFs[ifine];
+
+        if (fineIrregIVS.contains(fineVoF.gridIndex())) {
+          numVoFs += 1;
+          a_coarData(coarVoF, coarVar) += a_fineData(fineVoF, fineVar);
+        }
       }
 
-      a_coarData(coarFace, ivarc) = dataVal;
+      if (numVoFs > 0) {
+        a_coarData(coarVoF, coarVar) = a_coarData(coarVoF, coarVar) / numVoFs;
+      }
+    }
+  }
+}
+
+void
+EbCoarAve::harmonicAverage(BaseIVFAB<Real>&       a_coarData,
+                           const BaseIVFAB<Real>& a_fineData,
+                           const DataIndex&       a_datInd,
+                           const Interval&        a_coarInterv,
+                           const Interval&        a_fineInterv) const
+{
+  CH_assert(isDefined());
+
+  const EBISBox& ebisBoxCoar = m_eblgCoFi.getEBISL()[a_datInd];
+  const EBISBox& ebisBoxFine = m_eblgFine.getEBISL()[a_datInd];
+
+  const IntVectSet& coarIrregIVS = a_coarData.getIVS();
+  const IntVectSet& fineIrregIVS = a_fineData.getIVS();
+
+  for (VoFIterator vofitCoar(coarIrregIVS, ebisBoxCoar.getEBGraph()); vofitCoar.ok(); ++vofitCoar) {
+    const VolIndex&        coarVoF  = vofitCoar();
+    const Vector<VolIndex> fineVoFs = m_eblgCoFi.getEBISL().refine(coarVoF, m_refRat, a_datInd);
+
+    for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+      const int fineVar = a_fineInterv.begin() + ioff;
+      const int coarVar = a_coarInterv.begin() + ioff;
+
+      a_coarData(coarVoF, coarVar) = 0.0;
+
+      int numVoFs = 0;
+
+      for (int ifine = 0; ifine < fineVoFs.size(); ifine++) {
+        const VolIndex& fineVoF = fineVoFs[ifine];
+
+        if (fineIrregIVS.contains(fineVoF.gridIndex())) {
+          numVoFs += 1;
+
+          a_coarData(coarVoF, coarVar) += 1.0 / a_fineData(fineVoF, fineVar);
+        }
+      }
+
+      if (numVoFs > 0) {
+        a_coarData(coarVoF, coarVar) = numVoFs / a_coarData(coarVoF, coarVar);
+      }
+    }
+  }
+}
+
+void
+EbCoarAve::conservativeAverage(BaseIVFAB<Real>&       a_coarData,
+                               const BaseIVFAB<Real>& a_fineData,
+                               const DataIndex&       a_datInd,
+                               const Interval&        a_coarInterv,
+                               const Interval&        a_fineInterv) const
+{
+  CH_assert(isDefined());
+
+  const EBISBox& ebisBoxCoar = m_eblgCoFi.getEBISL()[a_datInd];
+  const EBISBox& ebisBoxFine = m_eblgFine.getEBISL()[a_datInd];
+
+  const IntVectSet& coarIrregIVS = a_coarData.getIVS();
+  const IntVectSet& fineIrregIVS = a_fineData.getIVS();
+
+  const Real dxCoar = 1.0;
+  const Real dxFine = dxCoar / m_refRat;
+
+  // This loop computes phiCoar = sum(phiFine*areaFine)/areaCoar. If areaCoar == 0
+  // then we default to an arithmetic average.
+  for (VoFIterator vofitCoar(coarIrregIVS, ebisBoxCoar.getEBGraph()); vofitCoar.ok(); ++vofitCoar) {
+    const VolIndex&        coarVoF  = vofitCoar();
+    const Vector<VolIndex> fineVoFs = m_eblgCoFi.getEBISL().refine(coarVoF, m_refRat, a_datInd);
+
+    const Real areaCoar = ebisBoxCoar.bndryArea(coarVoF);
+
+    for (int ioff = 0; ioff < a_fineInterv.size(); ioff++) {
+      const int fineVar = a_fineInterv.begin() + ioff;
+      const int coarVar = a_coarInterv.begin() + ioff;
+
+      a_coarData(coarVoF, coarVar) = 0.0;
+
+      if (areaCoar > 0.0) {
+        for (int ifine = 0; ifine < fineVoFs.size(); ifine++) {
+          const VolIndex& fineVoF = fineVoFs[ifine];
+
+          a_coarData(coarVoF, coarVar) += ebisBoxFine.bndryArea(fineVoF) * a_fineData(fineVoF, fineVar);
+        }
+
+        a_coarData(coarVoF, coarVar) = a_coarData(coarVoF, coarVar) * std::pow(dxFine / dxCoar, SpaceDim - 1);
+        a_coarData(coarVoF, coarVar) = a_coarData(coarVoF, coarVar) / areaCoar;
+      }
+      else {
+        // Do arithmetic average if there is no coarse boundary area.
+        int numVoFs = 0;
+
+        for (int ifine = 0; ifine < fineVoFs.size(); ifine++) {
+          const VolIndex& fineVoF = fineVoFs[ifine];
+
+          if (fineIrregIVS.contains(fineVoF.gridIndex())) {
+            numVoFs += 1;
+
+            a_coarData(coarVoF, coarVar) += a_fineData(fineVoF, fineVar);
+          }
+        }
+
+        if (numVoFs > 0) {
+          a_coarData(coarVoF, coarVar) = a_coarData(coarVoF, coarVar) / numVoFs;
+        }
+      }
     }
   }
 }

--- a/Source/AmrMesh/CD_PhaseRealm.H
+++ b/Source/AmrMesh/CD_PhaseRealm.H
@@ -468,6 +468,12 @@ protected:
   Vector<RefCountedPtr<EBLevelGrid>> m_eblg;
 
   /*!
+    @brief Coarsened fine-level EB grids. 
+    @details m_eblgCoFi[1] holds the coarsening of m_eblg[1].
+  */
+  Vector<RefCountedPtr<EBLevelGrid>> m_eblgCoFi;
+
+  /*!
     @brief Weird but true thing that indexces neighboring boxes
   */
   Vector<RefCountedPtr<LayoutData<Vector<LayoutIndex>>>> m_neighbors;

--- a/Source/AmrMesh/CD_PhaseRealm.H
+++ b/Source/AmrMesh/CD_PhaseRealm.H
@@ -15,7 +15,7 @@
 // Chombo includes
 #include <DisjointBoxLayout.H>
 #include <AggEBPWLFillPatch.H>
-#include <CD_EbCoarAve.H>
+#include <CD_EBCoarAve.H>
 #include <EBFluxRegister.H>
 #include <EBFluxRegister.H>
 #include <EBLevelRedist.H>
@@ -32,7 +32,7 @@
 #include <CD_IrregAmrStencil.H>
 #include <CD_LoadBalancing.H>
 #include <CD_MFLevelGrid.H>
-#include <CD_EbCoarAve.H>
+#include <CD_EBCoarAve.H>
 #include <CD_DomainFluxIFFAB.H>
 #include <CD_DomainFluxIFFABFactory.H>
 #include <CD_ParticleContainer.H>
@@ -283,7 +283,7 @@ public:
   /*!
     @brief Get coarsening operators
   */
-  Vector<RefCountedPtr<EbCoarAve>>&
+  Vector<RefCountedPtr<EBCoarAve>>&
   getCoarseAverage() const;
 
   /*!
@@ -491,7 +491,7 @@ protected:
   /*!
     @brief Coarsening operator
   */
-  mutable Vector<RefCountedPtr<EbCoarAve>> m_coarAve;
+  mutable Vector<RefCountedPtr<EBCoarAve>> m_coarAve;
 
   /*!
     @brief Multigrid interpolation utility
@@ -584,7 +584,7 @@ protected:
     @param[in] a_lmin Coarsest grid level that changes
   */
   void
-  defineEbCoarAve(const int a_lmin);
+  defineEBCoarAve(const int a_lmin);
 
   /*!
     @brief Define multigrid interpolation utility

--- a/Source/AmrMesh/CD_PhaseRealm.cpp
+++ b/Source/AmrMesh/CD_PhaseRealm.cpp
@@ -153,9 +153,9 @@ PhaseRealm::regridOperators(const int a_lmin)
 
     Timer timer("PhaseRealm::regridOperators(int)");
 
-    timer.startEvent("EbCoarAve");
-    this->defineEbCoarAve(a_lmin);
-    timer.stopEvent("EbCoarAve");
+    timer.startEvent("EBCoarAve");
+    this->defineEBCoarAve(a_lmin);
+    timer.stopEvent("EBCoarAve");
 
     timer.startEvent("Ghost interp");
     this->defineFillPatch(a_lmin);
@@ -409,11 +409,11 @@ PhaseRealm::defineLevelSet(const int a_lmin, const int a_numGhost)
 }
 
 void
-PhaseRealm::defineEbCoarAve(const int a_lmin)
+PhaseRealm::defineEBCoarAve(const int a_lmin)
 {
-  CH_TIME("PhaseRealm::defineEbCoarAve");
+  CH_TIME("PhaseRealm::defineEBCoarAve");
   if (m_verbose) {
-    pout() << "PhaseRealm::defineEbCoarAve" << endl;
+    pout() << "PhaseRealm::defineEBCoarAve" << endl;
   }
 
   const bool doThisOperator = this->queryOperator(s_eb_coar_ave);
@@ -426,8 +426,8 @@ PhaseRealm::defineEbCoarAve(const int a_lmin)
       const bool hasCoar = lvl > 0;
 
       if (hasCoar) {
-        m_coarAve[lvl] = RefCountedPtr<EbCoarAve>(
-          new EbCoarAve(*m_eblg[lvl], *m_eblg[lvl - 1], *m_eblgCoFi[lvl], m_refinementRatios[lvl - 1]));
+        m_coarAve[lvl] = RefCountedPtr<EBCoarAve>(
+          new EBCoarAve(*m_eblg[lvl], *m_eblg[lvl - 1], *m_eblgCoFi[lvl], m_refinementRatios[lvl - 1]));
       }
     }
   }
@@ -952,7 +952,7 @@ PhaseRealm::getNonConservativeDivergenceStencils() const
   return *m_NonConservativeDivergenceStencil;
 }
 
-Vector<RefCountedPtr<EbCoarAve>>&
+Vector<RefCountedPtr<EBCoarAve>>&
 PhaseRealm::getCoarseAverage() const
 {
   if (!this->queryOperator(s_eb_coar_ave)) {

--- a/Source/AmrMesh/CD_Realm.H
+++ b/Source/AmrMesh/CD_Realm.H
@@ -278,7 +278,7 @@ public:
     @brief Get data coarsening utility
     @param[in] a_phase Phase
   */
-  Vector<RefCountedPtr<EbCoarAve>>&
+  Vector<RefCountedPtr<EBCoarAve>>&
   getCoarseAverage(const phase::which_phase a_phase);
 
   /*!

--- a/Source/AmrMesh/CD_Realm.cpp
+++ b/Source/AmrMesh/CD_Realm.cpp
@@ -554,7 +554,7 @@ Realm::getNonConservativeDivergenceStencils(const phase::which_phase a_phase) co
   return m_realms[a_phase]->getNonConservativeDivergenceStencils();
 }
 
-Vector<RefCountedPtr<EbCoarAve>>&
+Vector<RefCountedPtr<EBCoarAve>>&
 Realm::getCoarseAverage(const phase::which_phase a_phase)
 {
   return m_realms[a_phase]->getCoarseAverage();

--- a/Source/ConvectionDiffusionReaction/CD_CdrCTU.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrCTU.cpp
@@ -194,7 +194,7 @@ CdrCTU::advectToFaces(EBAMRFluxData& a_facePhi, const EBAMRCellData& a_cellPhi, 
   m_amr->allocate(phi, m_realm, m_phase, m_nComp);
   DataOps::copy(phi, a_cellPhi);
 
-  m_amr->averageDown(phi, m_realm, m_phase);
+  m_amr->conservativeAverage(phi, m_realm, m_phase);
   m_amr->interpGhostPwl(phi, m_realm, m_phase);
 
   for (int lvl = 0; lvl <= m_amr->getFinestLevel(); lvl++) {

--- a/Source/ConvectionDiffusionReaction/CD_CdrGodunov.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrGodunov.cpp
@@ -238,7 +238,7 @@ CdrGodunov::advectToFaces(EBAMRFluxData& a_facePhi, const EBAMRCellData& a_cellP
     DataOps::incr(m_scratch, m_source, 1.0);
   }
 
-  m_amr->averageDown(m_scratch, m_realm, m_phase);
+  m_amr->conservativeAverage(m_scratch, m_realm, m_phase);
   m_amr->interpGhost(m_scratch, m_realm, m_phase);
 
   // This code extrapolates the cell-centered state to face centers on every grid level, in both space and time.

--- a/Source/ConvectionDiffusionReaction/CD_CdrMultigrid.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrMultigrid.cpp
@@ -355,22 +355,22 @@ CdrMultigrid::setupMultigrid()
   switch (m_bottomSolverType) {
   case BottomSolverType::Simple: {
     botsolver = &m_simpleSolver;
-    
+
     break;
   }
   case BottomSolverType::BiCGStab: {
     botsolver = &m_bicgstab;
-    
+
     break;
   }
   case BottomSolverType::GMRES: {
-    botsolver           = &m_gmres;
-    
+    botsolver = &m_gmres;
+
     m_gmres.m_verbosity = 0; // Shut up.
   }
   default: {
     MayDay::Error("CdrMultigrid::setupMultigrid() - logic bust in bottom solver setup");
-    
+
     break;
   }
   }
@@ -380,12 +380,12 @@ CdrMultigrid::setupMultigrid()
   switch (m_multigridType) {
   case MultigridType::VCycle: {
     gmgType = 1;
-    
+
     break;
   }
   case MultigridType::WCycle: {
     gmgType = 2;
-    
+
     break;
   }
   default: {

--- a/Source/ConvectionDiffusionReaction/CD_CdrMultigrid.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrMultigrid.cpp
@@ -564,7 +564,7 @@ CdrMultigrid::computeDivD(EBAMRCellData& a_divD,
                       *ebflux,
                       a_conservativeOnly); // General face-centered flux to divergence magic.
 
-    m_amr->averageDown(a_divD, m_realm, m_phase);
+    m_amr->conservativeAverage(a_divD, m_realm, m_phase);
     m_amr->interpGhost(a_divD, m_realm, m_phase);
   }
   else {

--- a/Source/ConvectionDiffusionReaction/CD_CdrMultigrid.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrMultigrid.cpp
@@ -353,31 +353,46 @@ CdrMultigrid::setupMultigrid()
   // Select the bottom solver
   LinearSolver<LevelData<EBCellFAB>>* botsolver = NULL;
   switch (m_bottomSolverType) {
-  case BottomSolverType::Simple:
+  case BottomSolverType::Simple: {
     botsolver = &m_simpleSolver;
+    
     break;
-  case BottomSolverType::BiCGStab:
+  }
+  case BottomSolverType::BiCGStab: {
     botsolver = &m_bicgstab;
+    
     break;
-  case BottomSolverType::GMRES:
+  }
+  case BottomSolverType::GMRES: {
     botsolver           = &m_gmres;
+    
     m_gmres.m_verbosity = 0; // Shut up.
-  default:
+  }
+  default: {
     MayDay::Error("CdrMultigrid::setupMultigrid() - logic bust in bottom solver setup");
+    
     break;
+  }
   }
 
   // Make m_multigridType into an int for multigrid
   int gmgType;
   switch (m_multigridType) {
-  case MultigridType::VCycle:
+  case MultigridType::VCycle: {
     gmgType = 1;
+    
     break;
-  case MultigridType::WCycle:
+  }
+  case MultigridType::WCycle: {
     gmgType = 2;
+    
     break;
-  default:
+  }
+  default: {
     MayDay::Error("CdrMultigrid::setupMultigrid() -- logic bust in multigrid type selection");
+
+    break;
+  }
   }
 
   const int           finestLevel    = m_amr->getFinestLevel();

--- a/Source/ConvectionDiffusionReaction/CD_CdrMultigrid.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrMultigrid.cpp
@@ -286,7 +286,7 @@ CdrMultigrid::setupHelmholtzFactory()
   }
 
   const Vector<RefCountedPtr<EBLevelGrid>>&             levelGrids = m_amr->getEBLevelGrid(m_realm, m_phase);
-  const Vector<RefCountedPtr<EbCoarAve>>&               coarAve    = m_amr->getCoarseAverage(m_realm, m_phase);
+  const Vector<RefCountedPtr<EBCoarAve>>&               coarAve    = m_amr->getCoarseAverage(m_realm, m_phase);
   const Vector<RefCountedPtr<EBFluxRegister>>&          fluxReg    = m_amr->getFluxRegister(m_realm, m_phase);
   const Vector<RefCountedPtr<EBMultigridInterpolator>>& interpolator =
     m_amr->getMultigridInterpolator(m_realm, m_phase);

--- a/Source/ConvectionDiffusionReaction/CD_CdrMultigrid.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrMultigrid.cpp
@@ -523,12 +523,15 @@ CdrMultigrid::computeDivF(EBAMRCellData& a_divF,
     if (m_whichRedistribution == Redistribution::MassWeighted) {
       this->setRedistWeights(a_phi);
     }
-    this->averageVelocityToFaces();                       // Cell-centered velocities become face-centered velocities.
-    this->advectToFaces(m_faceStates, a_phi, a_extrapDt); // Face extrapolation to cell-centered faces
-    this->computeAdvectionFlux(m_scratchFluxOne,
-                               m_faceVelocity,
-                               m_faceStates,
-                               a_domainFlux); // Compute face-centered fluxes
+
+    // Cell-centered velocities become face-centered velocities.
+    this->averageVelocityToFaces();
+
+    // Face extrapolation to cell-centered faces
+    this->advectToFaces(m_faceStates, a_phi, a_extrapDt);
+
+    // Compute face-centered fluxes
+    this->computeAdvectionFlux(m_scratchFluxOne, m_faceVelocity, m_faceStates, a_domainFlux);
 
     EBAMRIVData* ebflux;
     if (a_ebFlux) {
@@ -537,6 +540,8 @@ CdrMultigrid::computeDivF(EBAMRCellData& a_divF,
     else {
       ebflux = &m_ebZero;
     }
+
+    // Compute div(F) -- this includes interpolation to centroids and redistribution.
     this->computeDivG(a_divF, m_scratchFluxOne, *ebflux, a_conservativeOnly);
   }
   else {

--- a/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
@@ -491,7 +491,7 @@ CdrSolver::computeDivG(EBAMRCellData&     a_divG,
 
   // Interpolate fluxes to centroids and then coarsen them so we have consistent fluxes.
   this->interpolateFluxToFaceCentroids(a_G);
-  m_amr->averageDown(a_G, m_realm, m_phase);
+  m_amr->conservativeAverage(a_G, m_realm, m_phase);
 
   this->conservativeDivergenceNoKappaDivision(a_divG,
                                               a_G,
@@ -992,7 +992,7 @@ CdrSolver::conservativeDivergenceNoKappaDivision(EBAMRCellData&     a_conservati
     a_conservativeDivergence[lvl]->exchange();
   }
 
-  m_amr->averageDown(a_conservativeDivergence, m_realm, m_phase);
+  m_amr->conservativeAverage(a_conservativeDivergence, m_realm, m_phase);
   m_amr->interpGhost(a_conservativeDivergence, m_realm, m_phase);
 }
 
@@ -1213,7 +1213,7 @@ CdrSolver::initialData()
   // why is why initialDataParticles is called first!
   this->initialDataDistribution();
 
-  m_amr->averageDown(m_phi, m_realm, m_phase);
+  m_amr->conservativeAverage(m_phi, m_realm, m_phase);
   m_amr->interpGhost(m_phi, m_realm, m_phase);
 }
 
@@ -1235,7 +1235,7 @@ CdrSolver::initialDataDistribution()
   DataOps::incr(m_phi, m_scratch, 1.0);
   DataOps::setCoveredValue(m_phi, 0, 0.0);
 
-  m_amr->averageDown(m_phi, m_realm, m_phase);
+  m_amr->conservativeAverage(m_phi, m_realm, m_phase);
   m_amr->interpGhost(m_phi, m_realm, m_phase);
 }
 
@@ -1642,10 +1642,10 @@ CdrSolver::regrid(const int a_lmin, const int a_oldFinestLevel, const int a_newF
   m_amr->interpToNewGrids(m_source, m_cacheSource, m_phase, a_lmin, a_oldFinestLevel, a_newFinestLevel, m_regridSlopes);
 
   // Coarsen data and update ghost cells.
-  m_amr->averageDown(m_phi, m_realm, m_phase);
+  m_amr->conservativeAverage(m_phi, m_realm, m_phase);
   m_amr->interpGhost(m_phi, m_realm, m_phase);
 
-  m_amr->averageDown(m_source, m_realm, m_phase);
+  m_amr->conservativeAverage(m_source, m_realm, m_phase);
   m_amr->interpGhost(m_source, m_realm, m_phase);
 
   // Deallocate the scratch storage.
@@ -1746,8 +1746,8 @@ CdrSolver::setDiffusionCoefficient(const EBAMRFluxData& a_diffusionCoefficient,
   m_faceCenteredDiffusionCoefficient.copy(a_diffusionCoefficient);
   m_ebCenteredDiffusionCoefficient.copy(a_ebDiffusionCoefficient);
 
-  m_amr->averageDown(m_faceCenteredDiffusionCoefficient, m_realm, m_phase);
-  m_amr->averageDown(m_ebCenteredDiffusionCoefficient, m_realm, m_phase);
+  m_amr->conservativeAverage(m_faceCenteredDiffusionCoefficient, m_realm, m_phase);
+  m_amr->conservativeAverage(m_ebCenteredDiffusionCoefficient, m_realm, m_phase);
 }
 
 void
@@ -1761,8 +1761,8 @@ CdrSolver::setDiffusionCoefficient(const Real a_diffusionCoefficient)
   DataOps::setValue(m_faceCenteredDiffusionCoefficient, a_diffusionCoefficient);
   DataOps::setValue(m_ebCenteredDiffusionCoefficient, a_diffusionCoefficient);
 
-  m_amr->averageDown(m_faceCenteredDiffusionCoefficient, m_realm, m_phase);
-  m_amr->averageDown(m_ebCenteredDiffusionCoefficient, m_realm, m_phase);
+  m_amr->conservativeAverage(m_faceCenteredDiffusionCoefficient, m_realm, m_phase);
+  m_amr->conservativeAverage(m_ebCenteredDiffusionCoefficient, m_realm, m_phase);
 }
 
 void
@@ -1842,7 +1842,7 @@ CdrSolver::setSource(const EBAMRCellData& a_source)
 
   m_source.copy(a_source);
 
-  m_amr->averageDown(m_source, m_realm, m_phase);
+  m_amr->conservativeAverage(m_source, m_realm, m_phase);
   m_amr->interpGhost(m_source, m_realm, m_phase);
 }
 
@@ -1856,7 +1856,7 @@ CdrSolver::setSource(const Real a_source)
 
   DataOps::setValue(m_source, a_source);
 
-  m_amr->averageDown(m_source, m_realm, m_phase);
+  m_amr->conservativeAverage(m_source, m_realm, m_phase);
   m_amr->interpGhost(m_source, m_realm, m_phase);
 }
 
@@ -1870,7 +1870,7 @@ CdrSolver::setSource(const std::function<Real(const RealVect a_position)> a_sour
 
   DataOps::setValue(m_source, a_source, m_amr->getProbLo(), m_amr->getDx(), m_comp);
 
-  m_amr->averageDown(m_source, m_realm, m_phase);
+  m_amr->conservativeAverage(m_source, m_realm, m_phase);
   m_amr->interpGhost(m_source, m_realm, m_phase);
 }
 
@@ -1899,7 +1899,7 @@ CdrSolver::setVelocity(const EBAMRCellData& a_velo)
 
   m_cellVelocity.copy(a_velo);
 
-  m_amr->averageDown(m_cellVelocity, m_realm, m_phase);
+  m_amr->conservativeAverage(m_cellVelocity, m_realm, m_phase);
   m_amr->interpGhost(m_cellVelocity, m_realm, m_phase);
 }
 
@@ -1917,7 +1917,7 @@ CdrSolver::setVelocity(const RealVect a_velo)
     }
   }
 
-  m_amr->averageDown(m_cellVelocity, m_realm, m_phase);
+  m_amr->conservativeAverage(m_cellVelocity, m_realm, m_phase);
   m_amr->interpGhost(m_cellVelocity, m_realm, m_phase);
 }
 
@@ -2075,7 +2075,7 @@ CdrSolver::writeData(EBAMRCellData& a_output, int& a_comp, const EBAMRCellData& 
     m_amr->interpToCentroids(scratch, m_realm, phase::gas);
   }
 
-  m_amr->averageDown(scratch, m_realm, m_phase);
+  m_amr->conservativeAverage(scratch, m_realm, m_phase);
   m_amr->interpGhost(scratch, m_realm, m_phase);
 
   // Need a more general copy method because we can't call DataOps::copy (because realms might not be the same) and
@@ -2455,10 +2455,10 @@ CdrSolver::weightedUpwind(EBAMRCellData& a_weightedUpwindPhi, const int a_pow)
   }
 
   if (m_isMobile) {
-    m_amr->averageDown(m_cellVelocity, m_realm, m_phase);
+    m_amr->conservativeAverage(m_cellVelocity, m_realm, m_phase);
     m_amr->interpGhost(m_cellVelocity, m_realm, m_phase);
 
-    m_amr->averageDown(m_phi, m_realm, m_phase);
+    m_amr->conservativeAverage(m_phi, m_realm, m_phase);
     m_amr->interpGhost(m_phi, m_realm, m_phase);
 
     // Compute velocity on faces and EBs. The data is currently face-centered.
@@ -2598,7 +2598,7 @@ CdrSolver::weightedUpwind(EBAMRCellData& a_weightedUpwindPhi, const int a_pow)
     DataOps::setValue(zero, 0.0);
     DataOps::divideFallback(a_weightedUpwindPhi, m_scratch, zero);
 
-    m_amr->averageDown(a_weightedUpwindPhi, m_realm, m_phase);
+    m_amr->conservativeAverage(a_weightedUpwindPhi, m_realm, m_phase);
     m_amr->interpGhost(a_weightedUpwindPhi, m_realm, m_phase);
   }
   else {
@@ -2627,7 +2627,7 @@ CdrSolver::computeMass(EBAMRCellData& a_phi)
 
   // TLDR: We have conservative coarsening so we just coarsen the solution and compute the mass on the coarsest level only.
 
-  m_amr->averageDown(a_phi, m_realm, m_phase);
+  m_amr->conservativeAverage(a_phi, m_realm, m_phase);
 
   const Real dx = m_amr->getDx()[0];
 
@@ -2981,7 +2981,7 @@ CdrSolver::gwnDiffusionSource(EBAMRCellData& a_noiseSource, const EBAMRCellData&
                       false); // Compute the finite volume approximation and make it into a source term.
 
 #if 0 // Debug, check if we have NaNs/Infs
-    m_amr->averageDown(a_noiseSource, m_realm, m_phase);
+    m_amr->conservativeAverage(a_noiseSource, m_realm, m_phase);
     for (int lvl = 0; lvl <= m_amr->getFinestLevel(); lvl++){
       if(EBLevelDataOps::checkNANINF(*a_noiseSource[lvl])){
 	MayDay::Abort("CdrSolver::gwnDiffusionSource - something is wrong");

--- a/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
@@ -356,7 +356,7 @@ CdrSolver::averageVelocityToFaces(EBAMRFluxData& a_faceVelocity, const EBAMRCell
 #endif
 
   for (int lvl = 0; lvl <= m_amr->getFinestLevel(); lvl++) {
-    DataOps::averageCellVectorToFaceScalar(*a_faceVelocity[lvl], *a_cellVelocity[lvl], m_amr->getDomains()[lvl]);
+    DataOps::averageCellVelocityToFaceVelocity(*a_faceVelocity[lvl], *a_cellVelocity[lvl], m_amr->getDomains()[lvl]);
   }
 }
 

--- a/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
@@ -945,7 +945,9 @@ CdrSolver::fillDomainFlux(LevelData<EBFluxFAB>& a_flux, const int a_level)
 
             break;
           }
-          case CdrDomainBC::BcType::Solver: { // Don't do anything beacuse the solver will have filled the flux already.
+          case CdrDomainBC::BcType::Solver: {
+	    // Don't do anything beacuse the solver will have filled the flux already.
+	    
             break;
           }
           default: {

--- a/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
@@ -946,8 +946,8 @@ CdrSolver::fillDomainFlux(LevelData<EBFluxFAB>& a_flux, const int a_level)
             break;
           }
           case CdrDomainBC::BcType::Solver: {
-	    // Don't do anything beacuse the solver will have filled the flux already.
-	    
+            // Don't do anything beacuse the solver will have filled the flux already.
+
             break;
           }
           default: {

--- a/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
@@ -747,16 +747,15 @@ CdrSolver::computeAdvectionDiffusionFlux(EBAMRFluxData&       a_flux,
 
         const Box grownBox = grow(cellBox, 1) & domain;
 
-        // When setting the diffusion flux we only do the interior faces (no diffusion flux across boundary faces). But
+        // When adding the diffusion flux we only do the interior faces (no diffusion flux across boundary faces). But
         // note that we need to fill fluxes also in the "ghost faces" because when computing the divergence we will
         // interpolate fluxes to centroids.
-        Box interiorCells = cellBox;
-        interiorCells.grow(1);
-        interiorCells &= domain;
-        interiorCells.grow(dir, -1);
+        Box interiorFaces = cellBox;
+        interiorFaces.grow(1);
+        interiorFaces &= domain;
+        interiorFaces.grow(dir, -1);
+        interiorFaces.surroundingNodes(dir);
 
-        // These are the "regions" for the regular and cut-cell kernels.
-        const Box    interiorFaces = surroundingNodes(grownBox, dir);
         FaceIterator faceit(ebisbox.getIrregIVS(grownBox), ebgraph, dir, FaceStop::SurroundingNoBoundary);
 
         // Regular kernel. Note that we call the kernel on a face-centered box, so the cell on the high side is located at

--- a/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
+++ b/Source/ConvectionDiffusionReaction/CD_CdrSolver.cpp
@@ -356,7 +356,12 @@ CdrSolver::averageVelocityToFaces(EBAMRFluxData& a_faceVelocity, const EBAMRCell
 #endif
 
   for (int lvl = 0; lvl <= m_amr->getFinestLevel(); lvl++) {
-    DataOps::averageCellVelocityToFaceVelocity(*a_faceVelocity[lvl], *a_cellVelocity[lvl], m_amr->getDomains()[lvl]);
+    const int tanGhosts = 1;
+
+    DataOps::averageCellVelocityToFaceVelocity(*a_faceVelocity[lvl],
+                                               *a_cellVelocity[lvl],
+                                               m_amr->getDomains()[lvl],
+                                               tanGhosts);
   }
 }
 

--- a/Source/Electrostatics/CD_FieldSolver.H
+++ b/Source/Electrostatics/CD_FieldSolver.H
@@ -238,7 +238,7 @@ public:
     @brief Set the permittivities
     @details This sets m_permittivityCell, m_permittivityFace, and m_permittivityEB.
   */
-  void
+  virtual void
   setPermittivities();
 
   /*!

--- a/Source/Electrostatics/CD_FieldSolver.cpp
+++ b/Source/Electrostatics/CD_FieldSolver.cpp
@@ -1028,16 +1028,20 @@ FieldSolver::writeCheckpointLevel(HDF5Handle& a_handle, const int a_level) const
   LevelData<EBCellFAB> potentialGas;
   LevelData<EBCellFAB> potentialSol;
 
-  if (!ebisGas.isNull())
+  if (!ebisGas.isNull()) {
     MultifluidAlias::aliasMF(potentialGas, phase::gas, *m_potential[a_level]);
-  if (!ebisSol.isNull())
+  }
+  if (!ebisSol.isNull()) {
     MultifluidAlias::aliasMF(potentialSol, phase::solid, *m_potential[a_level]);
+  }
 
   // Write data
-  if (!ebisGas.isNull())
+  if (!ebisGas.isNull()) {
     write(a_handle, potentialGas, "FieldSolver::m_potential(gas)");
-  if (!ebisSol.isNull())
+  }
+  if (!ebisSol.isNull()) {
     write(a_handle, potentialSol, "FieldSolver::m_potential(solid)");
+  }
 }
 #endif
 
@@ -1057,26 +1061,30 @@ FieldSolver::readCheckpointLevel(HDF5Handle& a_handle, const int a_level)
   LevelData<EBCellFAB> potentialGas;
   LevelData<EBCellFAB> potentialSol;
 
-  if (!ebisGas.isNull())
+  if (!ebisGas.isNull()) {
     MultifluidAlias::aliasMF(potentialGas, phase::gas, *m_potential[a_level]);
-  if (!ebisSol.isNull())
+  }
+  if (!ebisSol.isNull()) {
     MultifluidAlias::aliasMF(potentialSol, phase::solid, *m_potential[a_level]);
+  }
 
   // Read data
-  if (!ebisGas.isNull())
+  if (!ebisGas.isNull()) {
     read<EBCellFAB>(a_handle,
                     potentialGas,
                     "FieldSolver::m_potential(gas)",
                     m_amr->getGrids(m_realm)[a_level],
                     Interval(0, 0),
                     false);
-  if (!ebisSol.isNull())
+  }
+  if (!ebisSol.isNull()) {
     read<EBCellFAB>(a_handle,
                     potentialSol,
                     "FieldSolver::m_potential(solid)",
                     m_amr->getGrids(m_realm)[a_level],
                     Interval(0, 0),
                     false);
+  }
 }
 #endif
 

--- a/Source/Electrostatics/CD_FieldSolver.cpp
+++ b/Source/Electrostatics/CD_FieldSolver.cpp
@@ -287,7 +287,7 @@ FieldSolver::computeEnergy(const MFAMRCellData& a_electricField)
   // Compute D = eps*E and then the dot product E*D.
   this->computeDisplacementField(D, a_electricField);
   DataOps::dotProduct(EdotD, D, a_electricField);
-  m_amr->averageDown(EdotD, m_realm);
+  m_amr->conservativeAverage(EdotD, m_realm);
 
   // This defines a lambda which computes the energy in a specified phase
   auto phaseEnergy = [&EdotD, &amr = this->m_amr](const phase::which_phase a_phase) -> Real {
@@ -389,7 +389,7 @@ FieldSolver::regrid(const int a_lmin, const int a_oldFinestLevel, const int a_ne
   m_amr->interpToNewGrids(m_potential, m_cache, a_lmin, a_oldFinestLevel, a_newFinestLevel, m_regridSlopes);
 
   // Synchronize over levels.
-  m_amr->averageDown(m_potential, m_realm);
+  m_amr->conservativeAverage(m_potential, m_realm);
   m_amr->interpGhost(m_potential, m_realm);
 
   // Recompute E from the new potential.
@@ -1174,11 +1174,11 @@ FieldSolver::writeMultifluidData(EBAMRCellData&           a_output,
 
   // Coarsen data.
   if (reallyMultiPhase) {
-    m_amr->averageDown(scratchGas, m_realm, phase::gas);
-    m_amr->averageDown(scratchSolid, m_realm, phase::solid);
+    m_amr->conservativeAverage(scratchGas, m_realm, phase::gas);
+    m_amr->conservativeAverage(scratchSolid, m_realm, phase::solid);
   }
   else {
-    m_amr->averageDown(scratchGas, m_realm, phase::gas);
+    m_amr->conservativeAverage(scratchGas, m_realm, phase::gas);
   }
 
   // Interpolate ghost cells.

--- a/Source/Electrostatics/CD_FieldSolverMultigrid.H
+++ b/Source/Electrostatics/CD_FieldSolverMultigrid.H
@@ -382,6 +382,14 @@ protected:
   parseJumpBC();
 
   /*!
+    @brief Set the permittivities
+    @details This sets m_permittivityCell, m_permittivityFace, and m_permittivityEB and fills
+    necessary ghost faces/cells. 
+  */
+  virtual void
+  setPermittivities() override;
+
+  /*!
     @brief Set up the multigrid operator factory
   */
   virtual void

--- a/Source/Electrostatics/CD_FieldSolverMultigrid.cpp
+++ b/Source/Electrostatics/CD_FieldSolverMultigrid.cpp
@@ -269,9 +269,9 @@ FieldSolverMultigrid::solve(MFAMRCellData&       a_phi,
     DataOps::kappaScale(m_kappaRhoByEps0);
   }
 
-  m_amr->averageDown(a_phi, m_realm);
+  m_amr->conservativeAverage(a_phi, m_realm);
   m_amr->interpGhost(a_phi, m_realm);
-  m_amr->averageDown(m_kappaRhoByEps0, m_realm);
+  m_amr->conservativeAverage(m_kappaRhoByEps0, m_realm);
   m_amr->interpGhost(m_kappaRhoByEps0, m_realm);
 
   // Do the scaled surface charge
@@ -319,7 +319,7 @@ FieldSolverMultigrid::solve(MFAMRCellData&       a_phi,
 
   m_multigridSolver.revert(phi, rhs, finestLevel, 0);
 
-  m_amr->averageDown(a_phi, m_realm);
+  m_amr->conservativeAverage(a_phi, m_realm);
   m_amr->interpGhostMG(a_phi, m_realm);
 
   this->computeElectricField(m_electricField, a_phi);
@@ -676,7 +676,7 @@ FieldSolverMultigrid::computeElectricField(MFAMRCellData& a_electricField, const
   DataOps::scale(a_electricField, -1.0);
 
   // Coarsen solution and update ghost cells.
-  m_amr->averageDown(a_electricField, m_realm);
+  m_amr->conservativeAverage(a_electricField, m_realm);
   m_amr->interpGhost(a_electricField, m_realm);
 }
 
@@ -735,7 +735,7 @@ FieldSolverMultigrid::computeElectricField(EBAMRCellData&           a_electricFi
   DataOps::scale(a_electricField, -1.0);
 
   // Coarsen solution and update ghost cells.
-  m_amr->averageDown(a_electricField, m_realm, a_phase);
+  m_amr->conservativeAverage(a_electricField, m_realm, a_phase);
   m_amr->interpGhost(a_electricField, m_realm, a_phase);
 }
 

--- a/Source/Electrostatics/CD_FieldSolverMultigrid.cpp
+++ b/Source/Electrostatics/CD_FieldSolverMultigrid.cpp
@@ -417,7 +417,7 @@ FieldSolverMultigrid::setupHelmholtzFactory()
     Vector<EBLevelGrid>                            eblgPhases(numPhases);
     Vector<RefCountedPtr<EBMultigridInterpolator>> interpPhases(numPhases);
     Vector<RefCountedPtr<EBFluxRegister>>          fluxRegPhases(numPhases);
-    Vector<RefCountedPtr<EbCoarAve>>               avePhases(numPhases);
+    Vector<RefCountedPtr<EBCoarAve>>               avePhases(numPhases);
 
     if (!ebisGas.isNull())
       eblgPhases[phase::gas] = *(m_amr->getEBLevelGrid(m_realm, phase::gas)[lvl]);

--- a/Source/Elliptic/CD_EBHelmholtzOp.H
+++ b/Source/Elliptic/CD_EBHelmholtzOp.H
@@ -28,7 +28,7 @@
 // Our includes
 #include <CD_Location.H>
 #include <CD_EBMultigridInterpolator.H>
-#include <CD_EbCoarAve.H>
+#include <CD_EBCoarAve.H>
 #include <CD_EBHelmholtzEBBC.H>
 #include <CD_EBHelmholtzDomainBC.H>
 #include <CD_NamespaceHeader.H>
@@ -105,7 +105,7 @@ public:
                 const EBLevelGrid&                               a_eblgCoarMG,
                 const RefCountedPtr<EBMultigridInterpolator>&    a_interpolator,
                 const RefCountedPtr<EBFluxRegister>&             a_fluxReg,
-                const RefCountedPtr<EbCoarAve>&                  a_coarAve,
+                const RefCountedPtr<EBCoarAve>&                  a_coarAve,
                 const RefCountedPtr<EBHelmholtzDomainBC>&        a_domainBC,
                 const RefCountedPtr<EBHelmholtzEBBC>&            a_ebBC,
                 const RealVect&                                  a_probLo,
@@ -817,7 +817,7 @@ protected:
   /*!
     @brief Conservative coarsener
   */
-  RefCountedPtr<EbCoarAve> m_coarAve;
+  RefCountedPtr<EBCoarAve> m_coarAve;
 
   /*!
     @brief A-coefficient in Helmholtz equation

--- a/Source/Elliptic/CD_EBHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_EBHelmholtzOp.cpp
@@ -33,7 +33,7 @@ EBHelmholtzOp::EBHelmholtzOp(const Location::Cell                             a_
                              const EBLevelGrid&                               a_eblgCoarMG,
                              const RefCountedPtr<EBMultigridInterpolator>&    a_interpolator,
                              const RefCountedPtr<EBFluxRegister>&             a_fluxReg,
-                             const RefCountedPtr<EbCoarAve>&                  a_coarAve,
+                             const RefCountedPtr<EBCoarAve>&                  a_coarAve,
                              const RefCountedPtr<EBHelmholtzDomainBC>&        a_domainBc,
                              const RefCountedPtr<EBHelmholtzEBBC>&            a_ebBc,
                              const RealVect&                                  a_probLo,

--- a/Source/Elliptic/CD_EBHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_EBHelmholtzOp.cpp
@@ -1766,7 +1766,7 @@ EBHelmholtzOp::coarsen(LevelData<EBCellFAB>& a_phi, const LevelData<EBCellFAB>& 
 {
   CH_TIME("EBHelmholtzOp::coarsen(LD<EBCellFAB>, LD<EBCellFAB>)");
 
-  m_coarAve->average(a_phi, a_phiFine, m_interval);
+  m_coarAve->averageData(a_phi, a_phiFine, m_interval, Average::Conservative);
 }
 
 #include <CD_NamespaceFooter.H>

--- a/Source/Elliptic/CD_EBHelmholtzOpFactory.H
+++ b/Source/Elliptic/CD_EBHelmholtzOpFactory.H
@@ -25,7 +25,7 @@
 
 // Our includes
 #include <CD_Location.H>
-#include <CD_EbCoarAve.H>
+#include <CD_EBCoarAve.H>
 #include <CD_EBMultigridInterpolator.H>
 #include <CD_EBHelmholtzOp.H>
 #include <CD_EBHelmholtzEBBCFactory.H>
@@ -47,7 +47,7 @@ public:
   using AmrLevelGrids    = Vector<RefCountedPtr<EBLevelGrid>>;
   using AmrInterpolators = Vector<RefCountedPtr<EBMultigridInterpolator>>;
   using AmrFluxRegisters = Vector<RefCountedPtr<EBFluxRegister>>;
-  using AmrCoarseners    = Vector<RefCountedPtr<EbCoarAve>>;
+  using AmrCoarseners    = Vector<RefCountedPtr<EBCoarAve>>;
 
   using AmrCellData = Vector<RefCountedPtr<LevelData<EBCellFAB>>>;
   using AmrFluxData = Vector<RefCountedPtr<LevelData<EBFluxFAB>>>;

--- a/Source/Elliptic/CD_EBHelmholtzOpFactory.H
+++ b/Source/Elliptic/CD_EBHelmholtzOpFactory.H
@@ -16,7 +16,6 @@
 #include <RealVect.H>
 #include <EBLevelGrid.H>
 #include <EBFluxRegister.H>
-#include <EBCoarseAverage.H>
 #include <EBCellFAB.H>
 #include <EBFluxFAB.H>
 #include <BaseIVFAB.H>

--- a/Source/Elliptic/CD_EBHelmholtzOpFactory.cpp
+++ b/Source/Elliptic/CD_EBHelmholtzOpFactory.cpp
@@ -13,6 +13,7 @@
 #include <ParmParse.H>
 #include <BRMeshRefine.H>
 #include <LoadBalance.H>
+#include <BaseIVFactory.H>
 #include <CH_Timer.H>
 
 // Our includes
@@ -360,7 +361,6 @@ EBHelmholtzOpFactory::coarsenCoefficients(LevelData<EBCellFAB>&             a_co
                         a_eblgCoar.getEBISL(),
                         a_eblgCoar.getDomain(),
                         a_refRat,
-                        1,
                         a_eblgCoar.getEBIS());
 
     const Average average = Average::Conservative;

--- a/Source/Elliptic/CD_EBHelmholtzOpFactory.cpp
+++ b/Source/Elliptic/CD_EBHelmholtzOpFactory.cpp
@@ -363,9 +363,11 @@ EBHelmholtzOpFactory::coarsenCoefficients(LevelData<EBCellFAB>&             a_co
                         1,
                         a_eblgCoar.getEBIS());
 
-    averageOp.average(a_coarAcoef, a_fineAcoef, interv);
-    averageOp.averageFaceData(a_coarBcoef, a_fineBcoef, interv);
-    averageOp.average(a_coarBcoefIrreg, a_fineBcoefIrreg, interv);
+    const Average average = Average::Conservative;
+
+    averageOp.averageData(a_coarAcoef, a_fineAcoef, interv, average);
+    averageOp.averageData(a_coarBcoef, a_fineBcoef, interv, average);
+    averageOp.averageData(a_coarBcoefIrreg, a_fineBcoefIrreg, interv, average);
 
     a_coarAcoef.exchange();
     a_coarBcoef.exchange();

--- a/Source/Elliptic/CD_EBHelmholtzOpFactory.cpp
+++ b/Source/Elliptic/CD_EBHelmholtzOpFactory.cpp
@@ -355,7 +355,7 @@ EBHelmholtzOpFactory::coarsenCoefficients(LevelData<EBCellFAB>&             a_co
     a_fineBcoefIrreg.copyTo(a_coarBcoefIrreg);
   }
   else {
-    EbCoarAve averageOp(a_eblgFine.getDBL(),
+    EBCoarAve averageOp(a_eblgFine.getDBL(),
                         a_eblgCoar.getDBL(),
                         a_eblgFine.getEBISL(),
                         a_eblgCoar.getEBISL(),
@@ -408,7 +408,7 @@ EBHelmholtzOpFactory::MGnewOp(const ProblemDomain& a_fineDomain, int a_depth, bo
 
   RefCountedPtr<EBMultigridInterpolator> interpolator; // Only if defined on an AMR level
   RefCountedPtr<EBFluxRegister>          fluxReg;      // Only if defined on an AMR level
-  RefCountedPtr<EbCoarAve>               coarsener;    // Only if defined on an AMR level
+  RefCountedPtr<EBCoarAve>               coarsener;    // Only if defined on an AMR level
 
   RefCountedPtr<LevelData<EBCellFAB>>       Acoef;      // Always defined.
   RefCountedPtr<LevelData<EBFluxFAB>>       Bcoef;      // Always defined.

--- a/Source/Elliptic/CD_EBHelmholtzOpFactory.cpp
+++ b/Source/Elliptic/CD_EBHelmholtzOpFactory.cpp
@@ -363,7 +363,7 @@ EBHelmholtzOpFactory::coarsenCoefficients(LevelData<EBCellFAB>&             a_co
                         a_refRat,
                         a_eblgCoar.getEBIS());
 
-    const Average average = Average::Conservative;
+    const Average average = Average::Arithmetic;
 
     averageOp.averageData(a_coarAcoef, a_fineAcoef, interv, average);
     averageOp.averageData(a_coarBcoef, a_fineBcoef, interv, average);

--- a/Source/Elliptic/CD_MFHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzOp.cpp
@@ -102,7 +102,7 @@ MFHelmholtzOp::MFHelmholtzOp(const Location::Cell                             a_
 
     RefCountedPtr<EBMultigridInterpolator> interpolator = RefCountedPtr<EBMultigridInterpolator>(nullptr);
     RefCountedPtr<EBFluxRegister>          fluxRegister = RefCountedPtr<EBFluxRegister>(nullptr);
-    RefCountedPtr<EbCoarAve>               coarsener    = RefCountedPtr<EbCoarAve>(nullptr);
+    RefCountedPtr<EBCoarAve>               coarsener    = RefCountedPtr<EBCoarAve>(nullptr);
 
     if (!a_isMGOperator) {
       if (a_hasFine) {

--- a/Source/Elliptic/CD_MFHelmholtzOpFactory.H
+++ b/Source/Elliptic/CD_MFHelmholtzOpFactory.H
@@ -352,7 +352,7 @@ protected:
   /*!
     @brief Coarsneing operator on deeper grids (used for coarsening jump)
   */
-  Vector<Vector<RefCountedPtr<EbCoarAve>>> m_mgAveOp;
+  Vector<Vector<RefCountedPtr<EBCoarAve>>> m_mgAveOp;
 
   /*!
     @brief Function which defines the multigrid levels for this operator factory

--- a/Source/Elliptic/CD_MFHelmholtzOpFactory.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzOpFactory.cpp
@@ -13,6 +13,7 @@
 #include <ParmParse.H>
 #include <BRMeshRefine.H>
 #include <LoadBalance.H>
+#include <BaseIVFactory.H>
 #include <CH_Timer.H>
 
 // Our includes
@@ -353,7 +354,6 @@ MFHelmholtzOpFactory::defineMultigridLevels()
                                                        eblgCoar.getEBISL(),
                                                        eblgCoar.getDomain(),
                                                        mgRefRatio,
-                                                       m_nComp,
                                                        eblgCoar.getEBIS()));
 
           // Append. Phew.
@@ -756,7 +756,6 @@ MFHelmholtzOpFactory::coarsenCoefficients(LevelData<MFCellFAB>&         a_coarAc
                       eblgCoar.getEBISL(),
                       eblgCoar.getDomain(),
                       a_refRat,
-                      m_nComp,
                       eblgCoar.getEBIS());
 
       LevelData<EBCellFAB>       coarAco;

--- a/Source/Elliptic/CD_MFHelmholtzOpFactory.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzOpFactory.cpp
@@ -774,7 +774,7 @@ MFHelmholtzOpFactory::coarsenCoefficients(LevelData<MFCellFAB>&         a_coarAc
       MultifluidAlias::aliasMF(fineBco, i, a_fineBcoef);
       MultifluidAlias::aliasMF(fineBcoIrreg, i, a_fineBcoefIrreg);
 
-      const Average average = Average::Conservative;
+      const Average average = Average::Arithmetic;
 
       aveOp.averageData(coarAco, fineAco, interv, average);
       aveOp.averageData(coarBco, fineBco, interv, average);

--- a/Source/Elliptic/CD_MFHelmholtzOpFactory.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzOpFactory.cpp
@@ -131,7 +131,7 @@ MFHelmholtzOpFactory::setJump(const EBAMRIVData& a_sigma, const Real& a_scale)
 
   // Average down on AMR levels.
   for (int lvl = m_numAmrLevels - 1; lvl > 0; lvl--) {
-    const RefCountedPtr<EbCoarAve>& aveOp = m_amrCoarseners[lvl].getAveOp(m_mainPhase);
+    const RefCountedPtr<EBCoarAve>& aveOp = m_amrCoarseners[lvl].getAveOp(m_mainPhase);
 
     const Average average = Average::Arithmetic;
 
@@ -258,7 +258,7 @@ MFHelmholtzOpFactory::defineMultigridLevels()
       m_mgBcoef[amrLevel].push_back(m_amrBcoef[amrLevel]);
       m_mgBcoefIrreg[amrLevel].push_back(m_amrBcoefIrreg[amrLevel]);
       m_mgJump[amrLevel].push_back(m_amrJump[amrLevel]);
-      m_mgAveOp[amrLevel].push_back(RefCountedPtr<EbCoarAve>(nullptr));
+      m_mgAveOp[amrLevel].push_back(RefCountedPtr<EBCoarAve>(nullptr));
 
       bool hasCoarser = true;
 
@@ -348,7 +348,7 @@ MFHelmholtzOpFactory::defineMultigridLevels()
           // This is a special object for coarsening jump data between MG levels.
           const EBLevelGrid&       eblgFine = mgMflgFine.getEBLevelGrid(m_mainPhase);
           const EBLevelGrid&       eblgCoar = mgMflgCoar.getEBLevelGrid(m_mainPhase);
-          RefCountedPtr<EbCoarAve> aveOp(new EbCoarAve(eblgFine.getDBL(),
+          RefCountedPtr<EBCoarAve> aveOp(new EBCoarAve(eblgFine.getDBL(),
                                                        eblgCoar.getDBL(),
                                                        eblgFine.getEBISL(),
                                                        eblgCoar.getEBISL(),
@@ -750,7 +750,7 @@ MFHelmholtzOpFactory::coarsenCoefficients(LevelData<MFCellFAB>&         a_coarAc
       const EBLevelGrid& eblgCoar = a_mflgCoar.getEBLevelGrid(i);
       const EBLevelGrid& eblgFine = a_mflgFine.getEBLevelGrid(i);
 
-      EbCoarAve aveOp(eblgFine.getDBL(),
+      EBCoarAve aveOp(eblgFine.getDBL(),
                       eblgCoar.getDBL(),
                       eblgFine.getEBISL(),
                       eblgCoar.getEBISL(),

--- a/Source/Elliptic/CD_MFHelmholtzOpFactory.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzOpFactory.cpp
@@ -131,7 +131,10 @@ MFHelmholtzOpFactory::setJump(const EBAMRIVData& a_sigma, const Real& a_scale)
   // Average down on AMR levels.
   for (int lvl = m_numAmrLevels - 1; lvl > 0; lvl--) {
     const RefCountedPtr<EbCoarAve>& aveOp = m_amrCoarseners[lvl].getAveOp(m_mainPhase);
-    aveOp->average(*m_amrJump[lvl - 1], *m_amrJump[lvl], Interval(m_comp, m_comp));
+
+    const Average average = Average::Arithmetic;
+
+    aveOp->averageData(*m_amrJump[lvl - 1], *m_amrJump[lvl], Interval(m_comp, m_comp), average);
   }
 
   // Average down on MG levels. I'm not really sure if we need to do this. Also,
@@ -772,9 +775,11 @@ MFHelmholtzOpFactory::coarsenCoefficients(LevelData<MFCellFAB>&         a_coarAc
       MultifluidAlias::aliasMF(fineBco, i, a_fineBcoef);
       MultifluidAlias::aliasMF(fineBcoIrreg, i, a_fineBcoefIrreg);
 
-      aveOp.average(coarAco, fineAco, interv);
-      aveOp.averageFaceData(coarBco, fineBco, interv);
-      aveOp.average(coarBcoIrreg, fineBcoIrreg, interv);
+      const Average average = Average::Conservative;
+
+      aveOp.averageData(coarAco, fineAco, interv, average);
+      aveOp.averageData(coarBco, fineBco, interv, average);
+      aveOp.averageData(coarBcoIrreg, fineBcoIrreg, interv, average);
 
       coarAco.exchange();
       coarBco.exchange();

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -1425,7 +1425,7 @@ ItoSolver::writeData(EBAMRCellData& a_output, int& a_comp, const EBAMRCellData& 
     m_amr->interpToCentroids(scratch, m_realm, phase::gas);
   }
 
-  m_amr->averageDown(scratch, m_realm, m_phase);
+  m_amr->conservativeAverage(scratch, m_realm, m_phase);
   m_amr->interpGhost(scratch, m_realm, m_phase);
 
   // Copy into source data holder.
@@ -2167,7 +2167,7 @@ ItoSolver::interpolateMobilities()
       // Compute |v|
       DataOps::vectorLength(m_scratch, m_velocityFunction);
 
-      m_amr->averageDown(m_scratch, m_realm, m_phase);
+      m_amr->conservativeAverage(m_scratch, m_realm, m_phase);
       m_amr->interpGhostMG(m_scratch, m_realm, m_phase);
 
       break;

--- a/Source/ItoDiffusion/CD_ItoSolverImplem.H
+++ b/Source/ItoDiffusion/CD_ItoSolverImplem.H
@@ -89,7 +89,7 @@ ItoSolver::depositParticles(EBAMRCellData&             a_phi,
   this->redistributeAMR(a_phi);
 
   // Average down and interpolate
-  m_amr->averageDown(a_phi, m_realm, m_phase);
+  m_amr->conservativeAverage(a_phi, m_realm, m_phase);
   m_amr->interpGhost(a_phi, m_realm, m_phase);
 }
 
@@ -116,7 +116,7 @@ ItoSolver::depositParticles(EBAMRCellData&             a_phi,
   this->redistributeAMR(a_phi);
 
   // Average down and interpolate
-  m_amr->averageDown(a_phi, m_realm, m_phase);
+  m_amr->conservativeAverage(a_phi, m_realm, m_phase);
   m_amr->interpGhost(a_phi, m_realm, m_phase);
 }
 

--- a/Source/MeshODESolver/CD_MeshODESolverImplem.H
+++ b/Source/MeshODESolver/CD_MeshODESolverImplem.H
@@ -402,7 +402,7 @@ MeshODESolver<N>::regrid(const int a_lmin, const int a_oldFinestLevel, const int
 
   m_amr->interpToNewGrids(m_phi, m_cache, m_phase, a_lmin, a_oldFinestLevel, a_newFinestLevel, m_regridSlopes);
 
-  m_amr->averageDown(m_phi, m_realm, m_phase);
+  m_amr->conservativeAverage(m_phi, m_realm, m_phase);
   m_amr->interpGhost(m_phi, m_realm, m_phase);
 
   m_amr->deallocate(m_cache);
@@ -674,7 +674,7 @@ MeshODESolver<N>::writeData(EBAMRCellData&       a_output,
     m_amr->interpToCentroids(scratch, m_realm, phase::gas);
   }
 
-  m_amr->averageDown(scratch, m_realm, m_phase);
+  m_amr->conservativeAverage(scratch, m_realm, m_phase);
   m_amr->interpGhost(scratch, m_realm, m_phase);
 
   // Need a more general copy method because we can't call DataOps::copy (because realms might not be the same) and

--- a/Source/Multifluid/CD_MFCoarAve.H
+++ b/Source/Multifluid/CD_MFCoarAve.H
@@ -5,7 +5,7 @@
 
 /*!
   @file   CD_MFCoarAve.H
-  @brief  Wrapper class for holding multifluid EbCoarAves
+  @brief  Wrapper class for holding multifluid EBCoarAves
   @author Robert Marskar
 */
 
@@ -16,7 +16,7 @@
 #include <map>
 
 // Our includes
-#include <CD_EbCoarAve.H>
+#include <CD_EBCoarAve.H>
 #include <CD_NamespaceHeader.H>
 
 /*!
@@ -39,27 +39,27 @@ public:
     @brief Full constructor. Calls define
     @param[in] aveOps Averaging operators on each phase. 
   */
-  MFCoarAve(const Vector<RefCountedPtr<EbCoarAve>>& a_aveOps);
+  MFCoarAve(const Vector<RefCountedPtr<EBCoarAve>>& a_aveOps);
 
   /*!
     @brief Define function
     @param[in] aveOps Averaging operators on each phase. 
   */
   void
-  define(const Vector<RefCountedPtr<EbCoarAve>>& a_aveOps);
+  define(const Vector<RefCountedPtr<EBCoarAve>>& a_aveOps);
 
   /*!
     @brief Get coarsening utility for specified phase.
     @param[in] a_phase Phase
   */
-  const RefCountedPtr<EbCoarAve>&
+  const RefCountedPtr<EBCoarAve>&
   getAveOp(const int a_phase) const;
 
 protected:
   /*!
     @brief Interpolation for each phase. 
   */
-  Vector<RefCountedPtr<EbCoarAve>> m_aveOps;
+  Vector<RefCountedPtr<EBCoarAve>> m_aveOps;
 };
 
 #include <CD_NamespaceFooter.H>

--- a/Source/Multifluid/CD_MFCoarAve.cpp
+++ b/Source/Multifluid/CD_MFCoarAve.cpp
@@ -17,15 +17,15 @@ MFCoarAve::MFCoarAve() {}
 
 MFCoarAve::~MFCoarAve() {}
 
-MFCoarAve::MFCoarAve(const Vector<RefCountedPtr<EbCoarAve>>& a_aveOps) { this->define(a_aveOps); }
+MFCoarAve::MFCoarAve(const Vector<RefCountedPtr<EBCoarAve>>& a_aveOps) { this->define(a_aveOps); }
 
 void
-MFCoarAve::define(const Vector<RefCountedPtr<EbCoarAve>>& a_aveOps)
+MFCoarAve::define(const Vector<RefCountedPtr<EBCoarAve>>& a_aveOps)
 {
   m_aveOps = a_aveOps;
 }
 
-const RefCountedPtr<EbCoarAve>&
+const RefCountedPtr<EBCoarAve>&
 MFCoarAve::getAveOp(const int a_phase) const
 {
   return m_aveOps[a_phase];

--- a/Source/README.md
+++ b/Source/README.md
@@ -15,4 +15,5 @@ The folder is organized as follows:
 * Particle Contains source code for using particles with EBs and AMR.
 * RadiativeTransfer Contains source code for various radiative transfer solvers.
 * SigmaSolver Contains source code for a surface charge solver.
+* TracerParticles Contains source code for the tracer particle solver. 
 * Utilities Contains various source code for useful utilities used in chombo-discharge source and application codes. 

--- a/Source/RadiativeTransfer/CD_EddingtonSP1.cpp
+++ b/Source/RadiativeTransfer/CD_EddingtonSP1.cpp
@@ -540,7 +540,7 @@ EddingtonSP1::regrid(const int a_lmin, const int a_oldFinestLevel, const int a_n
   m_amr->interpToNewGrids(m_source, m_cacheSrc, m_phase, a_lmin, a_oldFinestLevel, a_newFinestLevel, m_regridSlopes);
 
   // Coarsen and update ghost cells.
-  m_amr->averageDown(m_phi, m_realm, m_phase);
+  m_amr->conservativeAverage(m_phi, m_realm, m_phase);
   m_amr->interpGhost(m_phi, m_realm, m_phase);
 
   m_isSolverSetup = false;
@@ -653,7 +653,7 @@ EddingtonSP1::advance(const Real a_dt, EBAMRCellData& a_phi, const EBAMRCellData
     DataOps::copy(a_phi, m_resid);
   }
 
-  m_amr->averageDown(a_phi, m_realm, m_phase);
+  m_amr->conservativeAverage(a_phi, m_realm, m_phase);
   m_amr->interpGhost(a_phi, m_realm, m_phase);
 
   return converged;
@@ -1030,7 +1030,7 @@ EddingtonSP1::computeBoundaryFlux(EBAMRIVData& a_ebFlux, const EBAMRCellData& a_
     sten.apply(*a_ebFlux[lvl], *a_phi[lvl], lvl);
   }
 
-  m_amr->averageDown(a_ebFlux, m_realm, m_phase);
+  m_amr->conservativeAverage(a_ebFlux, m_realm, m_phase);
 
   DataOps::scale(a_ebFlux, 0.5 * Units::c);
 }
@@ -1121,7 +1121,7 @@ EddingtonSP1::computeFlux(EBAMRCellData& a_flux, const EBAMRCellData& a_phi)
     DataOps::scale(*a_flux[lvl], -Units::c * Units::c / 3.0); // flux = -c*grad(phi)/3.
   }
 
-  m_amr->averageDown(a_flux, m_realm, m_phase);
+  m_amr->conservativeAverage(a_flux, m_realm, m_phase);
   m_amr->interpGhost(a_flux, m_realm, m_phase);
 }
 

--- a/Source/RadiativeTransfer/CD_EddingtonSP1.cpp
+++ b/Source/RadiativeTransfer/CD_EddingtonSP1.cpp
@@ -827,7 +827,7 @@ EddingtonSP1::setupHelmholtzFactory()
   }
 
   const Vector<RefCountedPtr<EBLevelGrid>>&             levelGrids = m_amr->getEBLevelGrid(m_realm, m_phase);
-  const Vector<RefCountedPtr<EbCoarAve>>&               coarAve    = m_amr->getCoarseAverage(m_realm, m_phase);
+  const Vector<RefCountedPtr<EBCoarAve>>&               coarAve    = m_amr->getCoarseAverage(m_realm, m_phase);
   const Vector<RefCountedPtr<EBFluxRegister>>&          fluxReg    = m_amr->getFluxRegister(m_realm, m_phase);
   const Vector<RefCountedPtr<EBMultigridInterpolator>>& interpolator =
     m_amr->getMultigridInterpolator(m_realm, m_phase);

--- a/Source/RadiativeTransfer/CD_McPhoto.cpp
+++ b/Source/RadiativeTransfer/CD_McPhoto.cpp
@@ -986,7 +986,7 @@ McPhoto::depositPhotons(EBAMRCellData& a_phi, ParticleContainer<Photon>& a_photo
   this->coarseFineRedistribution(a_phi); // Do the coarse-fine redistribution
 
   // Average down and interpolate
-  m_amr->averageDown(a_phi, m_realm, m_phase);
+  m_amr->conservativeAverage(a_phi, m_realm, m_phase);
   m_amr->interpGhost(a_phi, m_realm, m_phase);
 }
 

--- a/Source/RadiativeTransfer/CD_RtSolver.cpp
+++ b/Source/RadiativeTransfer/CD_RtSolver.cpp
@@ -228,7 +228,7 @@ RtSolver::setSource(const EBAMRCellData& a_source)
     a_source[lvl]->localCopyTo(*m_source[lvl]);
   }
 
-  m_amr->averageDown(m_source, m_realm, m_phase);
+  m_amr->conservativeAverage(m_source, m_realm, m_phase);
   m_amr->interpGhost(m_source, m_realm, m_phase);
 }
 
@@ -255,7 +255,7 @@ RtSolver::setSource(const Real a_source)
 
   DataOps::setValue(m_source, a_source);
 
-  m_amr->averageDown(m_source, m_realm, m_phase);
+  m_amr->conservativeAverage(m_source, m_realm, m_phase);
   m_amr->interpGhost(m_source, m_realm, m_phase);
 }
 
@@ -329,7 +329,7 @@ RtSolver::writeData(EBAMRCellData& a_output, int& a_comp, const EBAMRCellData& a
     m_amr->interpToCentroids(scratch, m_realm, phase::gas);
   }
 
-  m_amr->averageDown(scratch, m_realm, m_phase);
+  m_amr->conservativeAverage(scratch, m_realm, m_phase);
   m_amr->interpGhost(scratch, m_realm, m_phase);
 
   for (int lvl = 0; lvl <= m_amr->getFinestLevel(); lvl++) {

--- a/Source/SigmaSolver/CD_SigmaSolver.cpp
+++ b/Source/SigmaSolver/CD_SigmaSolver.cpp
@@ -11,6 +11,7 @@
 
 // Chombo includes
 #include <CH_Timer.H>
+#include <BaseIVFactory.H>
 
 // Our includes
 #include <CD_SigmaSolver.H>

--- a/Source/SigmaSolver/CD_SigmaSolver.cpp
+++ b/Source/SigmaSolver/CD_SigmaSolver.cpp
@@ -483,7 +483,7 @@ SigmaSolver::computeCharge()
   // TLDR: Since we can coarsen conservatively, we compute coarsen the solution
   //       onto the coarsest level and do the integration there.
 
-  m_amr->averageDown(m_phi, m_realm, m_phase);
+  m_amr->conservativeAverage(m_phi, m_realm, m_phase);
 
   Real charge = 0.0;
 

--- a/Source/Utilities/CD_DataOps.H
+++ b/Source/Utilities/CD_DataOps.H
@@ -49,12 +49,13 @@ public:
     @param[out] a_faceData Face data. Must have one component. 
     @param[in]  a_cellData Cell data. Must have SpaceDim components. 
     @param[in]  a_domains  AMR domains.
-    @note This routine also fills one tangential ghost face.
+    @param[in]  a_tanGhost Number of ghost faces to fill.
   */
   static void
   averageCellVelocityToFaceVelocity(EBAMRFluxData&               a_faceData,
                                     const EBAMRCellData&         a_cellData,
-                                    const Vector<ProblemDomain>& a_domains);
+                                    const Vector<ProblemDomain>& a_domains,
+                                    const int                    a_tanGhosts);
 
   /*!
     @brief Routine which computes the average of a cell-centered quantity on faces for the normal component only.
@@ -62,13 +63,12 @@ public:
     @param[in]  a_cellData Cell data. Must have SpaceDim components. 
     @param[in]  a_domain   Problem domain
     @param[in]  a_tanGhost Number of ghost faces to fill
-    @param[in]  a_average  Averaging method
-    @note This routine also fills one tangential ghost face.
   */
   static void
   averageCellVelocityToFaceVelocity(LevelData<EBFluxFAB>&       a_faceData,
                                     const LevelData<EBCellFAB>& a_cellData,
-                                    const ProblemDomain&        a_domain);
+                                    const ProblemDomain&        a_domain,
+                                    const int                   a_tanGhosts);
 
   /*!
     @brief Average all components of the cell-centered data to faces.

--- a/Source/Utilities/CD_DataOps.H
+++ b/Source/Utilities/CD_DataOps.H
@@ -52,9 +52,9 @@ public:
     @note This routine also fills one tangential ghost face.
   */
   static void
-  averageCellVectorToFaceScalar(EBAMRFluxData&               a_faceData,
-                                const EBAMRCellData&         a_cellData,
-                                const Vector<ProblemDomain>& a_domains);
+  averageCellVelocityToFaceVelocity(EBAMRFluxData&               a_faceData,
+                                    const EBAMRCellData&         a_cellData,
+                                    const Vector<ProblemDomain>& a_domains);
 
   /*!
     @brief Routine which computes the average of a cell-centered quantity on faces for the normal component only.
@@ -66,9 +66,9 @@ public:
     @note This routine also fills one tangential ghost face.
   */
   static void
-  averageCellVectorToFaceScalar(LevelData<EBFluxFAB>&       a_faceData,
-                                const LevelData<EBCellFAB>& a_cellData,
-                                const ProblemDomain&        a_domain);
+  averageCellVelocityToFaceVelocity(LevelData<EBFluxFAB>&       a_faceData,
+                                    const LevelData<EBCellFAB>& a_cellData,
+                                    const ProblemDomain&        a_domain);
 
   /*!
     @brief Average all components of the cell-centered data to faces.
@@ -76,7 +76,7 @@ public:
     @param[out] a_faceData Face data. 
     @param[in]  a_cellData Cell data. 
     @param[in]  a_domains  AMR domains.
-    @note This does not fill "tangential" ghost faces (unlike averageCellVectorToFaceScalar). 
+    @note This does not fill "tangential" ghost faces.
   */
   static void
   averageCellToFace(EBAMRFluxData& a_faceData, const EBAMRCellData& a_cellData, const Vector<ProblemDomain>& a_domains);

--- a/Source/Utilities/CD_DataOps.H
+++ b/Source/Utilities/CD_DataOps.H
@@ -13,6 +13,7 @@
 #define CD_DataOps_H
 
 // Our includes
+#include <CD_Average.H>
 #include <CD_EBAMRData.H>
 #include <CD_Decorations.H>
 #include <CD_MFInterfaceFAB.H>
@@ -60,6 +61,8 @@ public:
     @param[out] a_faceData Face data. Must have one component. 
     @param[in]  a_cellData Cell data. Must have SpaceDim components. 
     @param[in]  a_domain   Problem domain
+    @param[in]  a_tanGhost Number of ghost faces to fill
+    @param[in]  a_average  Averaging method
     @note This routine also fills one tangential ghost face.
   */
   static void
@@ -78,6 +81,46 @@ public:
   averageCellScalarToFaceScalar(EBAMRFluxData&               a_faceData,
                                 const EBAMRCellData&         a_cellData,
                                 const Vector<ProblemDomain>& a_domains);
+
+  /*!
+    @brief Routine which averages a cell-centered component to faces. 
+    @details User can choose what type of averaging to use, as well as choosing the number of ghost face to fill. These
+    faces are "tangential ghost faces", i.e. if the face direction is along +x, we extend the box with faces in the y- and z-
+    directions.
+    @param[out] a_faceData Face data. 
+    @param[in]  a_cellData Cell data. 
+    @param[in]  a_domains  Problem domains
+    @param[in]  a_tanGhost Number of ghost faces to fill
+    @param[in]  a_average  Averaging method
+  */
+  static void
+  averageCellToFace(EBAMRFluxData&               a_faceData,
+                    const EBAMRCellData&         a_cellData,
+                    const Vector<ProblemDomain>& a_domains,
+                    const int                    a_tanGhosts,
+                    const Interval&              a_faceInterval,
+                    const Interval&              a_cellInterval,
+                    const Average&               a_average);
+
+  /*!
+    @brief Routine which averages a cell-centered component to faces. 
+    @details User can choose what type of averaging to use, as well as choosing the number of ghost face to fill. These
+    faces are "tangential ghost faces", i.e. if the face direction is along +x, we extend the box with faces in the y- and z-
+    directions.
+    @param[out] a_faceData Face data. 
+    @param[in]  a_cellData Cell data. 
+    @param[in]  a_domain   Problem domain
+    @param[in]  a_tanGhost Number of ghost faces to fill
+    @param[in]  a_average  Averaging method
+  */
+  static void
+  averageCellToFace(LevelData<EBFluxFAB>&       a_faceData,
+                    const LevelData<EBCellFAB>& a_cellData,
+                    const ProblemDomain&        a_domain,
+                    const int                   a_tanGhosts,
+                    const Interval&             a_faceInterval,
+                    const Interval&             a_cellInterval,
+                    const Average&              a_average);
 
   /*!
     @brief Routine which computes the average of a cell-centered quantity on faces. This fills one tangential ghost face.

--- a/Source/Utilities/CD_DataOps.H
+++ b/Source/Utilities/CD_DataOps.H
@@ -71,16 +71,15 @@ public:
                                 const ProblemDomain&        a_domain);
 
   /*!
-    @brief Routine which computes the average of a cell-centered quantity on faces. This fills one tangential ghost face.
-    @param[out] a_faceData Face data. Must have one component. 
-    @param[in]  a_cellData Cell data. Must have one component. 
+    @brief Average all components of the cell-centered data to faces.
+    @details Calls the other version; uses arihtmetic averaging and does not fill ghost faces. 
+    @param[out] a_faceData Face data. 
+    @param[in]  a_cellData Cell data. 
     @param[in]  a_domains  AMR domains.
-    @note This routine also fills one tangential ghost face.
+    @note This does not fill "tangential" ghost faces (unlike averageCellVectorToFaceScalar). 
   */
   static void
-  averageCellScalarToFaceScalar(EBAMRFluxData&               a_faceData,
-                                const EBAMRCellData&         a_cellData,
-                                const Vector<ProblemDomain>& a_domains);
+  averageCellToFace(EBAMRFluxData& a_faceData, const EBAMRCellData& a_cellData, const Vector<ProblemDomain>& a_domains);
 
   /*!
     @brief Routine which averages a cell-centered component to faces. 
@@ -89,8 +88,10 @@ public:
     directions.
     @param[out] a_faceData Face data. 
     @param[in]  a_cellData Cell data. 
-    @param[in]  a_domains  Problem domains
+    @param[in]  a_domain   Problem domain
     @param[in]  a_tanGhost Number of ghost faces to fill
+    @param[in]  a_faceVars Face variables
+    @param[in]  a_cellVars Cell variables
     @param[in]  a_average  Averaging method
   */
   static void
@@ -98,8 +99,8 @@ public:
                     const EBAMRCellData&         a_cellData,
                     const Vector<ProblemDomain>& a_domains,
                     const int                    a_tanGhosts,
-                    const Interval&              a_faceInterval,
-                    const Interval&              a_cellInterval,
+                    const Interval&              a_faceVars,
+                    const Interval&              a_cellVars,
                     const Average&               a_average);
 
   /*!
@@ -111,6 +112,8 @@ public:
     @param[in]  a_cellData Cell data. 
     @param[in]  a_domain   Problem domain
     @param[in]  a_tanGhost Number of ghost faces to fill
+    @param[in]  a_faceVars Face variables
+    @param[in]  a_cellVars Cell variables
     @param[in]  a_average  Averaging method
   */
   static void
@@ -118,43 +121,9 @@ public:
                     const LevelData<EBCellFAB>& a_cellData,
                     const ProblemDomain&        a_domain,
                     const int                   a_tanGhosts,
-                    const Interval&             a_faceInterval,
-                    const Interval&             a_cellInterval,
+                    const Interval&             a_faceVars,
+                    const Interval&             a_cellVars,
                     const Average&              a_average);
-
-  /*!
-    @brief Routine which computes the average of a cell-centered quantity on faces. This fills one tangential ghost face.
-    @param[out] a_faceData Face data. Must have one component. 
-    @param[in]  a_cellData Cell data. Must have one component.
-    @param[in]  a_domain   Problem domain
-    @note This routine also fills one tangential ghost face.
-  */
-  static void
-  averageCellScalarToFaceScalar(LevelData<EBFluxFAB>&       a_faceData,
-                                const LevelData<EBCellFAB>& a_cellData,
-                                const ProblemDomain&        a_domain);
-
-  /*!
-    @brief Average all components of the cell-centered data to faces.
-    @param[out] a_faceData Face data. 
-    @param[in]  a_cellData Cell data. 
-    @param[in]  a_domains  AMR domains.
-    @note This does not fill "tangential" ghost faces (unlike averageCellVectorToFaceScalar). 
-  */
-  static void
-  averageCellToFace(EBAMRFluxData& a_faceData, const EBAMRCellData& a_cellData, const Vector<ProblemDomain>& a_domains);
-
-  /*!
-    @brief Average all components of the cell-centered data to faces.
-    @param[out] a_faceData Face data. 
-    @param[in]  a_cellData Cell data. 
-    @param[in]  a_domain   Domain
-    @note This does not fill "tangential" ghost faces (unlike averageCellVectorToFaceScalar)
-  */
-  static void
-  averageCellToFace(LevelData<EBFluxFAB>&       a_faceData,
-                    const LevelData<EBCellFAB>& a_cellData,
-                    const ProblemDomain&        a_domain);
 
   /*!
     @brief Average all components of face centered data to cell centers.

--- a/Source/Utilities/CD_DataOps.cpp
+++ b/Source/Utilities/CD_DataOps.cpp
@@ -26,27 +26,27 @@
 #include <CD_NamespaceHeader.H>
 
 void
-DataOps::averageCellVectorToFaceScalar(EBAMRFluxData&               a_faceData,
-                                       const EBAMRCellData&         a_cellData,
-                                       const Vector<ProblemDomain>& a_domains)
+DataOps::averageCellVelocityToFaceVelocity(EBAMRFluxData&               a_faceData,
+                                           const EBAMRCellData&         a_cellData,
+                                           const Vector<ProblemDomain>& a_domains)
 {
-  CH_TIME("DataOps::averageCellVectorToFaceScalar(EBAMRFluxData)");
+  CH_TIME("DataOps::averageCellVelocityToFaceVelocity(EBAMRFluxData)");
 
   for (int lvl = 0; lvl < a_faceData.size(); lvl++) {
 
     CH_assert(a_faceData[lvl]->nComp() == 1);
     CH_assert(a_cellData[lvl]->nComp() == SpaceDim);
 
-    DataOps::averageCellVectorToFaceScalar(*a_faceData[lvl], *a_cellData[lvl], a_domains[lvl]);
+    DataOps::averageCellVelocityToFaceVelocity(*a_faceData[lvl], *a_cellData[lvl], a_domains[lvl]);
   }
 }
 
 void
-DataOps::averageCellVectorToFaceScalar(LevelData<EBFluxFAB>&       a_faceData,
-                                       const LevelData<EBCellFAB>& a_cellData,
-                                       const ProblemDomain&        a_domain)
+DataOps::averageCellVelocityToFaceVelocity(LevelData<EBFluxFAB>&       a_faceData,
+                                           const LevelData<EBCellFAB>& a_cellData,
+                                           const ProblemDomain&        a_domain)
 {
-  CH_TIME("DataOps::averageCellVectorToFaceScalar");
+  CH_TIME("DataOps::averageCellVelocityToFaceVelocity");
 
   CH_assert(a_faceData.nComp() == 1);
   CH_assert(a_cellData.nComp() == SpaceDim);


### PR DESCRIPTION
## Summary

By default, EbCoarAve (now EBCoarAve) mostly did conservative coarsening; it can now do arithmetic/harmonic/conservative coarsening for cell, face, and EB-centered data.

This PR also does the following:

1. Improves convergence for geometric multigrid by swapping to arithmetic coarsening of the B-coefficient; this is helpful for B-coefficents that vary by orders of magnitude close to the EB.

2. Fixes corner transport upwind domain boundary conditions. 

## Intent

- [x] Fix a bug or incorrect behavior.
- [x] Add new capabilities.

## Checklist

- [ ] If relevant, add Sphinx documentation in the rst files. 
- [x] Add doxygen documentation. 
