### PR TITLE
Optimizations for linear solvers

### DIFF
--- a/Exec/Examples/Electrostatics/ProfiledSurface/example3d.inputs
+++ b/Exec/Examples/Electrostatics/ProfiledSurface/example3d.inputs
@@ -83,13 +83,13 @@ FieldSolverMultigrid.gmg_min_iter      = 5         # Minimum number of iteration
 FieldSolverMultigrid.gmg_max_iter      = 32        # Maximum number of iterations
 FieldSolverMultigrid.gmg_exit_tol      = 1.E-10    # Residue tolerance
 FieldSolverMultigrid.gmg_exit_hang     = 0.2       # Solver hang
-FieldSolverMultigrid.gmg_min_cells     = 16         # Bottom drop
+FieldSolverMultigrid.gmg_min_cells     = 8         # Bottom drop
 FieldSolverMultigrid.gmg_drop_order    = 32                 # Drop stencil order to 1 if domain is coarser than this.
-FieldSolverMultigrid.gmg_bc_order      = 1         # Boundary condition order for multigrid
+FieldSolverMultigrid.gmg_bc_order      = 2         # Boundary condition order for multigrid
 FieldSolverMultigrid.gmg_bc_weight     = 1         # Boundary condition weights (for least squares)
-FieldSolverMultigrid.gmg_jump_order    = 1         # Boundary condition order for jump conditions
+FieldSolverMultigrid.gmg_jump_order    = 2         # Boundary condition order for jump conditions
 FieldSolverMultigrid.gmg_jump_weight   = 1         # Boundary condition weight for jump conditions (for least squares)
-FieldSolverMultigrid.gmg_bottom_solver = simple 512  # Bottom solver type. 'simple', 'bicgstab', or 'gmres'
+FieldSolverMultigrid.gmg_bottom_solver = simple 32  # Bottom solver type. 'simple', 'bicgstab', or 'gmres'
 FieldSolverMultigrid.gmg_cycle         = vcycle    # Cycle type. Only 'vcycle' supported for now
 FieldSolverMultigrid.gmg_smoother      = red_black # Relaxation type. 'jacobi', 'multi_color', or 'red_black'
 

--- a/Source/Electrostatics/CD_MFHelmholtzSaturationChargeJumpBC.H
+++ b/Source/Electrostatics/CD_MFHelmholtzSaturationChargeJumpBC.H
@@ -48,7 +48,7 @@ public:
                                     const int                a_weight,
                                     const int                a_radius,
                                     const int                a_ghostCF,
-				    const IntVect            a_ghostPhi);
+                                    const IntVect            a_ghostPhi);
 
   /*!
     @brief Destructor (does nothing)

--- a/Source/Electrostatics/CD_MFHelmholtzSaturationChargeJumpBC.H
+++ b/Source/Electrostatics/CD_MFHelmholtzSaturationChargeJumpBC.H
@@ -37,6 +37,7 @@ public:
     @param[in] a_weight       Weighting factor for least squares
     @param[in] a_radius       Stencil radius
     @param[in] a_ghostCF      Number of grid cells that were filled across the CF. 
+    @param[in] a_ghostPhi     Number of ghost cells in phi (needed for AggStencil)
   */
   MFHelmholtzSaturationChargeJumpBC(const phase::which_phase a_phase,
                                     const Location::Cell     a_dataLocation,
@@ -46,12 +47,13 @@ public:
                                     const int                a_order,
                                     const int                a_weight,
                                     const int                a_radius,
-                                    const int                a_ghostCF);
+                                    const int                a_ghostCF,
+				    const IntVect            a_ghostPhi);
 
   /*!
     @brief Destructor (does nothing)
   */
-  ~MFHelmholtzSaturationChargeJumpBC();
+  virtual ~MFHelmholtzSaturationChargeJumpBC();
 
   /*!
     @brief Match the BC. 

--- a/Source/Electrostatics/CD_MFHelmholtzSaturationChargeJumpBC.cpp
+++ b/Source/Electrostatics/CD_MFHelmholtzSaturationChargeJumpBC.cpp
@@ -21,8 +21,9 @@ MFHelmholtzSaturationChargeJumpBC::MFHelmholtzSaturationChargeJumpBC(const phase
                                                                      const int                a_order,
                                                                      const int                a_weight,
                                                                      const int                a_radius,
-                                                                     const int                a_ghostCF)
-  : MFHelmholtzJumpBC(a_dataLocation, a_mflg, a_Bcoef, a_dx, a_order, a_weight, a_radius, a_ghostCF)
+                                                                     const int                a_ghostCF,
+                                                                     const IntVect            a_ghostPhi)
+  : MFHelmholtzJumpBC(a_dataLocation, a_mflg, a_Bcoef, a_dx, a_order, a_weight, a_radius, a_ghostCF, a_ghostPhi)
 {
   CH_TIME("MFHelmholtzSaturationChargeJumpBC::MFHelmholtzSaturationChargeJumpBC");
 

--- a/Source/Electrostatics/CD_MFHelmholtzSaturationChargeJumpBCFactory.H
+++ b/Source/Electrostatics/CD_MFHelmholtzSaturationChargeJumpBCFactory.H
@@ -48,6 +48,7 @@ public:
     @param[in] a_weight       Weighting factor for least squares
     @param[in] a_radius       Stencil radius
     @param[in] a_ghostCF      Number of grid cells that were filled across the CF. 
+    @param[in] a_ghostPhi     Number of ghost cells in phi
     @return Returns an MFHelmholtzJumpBC for encapsulating boundary conditions on multiphase cells. 
   */
   virtual RefCountedPtr<MFHelmholtzJumpBC>
@@ -58,7 +59,8 @@ public:
          const int            a_order,
          const int            a_weight,
          const int            a_radius,
-         const int            a_ghostCF) override;
+         const int            a_ghostCF,
+         const IntVect        a_ghostPhi) override;
 
 protected:
   /*!

--- a/Source/Electrostatics/CD_MFHelmholtzSaturationChargeJumpBCFactory.cpp
+++ b/Source/Electrostatics/CD_MFHelmholtzSaturationChargeJumpBCFactory.cpp
@@ -37,8 +37,11 @@ MFHelmholtzSaturationChargeJumpBCFactory::create(const Location::Cell a_dataLoca
                                                  const int            a_order,
                                                  const int            a_weight,
                                                  const int            a_radius,
-                                                 const int            a_ghostCF)
+                                                 const int            a_ghostCF,
+                                                 const IntVect        a_ghostPhi)
 {
+  CH_TIME("MFHelmholtzSaturationChargeJumpBCFactory::create");
+
   int order = a_order;
 
   // Drop order if we must
@@ -56,7 +59,8 @@ MFHelmholtzSaturationChargeJumpBCFactory::create(const Location::Cell a_dataLoca
                                                                                 order,
                                                                                 a_weight,
                                                                                 a_radius,
-                                                                                a_ghostCF));
+                                                                                a_ghostCF,
+                                                                                a_ghostPhi));
 }
 
 #include <CD_NamespaceFooter.H>

--- a/Source/Elliptic/CD_EBHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_EBHelmholtzOp.cpp
@@ -1204,9 +1204,9 @@ EBHelmholtzOp::applyOpIrregular(EBCellFAB&       a_Lphi,
                                 const bool       a_homogeneousPhysBC)
 {
   CH_TIMERS("EBHelmholtzOp::applyOpIrregular");
-  CH_TIMER("AggStencil", t1);  
+  CH_TIMER("AggStencil", t1);
   CH_TIMER("EB flux", t2);
-  CH_TIMER("Boundary flux",t3);  
+  CH_TIMER("Boundary flux", t3);
 
   // This routine computes L(phi) in a grid patch. This includes the cut-cell itself. Note that such cells can include cells that have both
   // an EB face and a domain face. This routine handles both.
@@ -1243,7 +1243,7 @@ EBHelmholtzOp::applyOpIrregular(EBCellFAB&       a_Lphi,
   CH_STOP(t1);
   CH_START(t2);
   m_ebBc->applyEBFlux(m_vofIterIrreg[a_dit], a_Lphi, a_phi, (*m_BcoefIrreg)[a_dit], a_dit, m_beta, a_homogeneousPhysBC);
-  CH_STOP(t2);  
+  CH_STOP(t2);
 #endif
 
   // Do irregular faces on domain sides. This was not included in the stencils above. m_domainBc should give the centroid-centered flux so we don't do interpolations here.
@@ -1271,7 +1271,7 @@ EBHelmholtzOp::applyOpIrregular(EBCellFAB&       a_Lphi,
     BoxLoops::loop(vofitLo, kernelLo);
     BoxLoops::loop(vofitHi, kernelHi);
   }
-  CH_STOP(t3);  
+  CH_STOP(t3);
 }
 
 void

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.H
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.H
@@ -153,6 +153,18 @@ public:
   getMultiPhaseVofs(const int a_phase, const DataIndex& a_dit) const;
 
   /*!
+    @brief Get stencils for computing dphi/dn at the boundary
+  */
+  virtual const LayoutData<MFInterfaceFAB<VoFStencil>>&
+  getGradPhiStencils() const noexcept;
+
+  /*!
+    @brief Get constant weights involved when computing dphi/dn at the boundary
+  */
+  virtual const LayoutData<MFInterfaceFAB<Real>>&
+  getGradPhiWeights() const noexcept;
+
+  /*!
     @brief Set everything to zero. This is a debugging function.
   */
   virtual void

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.H
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.H
@@ -228,6 +228,11 @@ protected:
   int m_numPhases;
 
   /*!
+    @brief Number of ghost cells in phi (must be exact match in order to use AggStencil)
+  */
+  IntVect m_ghostPhi;
+
+  /*!
     @brief Multiphase or not
   */
   bool m_multiPhase;

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.H
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.H
@@ -59,6 +59,7 @@ public:
     @param[in] a_weight       Weighting factor for least squares
     @param[in] a_radius       Stencil radius
     @param[in] a_ghostCF      Number of grid cells that were filled across the CF. 
+    @param[in] a_ghostPhi     Number of ghost cells in phi (needed for AggStencil)
   */
   MFHelmholtzJumpBC(const Location::Cell a_dataLocation,
                     const MFLevelGrid&   a_mflg,
@@ -67,7 +68,8 @@ public:
                     const int            a_order,
                     const int            a_weight,
                     const int            a_radius,
-                    const int            a_ghostCF);
+                    const int            a_ghostCF,
+                    const IntVect        a_ghostPhi);
 
   /*!
     @brief Disallowed copy constructor
@@ -271,6 +273,11 @@ protected:
     @brief Average stencil
   */
   LayoutData<MFInterfaceFAB<VoFStencil>> m_avgStencils;
+
+  /*!
+    @brief Target vofs for average stencils
+  */
+  LayoutData<MFInterfaceFAB<Vector<VolIndex>>> m_avgVoFs;
 
   /*!
     @brief Denominator 1/(bp*wp + bq*wq) for all interface cells. 

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.H
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.H
@@ -97,6 +97,13 @@ public:
   setBco(const RefCountedPtr<LevelData<MFBaseIVFAB>>& a_Bcoef);
 
   /*!
+    @brief Is multiphase or not
+    @return m_multiPhase
+  */
+  bool
+  isMultiPhase() const noexcept;
+
+  /*!
     @brief Return stencil order
   */
   int

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.H
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.H
@@ -18,6 +18,8 @@
 #include <LayoutData.H>
 #include <Stencils.H>
 #include <AggStencil.H>
+#include <EBCellFAB.H>
+#include <BaseIVFAB.H>
 
 // Our includes
 #include <CD_Location.H>

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.H
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.H
@@ -17,6 +17,7 @@
 #include <EBISBox.H>
 #include <LayoutData.H>
 #include <Stencils.H>
+#include <AggStencil.H>
 
 // Our includes
 #include <CD_Location.H>
@@ -275,6 +276,11 @@ protected:
     @brief Average weights
   */
   LayoutData<MFInterfaceFAB<Real>> m_avgWeights;
+
+  /*!
+    @brief Agg stencils for making matching go faster
+  */
+  LayoutData<RefCountedPtr<AggStencil<EBCellFAB, BaseIVFAB<Real>>>> m_aggStencils[2];
 
   /*!
     @brief Define function. Builds stencils. 

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
@@ -542,8 +542,8 @@ MFHelmholtzJumpBC::matchBC(BaseIVFAB<Real>& a_jump,
 
     Real jump = 0.0;
     if (!a_homogeneousPhysBC) {
-      for (const auto& v : vofsPhase0.stdVector()) {
-        jump += a_jump(v, m_comp);
+      for (int i = 0; i < vofsPhase0.size(); i++) {
+        jump += a_jump(vofsPhase0[i], m_comp);
       }
       jump *= 1. / vofsPhase0.size();
     }
@@ -552,18 +552,19 @@ MFHelmholtzJumpBC::matchBC(BaseIVFAB<Real>& a_jump,
     CH_START(t5);
     for (int i = 0; i < vofsPhase0.size(); i++) {
       bndryPhiPhase0(vofsPhase0[i], m_comp) += bndryPhiPhase1(vof0, m_comp);
+      bndryPhiPhase0(vofsPhase0[i], m_comp) *= -1.0;
     }
     for (int i = 0; i < vofsPhase1.size(); i++) {
       bndryPhiPhase1(vofsPhase1[i], m_comp) = bndryPhiPhase0(vof0, m_comp);
     }
 
-    for (int i = 0; i < vofsPhase0.size(); i++) {
-      bndryPhiPhase0(vofsPhase0[i], m_comp) *= -1.0;
-      bndryPhiPhase0(vofsPhase0[i], m_comp) += denomPhase0 * jump;
-    }
-    for (int i = 0; i < vofsPhase1.size(); i++) {
-      bndryPhiPhase1(vofsPhase1[i], m_comp) *= -1.0;
-      bndryPhiPhase1(vofsPhase1[i], m_comp) += denomPhase0 * jump;
+    if (!a_homogeneousPhysBC) {
+      for (int i = 0; i < vofsPhase0.size(); i++) {
+        bndryPhiPhase0(vofsPhase0[i], m_comp) += denomPhase0 * jump;
+      }
+      for (int i = 0; i < vofsPhase1.size(); i++) {
+        bndryPhiPhase1(vofsPhase1[i], m_comp) += denomPhase0 * jump;
+      }
     }
 
     CH_STOP(t5);

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
@@ -345,7 +345,10 @@ MFHelmholtzJumpBC::buildAverageStencils()
       BoxLoops::loop(vofit, kernel);
 
       aggStencils[dit()] = RefCountedPtr<AggStencil<EBCellFAB, BaseIVFAB<Real>>>(
-        new AggStencil(dstBaseIndex, dstBaseStencil, phiProxy[dit()], m_boundaryPhi[dit()].getIVFAB(iphase)));
+        new AggStencil<EBCellFAB, BaseIVFAB<Real>>(dstBaseIndex,
+                                                   dstBaseStencil,
+                                                   phiProxy[dit()],
+                                                   m_boundaryPhi[dit()].getIVFAB(iphase)));
     }
   }
 }

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
@@ -87,6 +87,18 @@ MFHelmholtzJumpBC::getMultiPhaseVofs(const int a_phase, const DataIndex& a_dit) 
   return (*m_multiPhaseVofs.at(a_phase))[a_dit];
 }
 
+const LayoutData<MFInterfaceFAB<VoFStencil>>&
+MFHelmholtzJumpBC::getGradPhiStencils() const noexcept
+{
+  return m_gradPhiStencils;
+}
+
+const LayoutData<MFInterfaceFAB<Real>>&
+MFHelmholtzJumpBC::getGradPhiWeights() const noexcept
+{
+  return m_gradPhiWeights;
+}
+
 void
 MFHelmholtzJumpBC::setBco(const RefCountedPtr<LevelData<MFBaseIVFAB>>& a_Bcoef)
 {

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
@@ -51,6 +51,8 @@ MFHelmholtzJumpBC::MFHelmholtzJumpBC(const Location::Cell a_dataLocation,
 
   m_ghostPhi = 2 * IntVect::Unit;
   MayDay::Warning("MFHelmholtzJumpBC -- must get number of ghost cells for using AggStencil properly");
+  MayDay::Warning("MFHelmholtzJumpBC -- should store target vofs for average jump calc");
+  MayDay::Warning("MFHelmholtzJumpBC -- check if we can trim exchange operation");
 
   this->defineIterators();
   this->defineStencils();
@@ -525,11 +527,12 @@ MFHelmholtzJumpBC::matchBC(BaseIVFAB<Real>& a_jump,
 
     Vector<VolIndex> vofsPhase0 = ebisBoxPhase0.getVoFs(iv);
     Vector<VolIndex> vofsPhase1 = ebisBoxPhase1.getVoFs(iv);
-
-    const Real& denomPhase0 = denomFactorPhase0(vof0, vofComp);
     CH_STOP(t3);
 
     CH_START(t4);
+    const Real& denomPhase0 = denomFactorPhase0(vof0, vofComp);
+
+
     Real jump = 0.0;
     if (!a_homogeneousPhysBC) {
       for (const auto& v : vofsPhase0.stdVector()) {

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
@@ -51,9 +51,6 @@ MFHelmholtzJumpBC::MFHelmholtzJumpBC(const Location::Cell a_dataLocation,
   m_multiPhase   = m_numPhases > 1;
   m_ghostPhi     = a_ghostPhi;
 
-  MayDay::Warning("MFHelmholtzJumpBC -- should store target vofs for average jump calc");
-  MayDay::Warning("MFHelmholtzJumpBC -- check if we can trim exchange operation");
-
   this->defineIterators();
   this->defineStencils();
 }

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
@@ -116,6 +116,13 @@ MFHelmholtzJumpBC::setBco(const RefCountedPtr<LevelData<MFBaseIVFAB>>& a_Bcoef)
     this->buildAverageStencils();
   }
 }
+bool
+MFHelmholtzJumpBC::isMultiPhase() const noexcept
+{
+  CH_TIME("MFHelmholtzJumpBC::isMultiPhase");
+
+  return m_multiPhase;
+}
 
 void
 MFHelmholtzJumpBC::defineStencils()

--- a/Source/Elliptic/CD_MFHelmholtzJumpBCFactory.H
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBCFactory.H
@@ -47,6 +47,7 @@ public:
     @param[in] a_weight       Weighting factor for least squares
     @param[in] a_radius       Stencil radius
     @param[in] a_ghostCF      Number of grid cells that were filled across the CF. 
+    @param[in] a_ghostPhi     Number of ghost cells in phi
   */
   virtual RefCountedPtr<MFHelmholtzJumpBC>
   create(const Location::Cell a_dataLocation,
@@ -56,7 +57,8 @@ public:
          const int            a_order,
          const int            a_weight,
          const int            a_radius,
-         const int            a_ghostCF);
+         const int            a_ghostCF,
+         const IntVect        a_ghostPhi);
 
   /*!
     @brief Drop BC order if domain size is equal or below this.

--- a/Source/Elliptic/CD_MFHelmholtzJumpBCFactory.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBCFactory.cpp
@@ -42,7 +42,8 @@ MFHelmholtzJumpBCFactory::create(const Location::Cell a_dataLocation,
                                  const int            a_order,
                                  const int            a_weight,
                                  const int            a_radius,
-                                 const int            a_ghostCF)
+                                 const int            a_ghostCF,
+                                 const IntVect        a_ghostPhi)
 {
   int order = a_order;
 
@@ -54,7 +55,7 @@ MFHelmholtzJumpBCFactory::create(const Location::Cell a_dataLocation,
   }
 
   return RefCountedPtr<MFHelmholtzJumpBC>(
-    new MFHelmholtzJumpBC(a_dataLocation, a_mflg, a_Bcoef, a_dx, order, a_weight, a_radius, a_ghostCF));
+    new MFHelmholtzJumpBC(a_dataLocation, a_mflg, a_Bcoef, a_dx, order, a_weight, a_radius, a_ghostCF, a_ghostPhi));
 }
 
 #include <CD_NamespaceFooter.H>

--- a/Source/Elliptic/CD_MFHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzOp.cpp
@@ -91,8 +91,9 @@ MFHelmholtzOp::MFHelmholtzOp(const Location::Cell                             a_
 
   // Instantiate jump bc object.
   const int ghostCF = a_hasCoar ? a_interpolator.getGhostCF() : 1;
-  m_jumpBC          = a_jumpBcFactory
-               ->create(m_dataLocation, m_mflg, a_BcoefIrreg, a_dx, a_jumpOrder, a_jumpWeight, a_jumpOrder, ghostCF);
+  m_jumpBC =
+    a_jumpBcFactory
+      ->create(m_dataLocation, m_mflg, a_BcoefIrreg, a_dx, a_jumpOrder, a_jumpWeight, a_jumpOrder, ghostCF, a_ghostPhi);
 
   // Make the operators on eachphase.
   for (int iphase = 0; iphase < m_numPhases; iphase++) {


### PR DESCRIPTION
## Summary

Use AggStencil for more efficient cache. Should reduce GMG solves with jump conditions by 20-30%.

## Intent

- [ ] Fix a bug or incorrect behavior.
- [x] Add new capabilities.

## Checklist

- [ ] If relevant, add Sphinx documentation in the rst files. 
- [ ] Add doxygen documentation. 
