### PR TITLE
Rename LookupTable

### DIFF
--- a/Exec/Examples/StreamerInception/ElectrodeRoughness/program.cpp
+++ b/Exec/Examples/StreamerInception/ElectrodeRoughness/program.cpp
@@ -2,7 +2,7 @@
 #include <CD_NoisePlane.H>
 #include <CD_StreamerInceptionStepper.H>
 #include <CD_StreamerInceptionTagger.H>
-#include <CD_LookupTable.H>
+#include <CD_LookupTable1D.H>
 #include <CD_DataParser.H>
 #include <ParmParse.H>
 
@@ -28,12 +28,12 @@ main(int argc, char* argv[])
   // Read ionization and attachment coefficients and make them into functions.
   constexpr Real N = 2.45E25;
 
-  LookupTable<2> ionizationData = DataParser::fractionalFileReadASCII("sf6.dat",
-                                                                      "E/N (Td)	Townsend ioniz. coef. alpha/N (m2)",
-                                                                      "");
-  LookupTable<2> attachmentData = DataParser::fractionalFileReadASCII("sf6.dat",
-                                                                      "E/N (Td)	Townsend attach. coef. eta/N (m2)",
-                                                                      "");
+  LookupTable1D<2> ionizationData = DataParser::fractionalFileReadASCII("sf6.dat",
+                                                                        "E/N (Td)	Townsend ioniz. coef. alpha/N (m2)",
+                                                                        "");
+  LookupTable1D<2> attachmentData = DataParser::fractionalFileReadASCII("sf6.dat",
+                                                                        "E/N (Td)	Townsend attach. coef. eta/N (m2)",
+                                                                        "");
 
   ionizationData.setRange(10, 4000, 0);
   attachmentData.setRange(10, 4000, 0);

--- a/Exec/Examples/StreamerInception/Vessel/program.cpp
+++ b/Exec/Examples/StreamerInception/Vessel/program.cpp
@@ -2,7 +2,7 @@
 #include <CD_Vessel.H>
 #include <CD_StreamerInceptionStepper.H>
 #include <CD_StreamerInceptionTagger.H>
-#include <CD_LookupTable.H>
+#include <CD_LookupTable1D.H>
 #include <CD_DataParser.H>
 #include <ParmParse.H>
 
@@ -27,12 +27,12 @@ main(int argc, char* argv[])
   const Real N2 = 0.8;
   const Real T  = 300.0;
 
-  LookupTable<2> ionizationData = DataParser::fractionalFileReadASCII("transport_data.txt",
-                                                                      "E/N (Td)	Townsend ioniz. coef. alpha/N (m2)",
-                                                                      "");
-  LookupTable<2> attachmentData = DataParser::fractionalFileReadASCII("transport_data.txt",
-                                                                      "E/N (Td)	Townsend attach. coef. eta/N (m2)",
-                                                                      "");
+  LookupTable1D<2> ionizationData = DataParser::fractionalFileReadASCII("transport_data.txt",
+                                                                        "E/N (Td)	Townsend ioniz. coef. alpha/N (m2)",
+                                                                        "");
+  LookupTable1D<2> attachmentData = DataParser::fractionalFileReadASCII("transport_data.txt",
+                                                                        "E/N (Td)	Townsend attach. coef. eta/N (m2)",
+                                                                        "");
 
   ionizationData.setRange(10, 2000, 0);
   attachmentData.setRange(10, 2000, 0);

--- a/Exec/Tests/StreamerInception/Vessel/program.cpp
+++ b/Exec/Tests/StreamerInception/Vessel/program.cpp
@@ -2,7 +2,7 @@
 #include <CD_Vessel.H>
 #include <CD_StreamerInceptionStepper.H>
 #include <CD_StreamerInceptionTagger.H>
-#include <CD_LookupTable.H>
+#include <CD_LookupTable1D.H>
 #include <CD_DataParser.H>
 #include <ParmParse.H>
 
@@ -27,12 +27,12 @@ main(int argc, char* argv[])
   const Real N2 = 0.8;
   const Real T  = 300.0;
 
-  LookupTable<2> ionizationData = DataParser::fractionalFileReadASCII("transport_data.txt",
-                                                                      "E/N (Td)	Townsend ioniz. coef. alpha/N (m2)",
-                                                                      "");
-  LookupTable<2> attachmentData = DataParser::fractionalFileReadASCII("transport_data.txt",
-                                                                      "E/N (Td)	Townsend attach. coef. eta/N (m2)",
-                                                                      "");
+  LookupTable1D<2> ionizationData = DataParser::fractionalFileReadASCII("transport_data.txt",
+                                                                        "E/N (Td)	Townsend ioniz. coef. alpha/N (m2)",
+                                                                        "");
+  LookupTable1D<2> attachmentData = DataParser::fractionalFileReadASCII("transport_data.txt",
+                                                                        "E/N (Td)	Townsend attach. coef. eta/N (m2)",
+                                                                        "");
 
   ionizationData.setRange(10, 2000, 0);
   attachmentData.setRange(10, 2000, 0);

--- a/Physics/CdrPlasma/PlasmaModels/CdrPlasmaJSON/CD_CdrPlasmaJSON.H
+++ b/Physics/CdrPlasma/PlasmaModels/CdrPlasmaJSON/CD_CdrPlasmaJSON.H
@@ -31,7 +31,7 @@
 #include <CD_CdrPlasmaReactionJSON.H>
 #include <CD_CdrPlasmaPhotoReactionJSON.H>
 #include <CD_CdrPlasmaSurfaceReactionJSON.H>
-#include <CD_LookupTable.H>
+#include <CD_LookupTable1D.H>
 #include <CD_NamespaceHeader.H>
 
 using json = nlohmann::json;
@@ -524,12 +524,12 @@ namespace Physics {
       /*!
 	@brief For when we can put alpha = table(E,N)
       */
-      LookupTable<2> m_alphaTableEN;
+      LookupTable1D<2> m_alphaTableEN;
 
       /*!
 	@brief For when we can put eta = table(E,N)
       */
-      LookupTable<2> m_etaTableEN;
+      LookupTable1D<2> m_etaTableEN;
 
       // ================================
       // MOBILITY QUANTITIES BEGIN HERE
@@ -558,13 +558,13 @@ namespace Physics {
       /*!
 	@brief Map for table-based mobilities. Stored as tables (E/N, mu*N)
       */
-      std::map<int, LookupTable<2>> m_mobilityTablesEN;
+      std::map<int, LookupTable1D<2>> m_mobilityTablesEN;
 
       /*!
 	@brief Map for table-based mobilities as function of energy. 
 	@details Stored as tables (eV, mu*N)
       */
-      std::map<int, LookupTable<2>> m_mobilityTablesEnergy;
+      std::map<int, LookupTable1D<2>> m_mobilityTablesEnergy;
 
       // ================================
       // DIFFUSION  QUANTITIES BEGIN HERE
@@ -589,13 +589,13 @@ namespace Physics {
 	@brief Map for table-based diffusion coefficients D = D(E,N).
 	@details Tables stored as (E/N, D*N)
       */
-      std::map<int, LookupTable<2>> m_diffusionTablesEN;
+      std::map<int, LookupTable1D<2>> m_diffusionTablesEN;
 
       /*!
 	@brief Map for table-based diffusion coefficients as function of energy. 
 	@details Stored as tables (eV, D*N)
       */
-      std::map<int, LookupTable<2>> m_diffusionTablesEnergy;
+      std::map<int, LookupTable1D<2>> m_diffusionTablesEnergy;
 
       // ===========================================
       // PLASMA SPECIES TEMPERATURE DATA BEGINS HERE
@@ -614,7 +614,7 @@ namespace Physics {
       /*!
 	@brief Temperatures as functions of E/N. 
       */
-      std::map<int, LookupTable<2>> m_temperatureTablesEN;
+      std::map<int, LookupTable1D<2>> m_temperatureTablesEN;
 
       // ================================
       // REACTION DATA BEGINS HERE
@@ -664,13 +664,13 @@ namespace Physics {
       /*!
 	@brief Map for table-based reaction coefficients, where k = k(E,N).
       */
-      std::map<int, LookupTable<2>> m_plasmaReactionTablesEN;
+      std::map<int, LookupTable1D<2>> m_plasmaReactionTablesEN;
 
       /*!
 	@brief Map for table-based reaction coefficients where k = k(energy).
 	@details The first index is the reaction index, while the pair describes which species energy and the tabulated data. 
       */
-      std::map<int, std::pair<int, LookupTable<2>>> m_plasmaReactionTablesEnergy;
+      std::map<int, std::pair<int, LookupTable1D<2>>> m_plasmaReactionTablesEnergy;
 
       /*!
 	@brief Scaled plasma reactions. These account for e.g. reaction efficiencies, collisional quenching, etc. 

--- a/Physics/CdrPlasma/PlasmaModels/CdrPlasmaJSON/CD_CdrPlasmaJSON.cpp
+++ b/Physics/CdrPlasma/PlasmaModels/CdrPlasmaJSON/CD_CdrPlasmaJSON.cpp
@@ -489,9 +489,9 @@ CdrPlasmaJSON::initializeNeutralSpecies()
       this->throwParserError(baseError + " and got tabulated gas law but file = '" + filename + "' was not found");
 
     // Let the data parser read the input.
-    LookupTable<2> temperatureTable = DataParser::simpleFileReadASCII(filename, height, T);
-    LookupTable<2> pressureTable    = DataParser::simpleFileReadASCII(filename, height, P);
-    LookupTable<2> densityTable     = DataParser::simpleFileReadASCII(filename, height, Rho);
+    LookupTable1D<2> temperatureTable = DataParser::simpleFileReadASCII(filename, height, T);
+    LookupTable1D<2> pressureTable    = DataParser::simpleFileReadASCII(filename, height, P);
+    LookupTable1D<2> densityTable     = DataParser::simpleFileReadASCII(filename, height, Rho);
 
     // Compute the number of points in the table
     const int numPoints = std::ceil((maxHeight - minHeight) / resHeight);
@@ -762,7 +762,7 @@ CdrPlasmaJSON::parsePlasmaSpeciesInitialData(const json& a_json) const
     std::vector<FunctionX> gauss4Functions;
 
     // Pointer to height profile table
-    LookupTable<2> heightProfile;
+    LookupTable1D<2> heightProfile;
 
     // Set the uniform density
     if (initData.contains("uniform")) {
@@ -895,7 +895,7 @@ CdrPlasmaJSON::parsePlasmaSpeciesInitialData(const json& a_json) const
       // Compute the number of points for the table
       const int numPoints = std::ceil((maxHeight - minHeight) / resHeight);
 
-      // Parse input file into our nifty little LookupTable.
+      // Parse input file into our nifty little LookupTable1D.
       heightProfile = DataParser::simpleFileReadASCII(filename, heightColumn, densityColumn);
 
       // Sort the table along the first column. This is the height above ground.
@@ -1478,7 +1478,7 @@ CdrPlasmaJSON::parseMobilities()
         // Read the table and format it. We happen to know that this function reads data into the approprate columns. So if
         // the user specified the correct E/N column then that data will be put in the first column. The data for mu*N will be in the
         // second column.
-        LookupTable<2> mobilityTable =
+        LookupTable1D<2> mobilityTable =
           DataParser::fractionalFileReadASCII(filename, startRead, stopRead, xColumn, yColumn);
 
         // If the table is empty then it's an error.
@@ -1566,7 +1566,7 @@ CdrPlasmaJSON::parseMobilities()
         // Read the table and format it. We happen to know that this function reads data into the approprate columns. So if
         // the user specified the correct eV column then that data will be put in the first column. The data for mu*N will be in the
         // second column.
-        LookupTable<2> mobilityTable =
+        LookupTable1D<2> mobilityTable =
           DataParser::fractionalFileReadASCII(filename, startRead, stopRead, xColumn, yColumn);
 
         // If the table is empty then it's an error.
@@ -1789,7 +1789,7 @@ CdrPlasmaJSON::parseDiffusion()
         // Read the table and format it. We happen to know that this function reads data into the approprate columns. So if
         // the user specified the correct E/N column then that data will be put in the first column. The data for D*N will be in the
         // second column.
-        LookupTable<2> diffusionTable =
+        LookupTable1D<2> diffusionTable =
           DataParser::fractionalFileReadASCII(filename, startRead, stopRead, xColumn, yColumn);
 
         // If the table is empty then it's an error.
@@ -1879,7 +1879,7 @@ CdrPlasmaJSON::parseDiffusion()
         // Read the table and format it. We happen to know that this function reads data into the approprate columns. So if
         // the user specified the correct E/N column then that data will be put in the first column. The data for D*N will be in the
         // second column.
-        LookupTable<2> diffusionTable =
+        LookupTable1D<2> diffusionTable =
           DataParser::fractionalFileReadASCII(filename, startRead, stopRead, xColumn, yColumn);
 
         // If the table is empty then it's an error.
@@ -2086,7 +2086,7 @@ CdrPlasmaJSON::parseTemperatures()
         // Read the table and format it. We happen to know that this function reads data into the approprate columns. So if
         // the user specified the correct E/N column then that data will be put in the first column. The data for D*N will be in the
         // second column.
-        LookupTable<2> temperatureTable =
+        LookupTable1D<2> temperatureTable =
           DataParser::fractionalFileReadASCII(filename, startRead, stopRead, xColumn, yColumn);
 
         // If the table is empty then it's an error.
@@ -2577,7 +2577,8 @@ CdrPlasmaJSON::parsePlasmaReactionRate(const int a_reactionIndex, const json& a_
     // Read the table and format it. We happen to know that this function reads data into the approprate columns. So if
     // the user specified the correct E/N column then that data will be put in the first column. The data for D*N will be in the
     // second column.
-    LookupTable<2> reactionTable = DataParser::fractionalFileReadASCII(filename, startRead, stopRead, xColumn, yColumn);
+    LookupTable1D<2> reactionTable =
+      DataParser::fractionalFileReadASCII(filename, startRead, stopRead, xColumn, yColumn);
 
     // If the table is empty then it's an error.
     if (reactionTable.getNumEntries() == 0) {
@@ -2656,7 +2657,8 @@ CdrPlasmaJSON::parsePlasmaReactionRate(const int a_reactionIndex, const json& a_
     // Read the table and format it. We happen to know that this function reads data into the approprate columns. So if
     // the user specified the correct E/N column then that data will be put in the first column. The data for D*N will be in the
     // second column.
-    LookupTable<2> reactionTable = DataParser::fractionalFileReadASCII(filename, startRead, stopRead, xColumn, yColumn);
+    LookupTable1D<2> reactionTable =
+      DataParser::fractionalFileReadASCII(filename, startRead, stopRead, xColumn, yColumn);
 
     // If the table is empty then it's an error.
     if (reactionTable.getNumEntries() == 0) {
@@ -4209,7 +4211,7 @@ CdrPlasmaJSON::computePlasmaSpeciesMobilities(const RealVect&          a_positio
       }
       case LookupMethod::TableEN: {
         // Recall; the mobility tables are stored as (E/N, mu*N) so we need to extract mu from that.
-        const LookupTable<2>& mobilityTable = m_mobilityTablesEN.at(i);
+        const LookupTable1D<2>& mobilityTable = m_mobilityTablesEN.at(i);
 
         mu[i] = mobilityTable.getEntry<1>(Etd); // Get mu*N
         mu[i] /= N;                             // Get mu
@@ -4217,7 +4219,7 @@ CdrPlasmaJSON::computePlasmaSpeciesMobilities(const RealVect&          a_positio
         break;
       }
       case LookupMethod::TableEnergy: {
-        const LookupTable<2>& mobilityTable = m_mobilityTablesEnergy.at(i);
+        const LookupTable1D<2>& mobilityTable = m_mobilityTablesEnergy.at(i);
 
         mu[i] = mobilityTable.getEntry<1>(energies[i]);
         mu[i] /= N;
@@ -4284,7 +4286,7 @@ CdrPlasmaJSON::computePlasmaSpeciesDiffusion(const RealVect          a_pos,
       }
       case LookupMethod::TableEN: {
         // Recall; the diffusion tables are stored as (E/N, D*N) so we need to extract D from that.
-        const LookupTable<2>& diffusionTable = m_diffusionTablesEN.at(i);
+        const LookupTable1D<2>& diffusionTable = m_diffusionTablesEN.at(i);
 
         Dco = diffusionTable.getEntry<1>(Etd); // Get D*N
         Dco /= N;                              // Get D
@@ -4293,7 +4295,7 @@ CdrPlasmaJSON::computePlasmaSpeciesDiffusion(const RealVect          a_pos,
       }
       case LookupMethod::TableEnergy: {
         // Recall: The diffusion tables are stored as (eV, D*N) so we just get D from that.
-        const LookupTable<2>& diffusionTable = m_diffusionTablesEnergy.at(i);
+        const LookupTable1D<2>& diffusionTable = m_diffusionTablesEnergy.at(i);
 
         Dco = diffusionTable.getEntry<1>(energies[i]);
         Dco /= N;
@@ -4396,7 +4398,7 @@ CdrPlasmaJSON::computePlasmaSpeciesEnergies(const RealVect&          a_position,
         }
         case LookupMethod::TableEN: {
           // Recall; the temperature tables are stored as (E/N, K) so we can fetch the temperature immediately.
-          const LookupTable<2>& temperatureTable = m_temperatureTablesEN.at(i);
+          const LookupTable1D<2>& temperatureTable = m_temperatureTablesEN.at(i);
 
           T = temperatureTable.getEntry<1>(Etd);
 
@@ -4478,7 +4480,7 @@ CdrPlasmaJSON::computePlasmaReactionRate(const int&                   a_reaction
   }
   case LookupMethod::TableEN: {
     // Recall; the reaction tables are stored as (E/N, rate/N) so we need to extract mu from that.
-    const LookupTable<2>& reactionTable = m_plasmaReactionTablesEN.at(a_reactionIndex);
+    const LookupTable1D<2>& reactionTable = m_plasmaReactionTablesEN.at(a_reactionIndex);
 
     // Get the reaction rate.
     k = reactionTable.getEntry<1>(a_Etd);
@@ -4491,8 +4493,8 @@ CdrPlasmaJSON::computePlasmaReactionRate(const int&                   a_reaction
     break;
   }
   case LookupMethod::TableEnergy: {
-    const int&            speciesIndex  = m_plasmaReactionTablesEnergy.at(a_reactionIndex).first;
-    const LookupTable<2>& reactionTable = m_plasmaReactionTablesEnergy.at(a_reactionIndex).second;
+    const int&              speciesIndex  = m_plasmaReactionTablesEnergy.at(a_reactionIndex).first;
+    const LookupTable1D<2>& reactionTable = m_plasmaReactionTablesEnergy.at(a_reactionIndex).second;
 
     const Real energy = a_cdrEnergies[speciesIndex];
 

--- a/Physics/ItoPlasma/CD_ItoPlasmaPhysics.H
+++ b/Physics/ItoPlasma/CD_ItoPlasmaPhysics.H
@@ -33,7 +33,7 @@
 #include <CD_ItoParticle.H>
 #include <CD_ItoPlasmaReaction.H>
 #include <CD_ItoPlasmaPhotoReaction.H>
-#include <CD_LookupTable.H>
+#include <CD_LookupTable1D.H>
 #include <CD_NamespaceHeader.H>
 
 namespace Physics {
@@ -285,7 +285,7 @@ namespace Physics {
       mutable std::map<std::string, ItoPlasmaPhotoReaction> m_photoReactions;
 
       // Lookup tables if you need them.
-      std::map<std::string, LookupTable<2>> m_tables;
+      std::map<std::string, LookupTable1D<2>> m_tables;
 
       /*!
 	@brief Add a table
@@ -297,7 +297,7 @@ namespace Physics {
 	@brief Read a file and put it in a lookup table
       */
       void
-      readFile(LookupTable<2>& a_table, const std::string a_file);
+      readFile(LookupTable1D<2>& a_table, const std::string a_file);
 
       /*!
 	@brief Draw a valid random position somewhere in a cell

--- a/Physics/ItoPlasma/CD_ItoPlasmaPhysics.cpp
+++ b/Physics/ItoPlasma/CD_ItoPlasmaPhysics.cpp
@@ -92,7 +92,7 @@ void
 ItoPlasmaPhysics::addTable(const std::string a_table_name, const std::string a_file)
 {
 
-  LookupTable<2> table;
+  LookupTable1D<2> table;
 
   this->readFile(table, a_file); // Read file
   table.sort();
@@ -101,7 +101,7 @@ ItoPlasmaPhysics::addTable(const std::string a_table_name, const std::string a_f
 }
 
 void
-ItoPlasmaPhysics::readFile(LookupTable<2>& a_table, const std::string a_file)
+ItoPlasmaPhysics::readFile(LookupTable1D<2>& a_table, const std::string a_file)
 {
 
   Real x, y;

--- a/Physics/ItoPlasma/PlasmaModels/ItoPlasmaAir3LEA/CD_ItoPlasmaAir3LEA.H
+++ b/Physics/ItoPlasma/PlasmaModels/ItoPlasmaAir3LEA/CD_ItoPlasmaAir3LEA.H
@@ -14,7 +14,7 @@
 
 // Our includes
 #include <CD_ItoPlasmaPhysicsLEA.H>
-#include <CD_LookupTable.H>
+#include <CD_LookupTable1D.H>
 #include <CD_NamespaceHeader.H>
 
 namespace Physics {
@@ -89,7 +89,7 @@ namespace Physics {
     {
     public:
       Electron() = default;
-      Electron(const LookupTable& a_mobility, const LookupTable& a_diffusion);
+      Electron(const LookupTable1D& a_mobility, const LookupTable1D& a_diffusion);
       ~Electron();
 
       Real
@@ -98,8 +98,8 @@ namespace Physics {
       diffusion(const Real a_energy) const override;
 
     protected:
-      LookupTable m_mobility;
-      LookupTable m_diffusion;
+      LookupTable1D m_mobility;
+      LookupTable1D m_diffusion;
     };
 
     class ItoPlasmaAir3LEA::Positive : public ItoSpecies

--- a/Physics/ItoPlasma/PlasmaModels/ItoPlasmaAir3LEA/CD_ItoPlasmaAir3LEA.cpp
+++ b/Physics/ItoPlasma/PlasmaModels/ItoPlasmaAir3LEA/CD_ItoPlasmaAir3LEA.cpp
@@ -235,7 +235,7 @@ ItoPlasmaAir3LEA::photoionizationRate(const Real a_E) const
   return excitationRates(a_E) * sergeyFactor(m_O2frac) * m_photoi_factor;
 }
 
-ItoPlasmaAir3LEA::Electron::Electron(const LookupTable& a_mobility, const LookupTable& a_diffusion)
+ItoPlasmaAir3LEA::Electron::Electron(const LookupTable1D& a_mobility, const LookupTable1D& a_diffusion)
   : m_mobility(a_mobility), m_diffusion(a_diffusion)
 {
   m_isMobile     = true;

--- a/Physics/ItoPlasma/PlasmaModels/ItoPlasmaAir3LFA/CD_ItoPlasmaAir3LFA.H
+++ b/Physics/ItoPlasma/PlasmaModels/ItoPlasmaAir3LFA/CD_ItoPlasmaAir3LFA.H
@@ -14,7 +14,7 @@
 
 // Our includes
 #include <CD_ItoPlasmaPhysicsLFA.H>
-#include <CD_LookupTable.H>
+#include <CD_LookupTable1D.H>
 #include <CD_NamespaceHeader.H>
 
 namespace Physics {

--- a/Source/Utilities/CD_DataParser.H
+++ b/Source/Utilities/CD_DataParser.H
@@ -13,7 +13,7 @@
 #define CD_DataParser_H
 
 // Our includes
-#include <CD_LookupTable.H>
+#include <CD_LookupTable1D.H>
 #include <CD_NamespaceHeader.H>
 
 /*!
@@ -23,16 +23,16 @@ namespace DataParser {
 
   /*!
     @brief Simple file parser which reads a file and puts the data into two columns (a lookup table). 
-    @details This will read ASCII row/column data into a LookupTable (which is a simple x-y data structure). The user can specify which columns
-    to use as the x and y coordinates in the LookupTable. If the user ask for a column that does not exist in the input file, the data will not be read
-    into the LookupTable. 
+    @details This will read ASCII row/column data into a LookupTable1D (which is a simple x-y data structure). The user can specify which columns
+    to use as the x and y coordinates in the LookupTable1D. If the user ask for a column that does not exist in the input file, the data will not be read
+    into the LookupTable1D. 
     @param[in] a_fileName    Input file name. Must be an ASCII file organized into rows and columns. 
     @param[in] a_xColumn     Which column to use as the x-column. 
     @param[in] a_yColumn     Which column to use as the y-column. 
     @param[in] a_ignoreChars Characters indicating comments in the file. Lines starting with these characters are ignored. 
     @note xColumn = 0 is the FIRST column, xColumn=1 is the SECOND column and so on. 
   */
-  static LookupTable<2>
+  static LookupTable1D<2>
   simpleFileReadASCII(const std::string       a_fileName,
                       const int               a_xColumn     = 0,
                       const int               a_yColumn     = 1,
@@ -51,7 +51,7 @@ namespace DataParser {
     @param[in] a_yColumn     Which column to use as the y-column. 
     @param[in] a_ignoreChars Characters indicating comments in the file. Lines starting with these characters are ignored. 
   */
-  static LookupTable<2>
+  static LookupTable1D<2>
   fractionalFileReadASCII(const std::string       a_fileName,
                           const std::string       a_startRead,
                           const std::string       a_stopRead,

--- a/Source/Utilities/CD_DataParserImplem.H
+++ b/Source/Utilities/CD_DataParserImplem.H
@@ -23,14 +23,14 @@
 #include <CD_DataParser.H>
 #include <CD_NamespaceHeader.H>
 
-LookupTable<2>
+LookupTable1D<2>
 DataParser::simpleFileReadASCII(const std::string       a_fileName,
                                 const int               a_xColumn,
                                 const int               a_yColumn,
                                 const std::vector<char> a_ignoreChars)
 {
   // This is the return table. It will be populated as we read the file.
-  LookupTable<2> returnTable = LookupTable<2>();
+  LookupTable1D<2> returnTable = LookupTable1D<2>();
 
   // Open an input file stream and start reading lines.
   std::ifstream inputFile(a_fileName);
@@ -65,7 +65,7 @@ DataParser::simpleFileReadASCII(const std::string       a_fileName,
           values.emplace_back(curVal);
         }
 
-        // Read the data into the LookupTable IF we have enough data in the input file. Rows that do not have enough data WILL be ignored.
+        // Read the data into the LookupTable1D IF we have enough data in the input file. Rows that do not have enough data WILL be ignored.
         const int numColumnsOnThisLine = values.size();
         if (a_xColumn < numColumnsOnThisLine && a_yColumn < numColumnsOnThisLine) {
           returnTable.addEntry(values[a_xColumn], values[a_yColumn]);
@@ -77,7 +77,7 @@ DataParser::simpleFileReadASCII(const std::string       a_fileName,
   return returnTable;
 }
 
-LookupTable<2>
+LookupTable1D<2>
 DataParser::fractionalFileReadASCII(const std::string       a_fileName,
                                     const std::string       a_startRead,
                                     const std::string       a_stopRead,
@@ -86,7 +86,7 @@ DataParser::fractionalFileReadASCII(const std::string       a_fileName,
                                     const std::vector<char> a_ignoreChars)
 {
   // This is the return table. It will be populated as we read the file.
-  LookupTable<2> returnTable = LookupTable<2>();
+  LookupTable1D<2> returnTable = LookupTable1D<2>();
 
   // Open an input file stream and start reading lines.
   bool          parseLine = false;
@@ -128,7 +128,7 @@ DataParser::fractionalFileReadASCII(const std::string       a_fileName,
           values.emplace_back(curVal);
         }
 
-        // Read the data into the LookupTable IF we have enough data in the input file. Rows that do not have enough
+        // Read the data into the LookupTable1D IF we have enough data in the input file. Rows that do not have enough
         // data WILL be ignored.
         const int numColumnsOnThisLine = values.size();
         if (a_xColumn < numColumnsOnThisLine && a_yColumn < numColumnsOnThisLine) {

--- a/Source/Utilities/CD_LookupTable1D.H
+++ b/Source/Utilities/CD_LookupTable1D.H
@@ -4,13 +4,13 @@
  */
 
 /*!
-  @file   CD_LookupTable.H
+  @file   CD_LookupTable1D.H
   @brief  Declaration of a table for looking up coefficients etc. 
   @author Robert Marskar
 */
 
-#ifndef CD_LookupTable_H
-#define CD_LookupTable_H
+#ifndef CD_LookupTable1D_H
+#define CD_LookupTable1D_H
 
 // Std includes
 #include <iostream>
@@ -35,7 +35,7 @@ enum class OutOfRangeStrategy
 };
 
 /*!
-  @brief For identifying columns in the LookupTable.
+  @brief For identifying columns in the LookupTable1D.
 */
 enum StateStatus
 {
@@ -57,23 +57,23 @@ enum class TableSpacing
   @brief Class for looking up and interpolation (x,y) data. 
 */
 template <int N>
-class LookupTable
+class LookupTable1D
 {
 public:
   /*!
     @brief Default constructor. Creates a table without any entries. 
   */
-  LookupTable();
+  LookupTable1D();
 
   /*!
     @brief Copy constructor. 
   */
-  LookupTable(const LookupTable& a_table);
+  LookupTable1D(const LookupTable1D& a_table);
 
   /*!
     @brief Destructor (does nothing). 
   */
-  virtual ~LookupTable();
+  virtual ~LookupTable1D();
 
   /*!
     @brief Clear all data
@@ -242,6 +242,6 @@ protected:
 
 #include <CD_NamespaceFooter.H>
 
-#include <CD_LookupTableImplem.H>
+#include <CD_LookupTable1DImplem.H>
 
 #endif

--- a/Source/Utilities/CD_LookupTable1DImplem.H
+++ b/Source/Utilities/CD_LookupTable1DImplem.H
@@ -4,13 +4,13 @@
  */
 
 /*!
-  @file   CD_LookupTableImplem.H
-  @brief  Implementation of CD_LookupTable.H
+  @file   CD_LookupTable1DImplem.H
+  @brief  Implementation of CD_LookupTable1D.H
   @author Robert Marskar
 */
 
-#ifndef CD_LookupTableImplem_H
-#define CD_LookupTableImplem_H
+#ifndef CD_LookupTable1DImplem_H
+#define CD_LookupTable1DImplem_H
 
 // Std includes
 #include <iostream>
@@ -19,11 +19,11 @@
 #include <math.h>
 
 // Our includes
-#include <CD_LookupTable.H>
+#include <CD_LookupTable1D.H>
 #include <CD_NamespaceHeader.H>
 
 template <int N>
-inline LookupTable<N>::LookupTable()
+inline LookupTable1D<N>::LookupTable1D()
 {
 
   // Default settings
@@ -35,11 +35,11 @@ inline LookupTable<N>::LookupTable()
 }
 
 template <int N>
-inline LookupTable<N>::~LookupTable()
+inline LookupTable1D<N>::~LookupTable1D()
 {}
 
 template <int N>
-inline LookupTable<N>::LookupTable(const LookupTable& a_table)
+inline LookupTable1D<N>::LookupTable1D(const LookupTable1D& a_table)
 {
   m_data    = a_table.m_data;
   m_state   = a_table.m_state;
@@ -53,7 +53,7 @@ inline LookupTable<N>::LookupTable(const LookupTable& a_table)
 template <int N>
 template <typename... Ts>
 inline void
-LookupTable<N>::addEntry(const Ts&... x)
+LookupTable1D<N>::addEntry(const Ts&... x)
 {
   std::array<Real, sizeof...(Ts)> arr = {x...};
   m_data.emplace_back(arr);
@@ -64,7 +64,7 @@ LookupTable<N>::addEntry(const Ts&... x)
 
 template <int N>
 inline void
-LookupTable<N>::sort(const int a_sortedColumn)
+LookupTable1D<N>::sort(const int a_sortedColumn)
 {
 
   auto comparator = [idx = a_sortedColumn](const std::array<Real, N>& a, const std::array<Real, N>& b) -> bool {
@@ -80,7 +80,7 @@ LookupTable<N>::sort(const int a_sortedColumn)
 template <int N>
 template <int K>
 inline void
-LookupTable<N>::scale(const Real a_scale)
+LookupTable1D<N>::scale(const Real a_scale)
 {
   for (auto& r : m_data) {
     r[K] *= a_scale;
@@ -93,7 +93,7 @@ LookupTable<N>::scale(const Real a_scale)
 
 template <int N>
 inline void
-LookupTable<N>::swap(const int a_column1, const int a_column2)
+LookupTable1D<N>::swap(const int a_column1, const int a_column2)
 {
   for (auto& r : m_data) {
     const Real tmp = r[a_column1];
@@ -115,14 +115,14 @@ LookupTable<N>::swap(const int a_column1, const int a_column2)
 
 template <int N>
 inline void
-LookupTable<N>::clear()
+LookupTable1D<N>::clear()
 {
   m_data.resize(0);
 }
 
 template <int N>
 inline void
-LookupTable<N>::setRange(const Real a_min, const Real a_max, const int a_colRange)
+LookupTable1D<N>::setRange(const Real a_min, const Real a_max, const int a_colRange)
 {
 
   // Do a backup of the data and reset data holder.
@@ -141,21 +141,21 @@ LookupTable<N>::setRange(const Real a_min, const Real a_max, const int a_colRang
 
 template <int N>
 inline void
-LookupTable<N>::setOutOfRangeStrategyLow(const OutOfRangeStrategy a_strategy)
+LookupTable1D<N>::setOutOfRangeStrategyLow(const OutOfRangeStrategy a_strategy)
 {
   m_strategyLo = a_strategy;
 }
 
 template <int N>
 inline void
-LookupTable<N>::setOutOfRangeStrategyHigh(const OutOfRangeStrategy a_strategy)
+LookupTable1D<N>::setOutOfRangeStrategyHigh(const OutOfRangeStrategy a_strategy)
 {
   m_strategyHi = a_strategy;
 }
 
 template <int N>
 inline void
-LookupTable<N>::setTableSpacing(const TableSpacing a_spacing)
+LookupTable1D<N>::setTableSpacing(const TableSpacing a_spacing)
 {
 
   // If we change the table spacing, we are no longer in "uniform" mode.
@@ -168,7 +168,7 @@ LookupTable<N>::setTableSpacing(const TableSpacing a_spacing)
 
 template <int N>
 inline void
-LookupTable<N>::dumpTable(std::ostream& a_outputStream) const
+LookupTable1D<N>::dumpTable(std::ostream& a_outputStream) const
 {
   for (const auto& r : m_data) {
     for (const auto& c : r) {
@@ -180,7 +180,7 @@ LookupTable<N>::dumpTable(std::ostream& a_outputStream) const
 
 template <int N>
 inline void
-LookupTable<N>::dumpTable(const std::string a_fileName) const
+LookupTable1D<N>::dumpTable(const std::string a_fileName) const
 {
 #ifdef CH_MPI
   if (procID() == 0) {
@@ -205,7 +205,7 @@ LookupTable<N>::dumpTable(const std::string a_fileName) const
 
 template <int N>
 inline int
-LookupTable<N>::getIndexLo(const Real a_x) const
+LookupTable1D<N>::getIndexLo(const Real a_x) const
 {
   int index = 0;
 
@@ -227,7 +227,7 @@ LookupTable<N>::getIndexLo(const Real a_x) const
     break;
   }
   default: {
-    MayDay::Error("LookupTable<N>::getIndexLo - logic bust");
+    MayDay::Error("LookupTable1D<N>::getIndexLo - logic bust");
   }
   }
 
@@ -237,7 +237,7 @@ LookupTable<N>::getIndexLo(const Real a_x) const
 template <int N>
 template <int K>
 inline Real
-LookupTable<N>::getEntry(const Real a_x) const
+LookupTable1D<N>::getEntry(const Real a_x) const
 {
 
   // TLDR: This is the main routine for fetching a column of data. This will switch between constant/linear interpolation outside of
@@ -290,7 +290,7 @@ LookupTable<N>::getEntry(const Real a_x) const
         break;
       }
       default:
-        MayDay::Error("LookupTable<N>::getEntry -- logic bust when fetching out-of-range endpoint on the low side");
+        MayDay::Error("LookupTable1D<N>::getEntry -- logic bust when fetching out-of-range endpoint on the low side");
 
         break;
       }
@@ -328,7 +328,7 @@ LookupTable<N>::getEntry(const Real a_x) const
         break;
       }
       default:
-        MayDay::Error("LookupTable<N>::getEntry -- logic bust when fetching out-of-range endpoint on the high side");
+        MayDay::Error("LookupTable1D<N>::getEntry -- logic bust when fetching out-of-range endpoint on the high side");
 
         break;
       }
@@ -351,7 +351,7 @@ LookupTable<N>::getEntry(const Real a_x) const
 
 template <int N>
 inline std::array<Real, N>
-LookupTable<N>::getData(const Real a_x) const
+LookupTable1D<N>::getData(const Real a_x) const
 {
 
   std::array<Real, N> ret;
@@ -395,7 +395,7 @@ LookupTable<N>::getData(const Real a_x) const
         break;
       }
       default:
-        MayDay::Error("LookupTable<N>::getData -- logic bust when fetching out-of-range endpoint on the low side");
+        MayDay::Error("LookupTable1D<N>::getData -- logic bust when fetching out-of-range endpoint on the low side");
 
         break;
       }
@@ -429,13 +429,13 @@ LookupTable<N>::getData(const Real a_x) const
         break;
       }
       default:
-        MayDay::Error("LookupTable<N>::getEntry -- logic bust when fetching out-of-range endpoint on the high side");
+        MayDay::Error("LookupTable1D<N>::getEntry -- logic bust when fetching out-of-range endpoint on the high side");
 
         break;
       }
     }
     else {
-      MayDay::Error("LookupTable<N>::getEntry (array version -- spacing is wrong");
+      MayDay::Error("LookupTable1D<N>::getEntry (array version -- spacing is wrong");
       const Real t = (a_x - m_data[idx][sortedColumn]) / m_delta;
 
       // Interpolate all variables.
@@ -450,12 +450,12 @@ LookupTable<N>::getData(const Real a_x) const
 
 template <int N>
 inline std::array<Real, N>
-LookupTable<N>::directLookup(const Real a_x) const
+LookupTable1D<N>::directLookup(const Real a_x) const
 {
 
   std::array<Real, N> ret;
   if (!std::get<Sorted>(m_state)) {
-    std::cerr << "LookupTable<N>::directLookup -- logic bust. Data must be sorted along the input column!\n";
+    std::cerr << "LookupTable1D<N>::directLookup -- logic bust. Data must be sorted along the input column!\n";
   }
   else {
     const int column = std::get<Column>(m_state);
@@ -491,7 +491,7 @@ LookupTable<N>::directLookup(const Real a_x) const
 
 template <int N>
 inline void
-LookupTable<N>::makeUniform(const int a_numRows)
+LookupTable1D<N>::makeUniform(const int a_numRows)
 {
 
   if (std::get<Sorted>(m_state)) {
@@ -530,7 +530,7 @@ LookupTable<N>::makeUniform(const int a_numRows)
         break;
       }
       default: {
-        MayDay::Error("LookupTable<N>::makeUniform - logic bust");
+        MayDay::Error("LookupTable1D<N>::makeUniform - logic bust");
       }
       }
 
@@ -548,17 +548,17 @@ LookupTable<N>::makeUniform(const int a_numRows)
       std::get<Uniform>(m_state) = true;
     }
     else {
-      std::cerr << "LookupTable<N>::makeUniform -- must have at least two rows!\n";
+      std::cerr << "LookupTable1D<N>::makeUniform -- must have at least two rows!\n";
     }
   }
   else {
-    std::cerr << "LookupTable<N>::makeUniform -- must sort the column along one of the coordinates first!\n";
+    std::cerr << "LookupTable1D<N>::makeUniform -- must sort the column along one of the coordinates first!\n";
   }
 }
 
 template <int N>
 inline int
-LookupTable<N>::getNumEntries() const
+LookupTable1D<N>::getNumEntries() const
 {
   return m_data.size();
 }


### PR DESCRIPTION
## Summary

Rename LookupTable as LookupTable1D to indicate the number of independent variables. 

## Intent

- [ ] Fix a bug or incorrect behavior.
- [ ] Add new capabilities.

## Checklist

- [ ] If relevant, add Sphinx documentation in the rst files. 
- [ ] Add doxygen documentation. 
