### PR TITLE
Particle merge and splitting abstractions

### DIFF
--- a/Source/ItoDiffusion/CD_ItoSolver.H
+++ b/Source/ItoDiffusion/CD_ItoSolver.H
@@ -20,7 +20,6 @@
 #include <CD_EBParticleMesh.H>
 #include <CD_ParticleContainer.H>
 #include <CD_EBRepresentation.H>
-#include <CD_ParticleManagement.H>
 #include <CD_EBIntersection.H>
 #include <CD_NamespaceHeader.H>
 
@@ -1026,11 +1025,6 @@ protected:
     @brief Switch for deciding how to interpolate mobilities, i.e. interpolating either mu*E or just mu (to the particle position)
   */
   WhichMobilityInterpolation m_mobilityInterp;
-
-  /*!
-    @brief Particle merger
-  */
-  ParticleManagement::ParticleMerger<ItoParticle> m_particleMerger;
 
   /*!
     @brief Number of particles used when restarting a simulation -- this is relevant only when restarting from a "fluid" checkpoint file. 

--- a/Source/ItoDiffusion/CD_ItoSolver.H
+++ b/Source/ItoDiffusion/CD_ItoSolver.H
@@ -20,6 +20,7 @@
 #include <CD_EBParticleMesh.H>
 #include <CD_ParticleContainer.H>
 #include <CD_EBRepresentation.H>
+#include <CD_ParticleManagement.H>
 #include <CD_EBIntersection.H>
 #include <CD_NamespaceHeader.H>
 
@@ -1025,6 +1026,11 @@ protected:
     @brief Switch for deciding how to interpolate mobilities, i.e. interpolating either mu*E or just mu (to the particle position)
   */
   WhichMobilityInterpolation m_mobilityInterp;
+
+  /*!
+    @brief Particle merger
+  */
+  ParticleManagement::ParticleMerger<ItoParticle> m_particleMerger;
 
   /*!
     @brief Number of particles used when restarting a simulation -- this is relevant only when restarting from a "fluid" checkpoint file. 

--- a/Source/ItoDiffusion/CD_ItoSolver.H
+++ b/Source/ItoDiffusion/CD_ItoSolver.H
@@ -33,6 +33,13 @@ class ItoSolver
 {
 public:
   /*!
+    @brief Concept for splitting/merging particles
+    @param[inout] a_particles Particles to be merged/split
+    @param[in] a_numTargetParticles Number of target particles
+  */
+  using ParticleMerger = std::function<void(List<ItoParticle>& a_particles, const int a_numTargetParticles)>;
+
+  /*!
     @brief Enum class for distinguishing various types of particle containers.
     @details This exists because the ItoSolver can partition particles into various containers, which is very useful when one wants to add particles from
     a source term, remove particles that fall inside the EB, or parse boundary conditions on the EB and domain faces. Here,
@@ -62,6 +69,19 @@ public:
     @brief Destructor (does nothing).
   */
   virtual ~ItoSolver();
+
+  /*!
+    @brief Set a default particle merger. This defaults to KD-tree merging following an "equal weight" principle.
+  */
+  virtual void
+  setDefaultParticleMerger() noexcept;
+
+  /*!
+    @brief Set the particle merger. This will get called when merging particles using makeSuperparticles.
+    @param[in] a_particleMerger Particle merger
+  */
+  virtual void
+  setParticleMerger(const ParticleMerger& a_particleMerger) noexcept;
 
   /*!
     @brief Get this solver's name 
@@ -804,7 +824,7 @@ public:
   */
   virtual void
   makeSuperparticles(const WhichContainer a_container,
-                     const int            a_particlesPerPatch,
+                     const int            a_particlesPerCell,
                      const int            a_level,
                      const DataIndex      a_dit);
 
@@ -1027,6 +1047,11 @@ protected:
   WhichMobilityInterpolation m_mobilityInterp;
 
   /*!
+    @brief Particle merger
+  */
+  ParticleMerger m_particleMerger;
+
+  /*!
     @brief Number of particles used when restarting a simulation -- this is relevant only when restarting from a "fluid" checkpoint file. 
   */
   int m_restartPPC;
@@ -1066,11 +1091,6 @@ protected:
     @details ItoSolver for parent class -- derived classes might be named something else.
   */
   std::string m_className;
-
-  /*!
-    @brief Uniform integer distribution between [0,SpaceDim-1]
-  */
-  mutable std::uniform_int_distribution<int> m_uniformDistribution0d;
 
   /*!
     @brief Truncation value for normal distribution. 
@@ -1405,7 +1425,7 @@ protected:
     the EB and put it back into the domain. 
     @param[inout] a_phi Quantity to be redistributed. 
   */
-  void
+  virtual void
   redistributeAMR(EBAMRCellData& a_phi) const;
 
   /*!
@@ -1413,7 +1433,7 @@ protected:
     @param[out] a_depositionNC     Non-conservative deposition
     @param[in]  a_depositionKappaC Conserved deposition
   */
-  void
+  virtual void
   depositNonConservative(EBAMRIVData& a_depositionNC, const EBAMRCellData& a_depositionKappaC) const;
 
   /*!
@@ -1422,16 +1442,16 @@ protected:
     @param[out]   a_massDifference On output, contains mass loss in each cut-cell.
     @param[in]    a_depositionNC   The "non-conservative" deposited variable.
   */
-  void
+  virtual void
   depositHybrid(EBAMRCellData& a_depositionH, EBAMRIVData& a_massDifference, const EBAMRIVData& a_depositionNC) const;
 
   /*!
-    @brief Superparticle merging with BVH trees
+    @brief Superparticle merging with KD/BVH trees
     @param[inout] a_particles        Particles to be merged/split
     @param[in]    a_particlesPerCell Target number of particles per cell
   */
   virtual void
-  makeSuperparticles(List<ItoParticle>& a_particles, const int a_particlesPerCell);
+  makeSuperparticlesEqualWeightKD(List<ItoParticle>& a_particles, const int a_particlesPerCell);
 
   /*!
     @brief Interpolate mobilities -- this will switch between the two ways of computing the particle mobility.

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -50,6 +50,8 @@ ItoSolver::ItoSolver()
   m_plotDeposition       = DepositionType::CIC;
   m_checkpointing        = WhichCheckpoint::Particles;
   m_mobilityInterp       = WhichMobilityInterpolation::Direct;
+
+  this->setDefaultParticleMerger();
 }
 
 ItoSolver::~ItoSolver() { CH_TIME("ItoSolver::~ItoSolver"); }
@@ -76,6 +78,24 @@ ItoSolver::setRealm(const std::string a_realm)
   CH_TIME("ItoSolver::setRealm");
 
   m_realm = a_realm;
+}
+
+void
+ItoSolver::setDefaultParticleMerger() noexcept
+{
+  CH_TIME("ItoSolver::setParticleMerger");
+
+  m_particleMerger = [this](List<ItoParticle>& a_particles, const int a_ppc) {
+    this->makeSuperparticlesEqualWeightKD(a_particles, a_ppc);
+  };
+}
+
+void
+ItoSolver::setParticleMerger(const ParticleMerger& a_particleMerger) noexcept
+{
+  CH_TIME("ItoSolver::setParticleMerger");
+
+  m_particleMerger = a_particleMerger;
 }
 
 const RefCountedPtr<ItoSpecies>&
@@ -153,9 +173,6 @@ ItoSolver::parseRNG()
   ParmParse pp(m_className.c_str());
 
   pp.get("normal_max", m_normalDistributionTruncation);
-
-  //Uniform integer distribution from [0, SpaceDim-1]
-  m_uniformDistribution0d = std::uniform_int_distribution<int>(0, SpaceDim - 1);
 }
 
 void
@@ -2818,7 +2835,7 @@ ItoSolver::organizeParticlesByPatch(const WhichContainer a_container)
 }
 
 void
-ItoSolver::makeSuperparticles(const WhichContainer a_container, const int a_particlesPerPatch)
+ItoSolver::makeSuperparticles(const WhichContainer a_container, const int a_particlesPerCell)
 {
   CH_TIME("ItoSolver::makeSuperparticles(WhichContainer, int)");
   if (m_verbosity > 5) {
@@ -2826,30 +2843,30 @@ ItoSolver::makeSuperparticles(const WhichContainer a_container, const int a_part
   }
 
   for (int lvl = 0; lvl <= m_amr->getFinestLevel(); lvl++) {
-    this->makeSuperparticles(a_container, a_particlesPerPatch, lvl);
+    this->makeSuperparticles(a_container, a_particlesPerCell, lvl);
   }
 }
 
 void
-ItoSolver::makeSuperparticles(const WhichContainer a_container, const Vector<int> a_particlesPerPatch)
+ItoSolver::makeSuperparticles(const WhichContainer a_container, const Vector<int> a_particlesPerCell)
 {
   CH_TIME("ItoSolver::makeSuperparticles(WhichContainer, Vector<int>)");
   if (m_verbosity > 5) {
     pout() << m_name + "::makeSuperparticles(WhichContainer, Vector<int>)" << endl;
   }
 
-  if (a_particlesPerPatch.size() < 1) {
+  if (a_particlesPerCell.size() < 1) {
     MayDay::Error("ItoSolver::makeSuperParticles(Container, Vector<int>) -logic bust");
   }
 
   for (int lvl = 0; lvl <= m_amr->getFinestLevel(); lvl++) {
     int ppc;
 
-    if (lvl < a_particlesPerPatch.size()) {
-      ppc = a_particlesPerPatch[lvl];
+    if (lvl < a_particlesPerCell.size()) {
+      ppc = a_particlesPerCell[lvl];
     }
     else {
-      ppc = a_particlesPerPatch.back();
+      ppc = a_particlesPerCell.back();
     }
 
     this->makeSuperparticles(a_container, ppc, lvl);
@@ -2857,7 +2874,7 @@ ItoSolver::makeSuperparticles(const WhichContainer a_container, const Vector<int
 }
 
 void
-ItoSolver::makeSuperparticles(const WhichContainer a_container, const int a_particlesPerPatch, const int a_level)
+ItoSolver::makeSuperparticles(const WhichContainer a_container, const int a_particlesPerCell, const int a_level)
 {
   CH_TIME("ItoSolver::makeSuperparticles(WhichContainer, int, int)");
   if (m_verbosity > 5) {
@@ -2867,7 +2884,7 @@ ItoSolver::makeSuperparticles(const WhichContainer a_container, const int a_part
   const DisjointBoxLayout& dbl = m_amr->getGrids(m_realm)[a_level];
 
   for (DataIterator dit(dbl); dit.ok(); ++dit) {
-    this->makeSuperparticles(a_container, a_particlesPerPatch, a_level, dit());
+    this->makeSuperparticles(a_container, a_particlesPerCell, a_level, dit());
   }
 }
 
@@ -2891,7 +2908,7 @@ ItoSolver::makeSuperparticles(const WhichContainer a_container,
     List<ItoParticle>& particles = cellParticles(iv, m_comp);
 
     if (particles.length() > 0) {
-      this->makeSuperparticles(particles, a_particlesPerCell);
+      m_particleMerger(particles, a_particlesPerCell);
     }
   };
 
@@ -2903,17 +2920,12 @@ ItoSolver::makeSuperparticles(const WhichContainer a_container,
 }
 
 void
-ItoSolver::makeSuperparticles(List<ItoParticle>& a_particles, const int a_ppc)
+ItoSolver::makeSuperparticlesEqualWeightKD(List<ItoParticle>& a_particles, const int a_ppc)
 {
   CH_TIMERS("ItoSolver::makeSuperparticles");
   CH_TIMER("ItoSolver::makeSuperParticles::populate_list", t1);
   CH_TIMER("ItoSolver::makeSuperParticles::build_kd", t2);
   CH_TIMER("ItoSolver::makeSuperParticles::merge_particles", t3);
-
-  // MayDay::Warning(
-  //   "ItoSolver::makeSuperParticles -- use dependency injection and inject a particle merger. Existing code should be a default particle merger");
-  // MayDay::Warning(
-  //   "ItoSolver::makeSuperParticles -- need better abstractions for particle splitting in PartilceManagement");
 
   using PType        = NonCommParticle<2, 1>;
   using Node         = KDNode<PType>;
@@ -2936,10 +2948,19 @@ ItoSolver::makeSuperparticles(List<ItoParticle>& a_particles, const int a_ppc)
   }
   CH_STOP(t1);
 
+  // Particle reconciler for manipulated two particles arising from splitting of one particle.
+  auto particleReconcile = [](PType& p1, PType& p2, const PType& p0) -> void {
+    p1.template real<1>() = p0.template real<1>();
+    p2.template real<1>() = p0.template real<1>();
+  };
+
   // 2. Build KD-tree.
-  const std::vector<std::shared_ptr<Node>> leaves = ParticleManagement::
-    recursivePartitionAndSplitEqualWeightKD<PType, &PType::template real<0>, &PType::template vect<0>>(particles,
-                                                                                                       a_ppc);
+  const std::vector<std::shared_ptr<Node>> leaves =
+    ParticleManagement::recursivePartitionAndSplitEqualWeightKD<PType,
+                                                                &PType::template real<0>,
+                                                                &PType::template vect<0>>(particles,
+                                                                                          a_ppc,
+                                                                                          particleReconcile);
 
   // Merge leaves into new particles.
   CH_START(t3);

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -2916,8 +2916,8 @@ ItoSolver::makeSuperparticles(List<ItoParticle>& a_particles, const int a_ppc)
     "ItoSolver::makeSuperParticles -- need better abstractions for particle splitting in PartilceManagement");
 
   using PType        = NonCommParticle<2, 1>;
-  using Node         = ParticleManagement::KDNode<PType>;
-  using ParticleList = ParticleManagement::KDNode<PType>::ParticleList;
+  using Node         = KDNode<PType>;
+  using ParticleList = KDNode<PType>::ParticleList;
 
   // 1. Make the input list into a vector of particles with a smaller memory footprint.
   CH_START(t1);
@@ -2937,9 +2937,9 @@ ItoSolver::makeSuperparticles(List<ItoParticle>& a_particles, const int a_ppc)
   CH_STOP(t1);
 
   // 2. Build KD-tree.
-  const std::vector<std::shared_ptr<Node>> leaves =
-    ParticleManagement::buildKDTreeEqualWeight<PType, &PType::template real<0>, &PType::template vect<0>>(particles,
-                                                                                                          a_ppc);
+  const std::vector<std::shared_ptr<Node>> leaves = ParticleManagement::
+    recursivePartitionAndSplitEqualWeightKD<PType, &PType::template real<0>, &PType::template vect<0>>(particles,
+                                                                                                       a_ppc);
 
   // Merge leaves into new particles.
   CH_START(t3);

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -2910,10 +2910,10 @@ ItoSolver::makeSuperparticles(List<ItoParticle>& a_particles, const int a_ppc)
   CH_TIMER("ItoSolver::makeSuperParticles::build_kd", t2);
   CH_TIMER("ItoSolver::makeSuperParticles::merge_particles", t3);
 
-  MayDay::Warning(
-    "ItoSolver::makeSuperParticles -- use dependency injection and inject a particle merger. Existing code should be a default particle merger");
-  MayDay::Warning(
-    "ItoSolver::makeSuperParticles -- need better abstractions for particle splitting in PartilceManagement");
+  // MayDay::Warning(
+  //   "ItoSolver::makeSuperParticles -- use dependency injection and inject a particle merger. Existing code should be a default particle merger");
+  // MayDay::Warning(
+  //   "ItoSolver::makeSuperParticles -- need better abstractions for particle splitting in PartilceManagement");
 
   using PType        = NonCommParticle<2, 1>;
   using Node         = KDNode<PType>;

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -2912,6 +2912,8 @@ ItoSolver::makeSuperparticles(List<ItoParticle>& a_particles, const int a_ppc)
 
   MayDay::Warning(
     "ItoSolver::makeSuperParticles -- use dependency injection and inject a particle merger. Existing code should be a default particle merger");
+  MayDay::Warning(
+    "ItoSolver::makeSuperParticles -- need better abstractions for particle splitting in PartilceManagement");
 
   using PType        = NonCommParticle<2, 1>;
   using Node         = ParticleManagement::KDNode<PType>;

--- a/Source/Particle/CD_KDNode.H
+++ b/Source/Particle/CD_KDNode.H
@@ -1,0 +1,184 @@
+/* chombo-discharge
+ * Copyright © 2022 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_KDNode.H
+  @brief  Namespace containing various particle management utilities.
+  @author Robert Marskar
+*/
+
+#ifndef CD_KDNode_H
+#define CD_KDNode_H
+
+// Std includes
+#include <memory>
+#include <vector>
+
+// Chombo includes
+#include <RealVect.H>
+#include <List.H>
+
+// Our includes
+#include <CD_NamespaceHeader.H>
+
+/*!
+  @brief Node in a particle-merging KD-tree. 
+  @details This node type is used for partitioning particles into spatial subsets and merging/splitting them. 
+  @details The template argument P is the particle type - the users decides how to merge/split/partition. 
+*/
+template <class P>
+class KDNode
+{
+public:
+  /*!
+    @brief List of particles. This is aliased because the KD-tree construction may require both random access
+    and something sortable. 
+  */
+  using ParticleList = std::vector<P>;
+
+  /*!
+    @brief Disallowed constructor
+  */
+  KDNode(const KDNode&) = delete;
+
+  /*!
+    @brief Disallowed constructor
+  */
+  KDNode(const KDNode&&) = delete;
+
+  /*!
+    @brief Disallowed assignment
+  */
+  KDNode&
+  operator=(const KDNode&) = delete;
+
+  /*!
+    @brief Disallowed assignment
+  */
+  KDNode&
+  operator=(const KDNode&&) = delete;
+
+  /*!
+    @brief Default constructor
+  */
+  KDNode();
+
+  /*!
+    @brief Valid constructor. Takes list of particles.
+    @param[inout] a_particles List of particles to be partitioned later. 
+    @note The input particle list is transferred to m_particles. 
+  */
+  KDNode(ParticleList& a_particles);
+
+  /*!
+    @brief Destructor. Does nothing.
+  */
+  virtual ~KDNode();
+
+  /*!
+    @brief Get the node weight
+  */
+  inline const Real&
+  weight() const noexcept;
+
+  /*!
+    @brief Get the node weight
+  */
+  inline Real&
+  weight() noexcept;
+
+  /*!
+    @brief Get particles in this node. 
+  */
+  inline const ParticleList&
+  getParticles() const noexcept;
+
+  /*!
+    @brief Get particles in this node. 
+  */
+  inline ParticleList&
+  getParticles() noexcept;
+
+  /*!
+    @brief Is leaf node or not.
+  */
+  inline bool
+  isLeafNode() const noexcept;
+
+  /*!
+    @brief Is leaf node or not.
+  */
+  inline bool
+  isInteriorNode() const noexcept;
+
+  /*!
+    @brief Gather particles further down in the subtree and return all particles (in the leaf nodes)
+  */
+  inline ParticleList
+  gatherParticles() const noexcept;
+
+  /*!
+    @brief Move the particles list further down in the subtree into this vector.
+    @note This clears the particles from the leaf nodes. Use gatherParticles if you do not
+    want to change the tree contents. 
+  */
+  inline ParticleList
+  moveParticles() noexcept;
+
+  /*!
+    @brief Get the left node.
+  */
+  inline std::shared_ptr<KDNode<P>>&
+  getLeft() noexcept;
+
+  /*!
+    @brief Get the right node.
+  */
+  inline std::shared_ptr<KDNode<P>>&
+  getRight() noexcept;
+
+protected:
+  /*!
+    @brief Left KD-node
+  */
+  std::shared_ptr<KDNode> m_left;
+
+  /*!
+    @brief Right KD-node
+  */
+  std::shared_ptr<KDNode> m_right;
+
+  /*!
+    @brief Node weight
+  */
+  Real m_weight;
+
+  /*!
+    @brief List of particles
+  */
+  ParticleList m_particles;
+
+  /*!
+    @brief Gather particles further down in the subtree and return all particles (in the leaf nodes)
+    @param[inout] a_particles List of particles
+  */
+  inline void
+  gatherParticles(ParticleList& a_particles) const noexcept;
+
+  /*!
+    @brief Move particles further down in the subtree and return all particles (in the leaf nodes)
+    @param[inout] a_particles List of particles
+    @note This clears the particles from the leaf nodes. Use gatherParticles if you do not
+    want to change the tree contents. 
+  */
+  inline void
+  moveParticles(ParticleList& a_particles) noexcept;
+};
+
+#include <CD_NamespaceFooter.H>
+
+#include <CD_KDNodeImplem.H>
+
+#endif

--- a/Source/Particle/CD_KDNodeImplem.H
+++ b/Source/Particle/CD_KDNodeImplem.H
@@ -1,0 +1,145 @@
+/* chombo-discharge
+ * Copyright © 2022 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_KDNodeImplem.H
+  @brief  Implementation of CD_KDNode.H
+  @author Robert Marskar
+*/
+
+#ifndef CD_KDNodeImplem_H
+#define CD_KDNodeImplem_H
+
+// Std includes
+#include <utility>
+#include <type_traits>
+
+// Our includes
+#include <CD_KDNode.H>
+#include <CD_NamespaceHeader.H>
+
+template <class P>
+inline KDNode<P>::KDNode() : m_left(nullptr), m_right(nullptr), m_weight(0.0)
+{}
+
+template <class P>
+inline KDNode<P>::KDNode(ParticleList& a_particles)
+  : m_left(nullptr), m_right(nullptr), m_weight(0.0), m_particles(std::move(a_particles))
+{}
+
+template <class P>
+inline KDNode<P>::~KDNode()
+{}
+
+template <class P>
+inline const typename KDNode<P>::ParticleList&
+KDNode<P>::getParticles() const noexcept
+{
+  return m_particles;
+}
+
+template <class P>
+inline typename KDNode<P>::ParticleList&
+KDNode<P>::getParticles() noexcept
+{
+  return m_particles;
+}
+
+template <class P>
+inline const Real&
+KDNode<P>::weight() const noexcept
+{
+  return m_weight;
+}
+
+template <class P>
+inline Real&
+KDNode<P>::weight() noexcept
+{
+  return m_weight;
+}
+
+template <class P>
+inline bool
+KDNode<P>::isLeafNode() const noexcept
+{
+  return (m_left == nullptr) && (m_right == nullptr);
+}
+
+template <class P>
+inline bool
+KDNode<P>::isInteriorNode() const noexcept
+{
+  return !(this->isLeafNode());
+}
+
+template <class P>
+inline typename KDNode<P>::ParticleList
+KDNode<P>::gatherParticles() const noexcept
+{
+  ParticleList primitives;
+
+  this->gatherParticles(primitives);
+
+  return primitives;
+}
+
+template <class P>
+inline void
+KDNode<P>::gatherParticles(ParticleList& a_particles) const noexcept
+{
+  if (this->isLeafNode()) {
+    a_particles.reserve(a_particles.size() + m_particles.size());
+    a_particles.insert(a_particles.end(), m_particles.begin(), m_particles.end());
+  }
+  else {
+    m_left->gatherParticles(a_particles);
+    m_right->gatherParticles(a_particles);
+  }
+}
+
+template <class P>
+inline typename KDNode<P>::ParticleList
+KDNode<P>::moveParticles() noexcept
+{
+  ParticleList primitives;
+
+  this->moveParticles(primitives);
+
+  return primitives;
+}
+
+template <class P>
+inline void
+KDNode<P>::moveParticles(ParticleList& a_particles) noexcept
+{
+  if (this->isLeafNode()) {
+    a_particles.reserve(a_particles.size() + m_particles.size());
+
+    std::move(m_particles.begin(), m_particles.end(), std::back_inserter(a_particles));
+  }
+  else {
+    m_left->moveParticles(a_particles);
+    m_right->moveParticles(a_particles);
+  }
+}
+
+template <class P>
+inline std::shared_ptr<KDNode<P>>&
+KDNode<P>::getLeft() noexcept
+{
+  return m_left;
+}
+
+template <class P>
+inline std::shared_ptr<KDNode<P>>&
+KDNode<P>::getRight() noexcept
+{
+  return m_right;
+}
+
+#include <CD_NamespaceFooter.H>
+
+#endif

--- a/Source/Particle/CD_ParticleContainerImplem.H
+++ b/Source/Particle/CD_ParticleContainerImplem.H
@@ -790,6 +790,7 @@ ParticleContainer<P>::remap()
   CH_STOP(t1);
 
   for (int lvl = m_finestLevel; lvl >= 0; lvl--) {
+    m_particles[lvl]->gatherOutcast();
     m_particles[lvl]->remapOutcast();
 
     CH_START(t2);

--- a/Source/Particle/CD_ParticleManagement.H
+++ b/Source/Particle/CD_ParticleManagement.H
@@ -21,6 +21,7 @@
 #include <List.H>
 
 // Our includes
+#include <CD_KDNode.H>
 #include <CD_NamespaceHeader.H>
 
 /*!
@@ -29,172 +30,29 @@
 namespace ParticleManagement {
 
   /*!
-    @brief Simple abstraction for encapsulating a particle merging/splitting concept
+    @brief Concept for splitting a particle into more particles
   */
-  template <class P>
-  using ParticleMerger = std::function<List<P>(List<P>& a_inputParticles)>;
+  template<class P, size_t N>
+  using ParticleSplitter = std::function<std::array<P, N>(const P& p)>;
 
   /*!
-    @brief Node in a particle-merging KD-tree. 
-    @details This node type is used for partitioning particles into spatial subsets and merging/splitting them. 
-    @details The template argument P is the particle type - the users decides how to merge/split/partition. 
+    @brief Partition and split a KD-node with particles so that the weights are approximately the same. 
+    @details This will partition particles on two sides of a plane parallel to one of the coordinate axis. The middle
+    particle closest to this plane may be split, and the weights of the resulting particles are assigned such that the
+    total weight of the two halves differ by at most one. The template parameters are 
+
+       P            -> Particle type
+       P::*weight   -> Function pointer to particle weight
+       P::*position -> Function pointer to particle position.
+
+    A possible call signature is e.g. recursivePartitionAndSplitEqualWeightKD<P, &P::weight, &P::position>.
   */
-  template <class P>
-  class KDNode
-  {
-  public:
-    /*!
-      @brief List of particles. This is aliased because the KD-tree construction may require both random access
-      and something sortable. 
-    */
-    using ParticleList = std::vector<P>;
-
-    /*!
-      @brief Node partitioner for KD-tree construction.
-    */
-    using Partitioner = std::function<void(KDNode&)>;
-
-    /*!
-      @brief Disallowed constructor
-    */
-    KDNode(const KDNode&) = delete;
-
-    /*!
-      @brief Disallowed constructor
-    */
-    KDNode(const KDNode&&) = delete;
-
-    /*!
-      @brief Disallowed assignment
-    */
-    KDNode&
-    operator=(const KDNode&) = delete;
-
-    /*!
-      @brief Disallowed assignment
-    */
-    KDNode&
-    operator=(const KDNode&&) = delete;
-
-    /*!
-      @brief Default constructor
-    */
-    KDNode();
-
-    /*!
-      @brief Valid constructor. Takes list of particles.
-      @param[inout] a_particles List of particles to be partitioned later. 
-      @note The input particle list is transferred to m_particles. 
-    */
-    KDNode(ParticleList& a_particles);
-
-    /*!
-      @brief Destructor. Does nothing.
-    */
-    virtual ~KDNode();
-
-    /*!
-      @brief Get the node weight
-    */
-    inline const Real&
-    weight() const noexcept;
-
-    /*!
-      @brief Get the node weight
-    */
-    inline Real&
-    weight() noexcept;
-
-    /*!
-      @brief Get particles in this node. 
-    */
-    inline const ParticleList&
-    getParticles() const noexcept;
-
-    /*!
-      @brief Get particles in this node. 
-    */
-    inline ParticleList&
-    getParticles() noexcept;
-
-    /*!
-      @brief Is leaf node or not.
-    */
-    inline bool
-    isLeafNode() const noexcept;
-
-    /*!
-      @brief Is leaf node or not.
-    */
-    inline bool
-    isInteriorNode() const noexcept;
-
-    /*!
-      @brief Gather particles further down in the subtree and return all particles (in the leaf nodes)
-    */
-    inline ParticleList
-    gatherParticles() const noexcept;
-
-    /*!
-      @brief Move the particles list further down in the subtree into this vector.
-      @note This clears the particles from the leaf nodes. Use gatherParticles if you do not
-      want to change the tree contents. 
-    */
-    inline ParticleList
-    moveParticles() noexcept;
-
-    /*!
-      @brief Get the left node.
-    */
-    inline std::shared_ptr<KDNode<P>>&
-    getLeft() noexcept;
-
-    /*!
-      @brief Get the right node.
-    */
-    inline std::shared_ptr<KDNode<P>>&
-    getRight() noexcept;
-
-  protected:
-    /*!
-      @brief Left KD-node
-    */
-    std::shared_ptr<KDNode> m_left;
-
-    /*!
-      @brief Right KD-node
-    */
-    std::shared_ptr<KDNode> m_right;
-
-    /*!
-      @brief Node weight
-    */
-    Real m_weight;
-
-    /*!
-      @brief List of particles
-    */
-    ParticleList m_particles;
-
-    /*!
-      @brief Gather particles further down in the subtree and return all particles (in the leaf nodes)
-      @param[inout] a_particles List of particles
-    */
-    inline void
-    gatherParticles(ParticleList& a_particles) const noexcept;
-
-    /*!
-      @brief Move particles further down in the subtree and return all particles (in the leaf nodes)
-      @param[inout] a_particles List of particles
-      @note This clears the particles from the leaf nodes. Use gatherParticles if you do not
-      want to change the tree contents. 
-    */
-    inline void
-    moveParticles(ParticleList& a_particles) noexcept;
-  };
+  template <class P,  Real& (P::*weight)(), const RealVect& (P::*position)() const>
+  static inline void
+  partitionAndSplitEqualWeightKD(KDNode<P>& a_node) noexcept;
 
   /*!
-    @brief Build a KD-tree following the "equal weight" principle when partitioning nodes.
+    @brief Recursively build a KD-tree following the "equal weight" principle when partitioning nodes.
     @details If the number of leaves is a factor of two, leaves exist on the same level and the weight in each node will differ by
     at most one physical particle. The template parameters are 
 
@@ -202,14 +60,14 @@ namespace ParticleManagement {
        P::*weight   -> Function pointer to particle weight
        P::*position -> Function pointer to particle position.
 
-    A possible call signature is e.g. buildKDTreeEqualWeight<P, &P::weight, &P::position>.
+    A possible call signature is e.g. recursivePartitionAndSplitEqualWeightKD<P, &P::weight, &P::position>.
     @param[inout] a_inputParticles Input particles. These are destroyed on output.
     @param[in] a_maxLeaves Maximum number of leaves in the tree.
     @return Returns leaf nodes with particles. 
   */
   template <class P,  Real& (P::*weight)(), const RealVect& (P::*position)() const>  
   static inline std::vector<std::shared_ptr<KDNode<P>>>
-  buildKDTreeEqualWeight(typename KDNode<P>::ParticleList& a_inputParticles, const int a_maxLeaves) noexcept;
+  recursivePartitionAndSplitEqualWeightKD(typename KDNode<P>::ParticleList& a_inputParticles, const int a_maxLeaves) noexcept;
 
   /*!
     @brief Remove physical particles from the input particles.

--- a/Source/Particle/CD_ParticleManagement.H
+++ b/Source/Particle/CD_ParticleManagement.H
@@ -30,13 +30,20 @@
 namespace ParticleManagement {
 
   /*!
-    @brief Concept for splitting a particle into more particles
+    @brief Declaration of a reconciliation function when splitting particles.
+    @details This is, for example, passed into the KD-tree equal-weight partioning structure, which may split a particle
+    such that the weight of the two nodes differ by at most one physical particle. By default, that method will call the
+    particle copy constructor, but this function permits the user to input a reconciliation function that manipulates other
+    class members in the split particles. 
   */
-  template<class P, size_t N>
-  using ParticleSplitter = std::function<std::array<P, N>(const P& p)>;
+  template <class P>
+  using BinaryParticleReconcile = std::function<void(P& p1, P& p2, const P& p0)>;
 
   /*!
     @brief Partition and split a KD-node with particles so that the weights are approximately the same. 
+
+    @param[inout] a_node Node to split. This MUST be a leaf node and it MUST be possible to split it. 
+    @param[in] a_particleReconcile Optional reconciliation function when splitting a particle into two new particles.
     @details This will partition particles on two sides of a plane parallel to one of the coordinate axis. The middle
     particle closest to this plane may be split, and the weights of the resulting particles are assigned such that the
     total weight of the two halves differ by at most one. The template parameters are 
@@ -46,13 +53,24 @@ namespace ParticleManagement {
        P::*position -> Function pointer to particle position.
 
     A possible call signature is e.g. recursivePartitionAndSplitEqualWeightKD<P, &P::weight, &P::position>.
+
+    The user can input a particle reconciliation function that manipulates the particle properties of the split particles. By default,
+    the split particles will use the copy constructor and thus inherit class members from p0, with the exception of the particle weights.
+    The reconcile function lets the user manipulate other particle properties, e.g. ones that are not properly captured by the particle copy
+    constructor, or that need some other form of reconciliation. 
   */
-  template <class P,  Real& (P::*weight)(), const RealVect& (P::*position)() const>
+  template <class P, Real& (P::*weight)(), const RealVect& (P::*position)() const>
   static inline void
-  partitionAndSplitEqualWeightKD(KDNode<P>& a_node) noexcept;
+  partitionAndSplitEqualWeightKD(
+    KDNode<P>&                       a_node,
+    const BinaryParticleReconcile<P> a_particleReconcile = [](P& p1, P& p2, const P& p0) -> void {
+    }) noexcept;
 
   /*!
     @brief Recursively build a KD-tree following the "equal weight" principle when partitioning nodes.
+    @param[inout] a_inputParticles Input particles. These are destroyed on output.
+    @param[in] a_maxLeaves Maximum number of leaves in the tree.
+    @return Returns leaf nodes containing the particles
     @details If the number of leaves is a factor of two, leaves exist on the same level and the weight in each node will differ by
     at most one physical particle. The template parameters are 
 
@@ -61,13 +79,20 @@ namespace ParticleManagement {
        P::*position -> Function pointer to particle position.
 
     A possible call signature is e.g. recursivePartitionAndSplitEqualWeightKD<P, &P::weight, &P::position>.
-    @param[inout] a_inputParticles Input particles. These are destroyed on output.
-    @param[in] a_maxLeaves Maximum number of leaves in the tree.
-    @return Returns leaf nodes with particles. 
+
+    The user can input a particle reconciliation function that manipulates the particle properties of the split particles. By default,
+    the split particles will use the copy constructor and thus inherit class members from p0, with the exception of the particle weights.
+    The reconcile function lets the user manipulate other particle properties, e.g. ones that are not properly captured by the particle copy
+    constructor, or that need some other form of reconciliation. 
+
   */
-  template <class P,  Real& (P::*weight)(), const RealVect& (P::*position)() const>  
+  template <class P, Real& (P::*weight)(), const RealVect& (P::*position)() const>
   static inline std::vector<std::shared_ptr<KDNode<P>>>
-  recursivePartitionAndSplitEqualWeightKD(typename KDNode<P>::ParticleList& a_inputParticles, const int a_maxLeaves) noexcept;
+  recursivePartitionAndSplitEqualWeightKD(
+    typename KDNode<P>::ParticleList& a_inputParticles,
+    const int                         a_maxLeaves,
+    const BinaryParticleReconcile<P>  a_particleReconcile = [](P& p1, P& p2, const P& p0) -> void {
+    }) noexcept;
 
   /*!
     @brief Remove physical particles from the input particles.

--- a/Source/Particle/CD_ParticleManagement.H
+++ b/Source/Particle/CD_ParticleManagement.H
@@ -29,6 +29,12 @@
 namespace ParticleManagement {
 
   /*!
+    @brief Simple abstraction for encapsulating a particle merging/splitting concept
+  */
+  template <class P>
+  using ParticleMerger = std::function<List<P>(List<P>& a_inputParticles)>;
+
+  /*!
     @brief Node in a particle-merging KD-tree. 
     @details This node type is used for partitioning particles into spatial subsets and merging/splitting them. 
     @details The template argument P is the particle type - the users decides how to merge/split/partition. 
@@ -47,11 +53,6 @@ namespace ParticleManagement {
       @brief Node partitioner for KD-tree construction.
     */
     using Partitioner = std::function<void(KDNode&)>;
-
-    /*!
-      @brief Stop function for KD-tree construction. 
-    */
-    using StopFunction = std::function<bool(const ParticleList&)>;
 
     /*!
       @brief Disallowed constructor
@@ -191,6 +192,24 @@ namespace ParticleManagement {
     inline void
     moveParticles(ParticleList& a_particles) noexcept;
   };
+
+  /*!
+    @brief Build a KD-tree following the "equal weight" principle when partitioning nodes.
+    @details If the number of leaves is a factor of two, leaves exist on the same level and the weight in each node will differ by
+    at most one physical particle. The template parameters are 
+
+       P            -> Particle type
+       P::*weight   -> Function pointer to particle weight
+       P::*position -> Function pointer to particle position.
+
+    A possible call signature is e.g. buildKDTreeEqualWeight<P, &P::weight, &P::position>.
+    @param[inout] a_inputParticles Input particles. These are destroyed on output.
+    @param[in] a_maxLeaves Maximum number of leaves in the tree.
+    @return Returns leaf nodes with particles. 
+  */
+  template <class P,  Real& (P::*weight)(), const RealVect& (P::*position)() const>  
+  static inline std::vector<std::shared_ptr<KDNode<P>>>
+  buildKDTreeEqualWeight(typename KDNode<P>::ParticleList& a_inputParticles, const int a_maxLeaves) noexcept;
 
   /*!
     @brief Remove physical particles from the input particles.

--- a/Source/Particle/CD_ParticleManagementImplem.H
+++ b/Source/Particle/CD_ParticleManagementImplem.H
@@ -151,7 +151,7 @@ namespace ParticleManagement {
     @note This only adjusts the weight of the median particle. The particle class P should have a copy constructor for the other
     fields; note that these fields are simply copied over when the particle is split and are not adjusted. 
   */
-  template <class P, Real& (P::*weight)(), const RealVect& (P::*position)() const>
+  template <class P,  Real& (P::*weight)(), const RealVect& (P::*position)() const>
   typename KDNode<P>::Partitioner PartitionEqualWeight = [](KDNode<P>& a_node) -> void {
     CH_assert(!(a_node.isInteriorNode()));
 
@@ -301,22 +301,53 @@ namespace ParticleManagement {
 #endif
   };
 
-  /*!
-    @brief Stop function which returns true if weight in node < 2
-    @note The particle type is P and P::*weight is a pointer to a member function providing const-reference access to the particle weight.
-  */
-  template <class P, const Real& (P::*weight)() const>
-  typename KDNode<P>::StopFunction InsufficientWeightForSplitting =
-    [](const typename KDNode<P>::ParticleList& a_particles) {
-      constexpr Real splitThresh = 2.0 - std::numeric_limits<Real>::min();
+  template <class P, Real& (P::*weight)(), const RealVect& (P::*position)() const>
+  inline std::vector<std::shared_ptr<KDNode<P>>>
+  buildKDTreeEqualWeight(typename KDNode<P>::ParticleList& a_inputParticles, const int a_maxLeaves) noexcept {
+    CH_TIME("ParticleManagement::buildKDTreeEqualWeight");
 
-      Real W = 0.0;
-      for (const auto& p : a_particles) {
-        W += (p.*weight)();
+    Real W = 0.0;
+
+    for (auto& p : a_inputParticles) {
+      W += (p.*weight)();
+    }
+
+    std::vector<std::shared_ptr<KDNode<P>>> leaves1;
+    std::vector<std::shared_ptr<KDNode<P>>> leaves2;
+    
+    leaves1.emplace_back(std::make_shared<KDNode<P>>(a_inputParticles));
+    leaves1[0]->weight() = W;
+
+    bool keepGoing = true;
+
+    while (keepGoing && leaves1.size() < a_maxLeaves) {
+      keepGoing = false;
+
+      for (const auto& l : leaves1) {
+	if (l->weight() > 2.0 - std::numeric_limits<Real>::min()) {
+	  ParticleManagement::PartitionEqualWeight<P, weight, position>(*l);
+
+	  leaves2.emplace_back(l->getLeft());
+	  leaves2.emplace_back(l->getRight());
+
+	  keepGoing = true;
+	}
+	else {
+	  leaves2.emplace_back(l);
+	}
+
+	// Break out if we have sufficient leaf nodes.
+	if (leaves2.size() >= a_maxLeaves) {
+	  break;
+	}
       }
 
-      return (W < splitThresh) ? true : false;
-    };
+      leaves1 = leaves2;
+      leaves2.resize(0);
+    }
+
+    return leaves1;
+  }
 
   template <typename P, typename T, typename>
   inline void

--- a/Source/Particle/CD_ParticleManagementImplem.H
+++ b/Source/Particle/CD_ParticleManagementImplem.H
@@ -31,7 +31,7 @@ namespace ParticleManagement {
   partitionAndSplitEqualWeightKD(KDNode<P>& a_node, const BinaryParticleReconcile<P> a_particleReconcile) noexcept
   {
     CH_assert(!(a_node.isInteriorNode()));
-    CH_assert(this->weight() > 2.0 - std::numeric_limits<Real>::min());
+    CH_assert(a_node.weight() > 2.0 - std::numeric_limits<Real>::min());
 
     constexpr Real splitThresh = 2.0 - std::numeric_limits<Real>::min();
 

--- a/Source/Particle/CD_ParticleManagementImplem.H
+++ b/Source/Particle/CD_ParticleManagementImplem.H
@@ -28,9 +28,10 @@ namespace ParticleManagement {
 
   template <class P, Real& (P::*weight)(), const RealVect& (P::*position)() const>
   static inline void
-  partitionAndSplitEqualWeightKD(KDNode<P>& a_node) noexcept
+  partitionAndSplitEqualWeightKD(KDNode<P>& a_node, const BinaryParticleReconcile<P> a_particleReconcile) noexcept
   {
     CH_assert(!(a_node.isInteriorNode()));
+    CH_assert(this->weight() > 2.0 - std::numeric_limits<Real>::min());
 
     constexpr Real splitThresh = 2.0 - std::numeric_limits<Real>::min();
 
@@ -110,7 +111,30 @@ namespace ParticleManagement {
         dwr += (ddw / N) * Nr;
       }
 
-      if (dwl > 0.0) {
+      if (dwl > 0.0 && dwr > 0.0) {
+        // Splitting particle.
+
+        P il(p);
+        P ir(p);
+
+        CH_assert(dwl >= 1.0);
+        CH_assert(dwr >= 1.0);
+
+        wl += dwl;
+        wr += dwr;
+
+        (il.*weight)() = dwl;
+        (ir.*weight)() = dwr;
+
+        // User can reconcile other particle properties.
+        a_particleReconcile(il, ir, p);
+
+        pl.emplace_back(std::move(il));
+        pr.emplace_back(std::move(ir));
+      }
+      else if (dwl > 0.0 && dwr == 0.0) {
+        // Particle assigned to left node.
+
         P il(p);
 
         CH_assert(dwl >= 1.0);
@@ -119,8 +143,9 @@ namespace ParticleManagement {
         (il.*weight)() = dwl;
         pl.emplace_back(std::move(il));
       }
+      else if (dwl == 0.0 && dwr > 0.0) {
+        // Particle assigned to right node.
 
-      if (dwr > 0.0) {
         P ir(p);
 
         CH_assert(dwr >= 1.0);
@@ -128,6 +153,11 @@ namespace ParticleManagement {
         wr += dwr;
         (ir.*weight)() = dwr;
         pr.emplace_back(std::move(ir));
+      }
+      else {
+        // Should not happen.
+
+        MayDay::Abort("ParticleManagement::partitionAndSplitEqualWeightKD - logic bust");
       }
     }
     else {
@@ -181,7 +211,8 @@ namespace ParticleManagement {
   template <class P, Real& (P::*weight)(), const RealVect& (P::*position)() const>
   inline std::vector<std::shared_ptr<KDNode<P>>>
   recursivePartitionAndSplitEqualWeightKD(typename KDNode<P>::ParticleList& a_inputParticles,
-                                          const int                         a_maxLeaves) noexcept
+                                          const int                         a_maxLeaves,
+                                          const BinaryParticleReconcile<P>  a_particleReconcile) noexcept
   {
     CH_TIME("ParticleManagement::recursivePartitionAndSplitEqualWeightKD");
 
@@ -191,41 +222,41 @@ namespace ParticleManagement {
       W += (p.*weight)();
     }
 
-    std::vector<std::shared_ptr<KDNode<P>>> leaves1;
-    std::vector<std::shared_ptr<KDNode<P>>> leaves2;
+    std::vector<std::shared_ptr<KDNode<P>>> leaves;
 
-    leaves1.emplace_back(std::make_shared<KDNode<P>>(a_inputParticles));
-    leaves1[0]->weight() = W;
+    leaves.emplace_back(std::make_shared<KDNode<P>>(a_inputParticles));
+    leaves[0]->weight() = W;
 
     bool keepGoing = true;
 
-    while (keepGoing && leaves1.size() < a_maxLeaves) {
+    while (keepGoing && leaves.size() < a_maxLeaves) {
       keepGoing = false;
 
-      for (const auto& l : leaves1) {
-        if (l->weight() > 2.0 - std::numeric_limits<Real>::min()) {
-          ParticleManagement::partitionAndSplitEqualWeightKD<P, weight, position>(*l);
+      std::vector<std::shared_ptr<KDNode<P>>> newLeaves;
 
-          leaves2.emplace_back(l->getLeft());
-          leaves2.emplace_back(l->getRight());
+      for (const auto& l : leaves) {
+        if (l->weight() > 2.0 - std::numeric_limits<Real>::min()) {
+          ParticleManagement::partitionAndSplitEqualWeightKD<P, weight, position>(*l, a_particleReconcile);
+
+          newLeaves.emplace_back(l->getLeft());
+          newLeaves.emplace_back(l->getRight());
 
           keepGoing = true;
         }
         else {
-          leaves2.emplace_back(l);
+          newLeaves.emplace_back(l);
         }
 
         // Break out if we have sufficient leaf nodes.
-        if (leaves2.size() >= a_maxLeaves) {
+        if (newLeaves.size() >= a_maxLeaves) {
           break;
         }
       }
 
-      leaves1 = leaves2;
-      leaves2.resize(0);
+      leaves = newLeaves;
     }
 
-    return leaves1;
+    return leaves;
   }
 
   template <typename P, typename T, typename>

--- a/Source/Particle/CD_ParticleManagementImplem.H
+++ b/Source/Particle/CD_ParticleManagementImplem.H
@@ -26,133 +26,10 @@
 
 namespace ParticleManagement {
 
-  template <class P>
-  inline KDNode<P>::KDNode() : m_left(nullptr), m_right(nullptr), m_weight(0.0)
-  {}
-
-  template <class P>
-  inline KDNode<P>::KDNode(ParticleList& a_particles)
-    : m_left(nullptr), m_right(nullptr), m_weight(0.0), m_particles(std::move(a_particles))
-  {}
-
-  template <class P>
-  inline KDNode<P>::~KDNode()
-  {}
-
-  template <class P>
-  inline const typename KDNode<P>::ParticleList&
-  KDNode<P>::getParticles() const noexcept
+  template <class P, Real& (P::*weight)(), const RealVect& (P::*position)() const>
+  static inline void
+  partitionAndSplitEqualWeightKD(KDNode<P>& a_node) noexcept
   {
-    return m_particles;
-  }
-
-  template <class P>
-  inline typename KDNode<P>::ParticleList&
-  KDNode<P>::getParticles() noexcept
-  {
-    return m_particles;
-  }
-
-  template <class P>
-  inline const Real&
-  KDNode<P>::weight() const noexcept
-  {
-    return m_weight;
-  }
-
-  template <class P>
-  inline Real&
-  KDNode<P>::weight() noexcept
-  {
-    return m_weight;
-  }
-
-  template <class P>
-  inline bool
-  KDNode<P>::isLeafNode() const noexcept
-  {
-    return (m_left == nullptr) && (m_right == nullptr);
-  }
-
-  template <class P>
-  inline bool
-  KDNode<P>::isInteriorNode() const noexcept
-  {
-    return !(this->isLeafNode());
-  }
-
-  template <class P>
-  inline typename KDNode<P>::ParticleList
-  KDNode<P>::gatherParticles() const noexcept
-  {
-    ParticleList primitives;
-
-    this->gatherParticles(primitives);
-
-    return primitives;
-  }
-
-  template <class P>
-  inline void
-  KDNode<P>::gatherParticles(ParticleList& a_particles) const noexcept
-  {
-    if (this->isLeafNode()) {
-      a_particles.reserve(a_particles.size() + m_particles.size());
-      a_particles.insert(a_particles.end(), m_particles.begin(), m_particles.end());
-    }
-    else {
-      m_left->gatherParticles(a_particles);
-      m_right->gatherParticles(a_particles);
-    }
-  }
-
-  template <class P>
-  inline typename KDNode<P>::ParticleList
-  KDNode<P>::moveParticles() noexcept
-  {
-    ParticleList primitives;
-
-    this->moveParticles(primitives);
-
-    return primitives;
-  }
-
-  template <class P>
-  inline void
-  KDNode<P>::moveParticles(ParticleList& a_particles) noexcept
-  {
-    if (this->isLeafNode()) {
-      a_particles.reserve(a_particles.size() + m_particles.size());
-
-      std::move(m_particles.begin(), m_particles.end(), std::back_inserter(a_particles));
-    }
-    else {
-      m_left->moveParticles(a_particles);
-      m_right->moveParticles(a_particles);
-    }
-  }
-
-  template <class P>
-  inline std::shared_ptr<KDNode<P>>&
-  KDNode<P>::getLeft() noexcept
-  {
-    return m_left;
-  }
-
-  template <class P>
-  inline std::shared_ptr<KDNode<P>>&
-  KDNode<P>::getRight() noexcept
-  {
-    return m_right;
-  }
-
-  /*!
-    @brief Partitioning method for KDNode<P> which equilibriates the weight across the two halves when splitting a node
-    @note This only adjusts the weight of the median particle. The particle class P should have a copy constructor for the other
-    fields; note that these fields are simply copied over when the particle is split and are not adjusted. 
-  */
-  template <class P,  Real& (P::*weight)(), const RealVect& (P::*position)() const>
-  typename KDNode<P>::Partitioner PartitionEqualWeight = [](KDNode<P>& a_node) -> void {
     CH_assert(!(a_node.isInteriorNode()));
 
     constexpr Real splitThresh = 2.0 - std::numeric_limits<Real>::min();
@@ -299,12 +176,14 @@ namespace ParticleManagement {
     CH_assert(WL == wl);
     CH_assert(WR == wr);
 #endif
-  };
+  }
 
   template <class P, Real& (P::*weight)(), const RealVect& (P::*position)() const>
   inline std::vector<std::shared_ptr<KDNode<P>>>
-  buildKDTreeEqualWeight(typename KDNode<P>::ParticleList& a_inputParticles, const int a_maxLeaves) noexcept {
-    CH_TIME("ParticleManagement::buildKDTreeEqualWeight");
+  recursivePartitionAndSplitEqualWeightKD(typename KDNode<P>::ParticleList& a_inputParticles,
+                                          const int                         a_maxLeaves) noexcept
+  {
+    CH_TIME("ParticleManagement::recursivePartitionAndSplitEqualWeightKD");
 
     Real W = 0.0;
 
@@ -314,7 +193,7 @@ namespace ParticleManagement {
 
     std::vector<std::shared_ptr<KDNode<P>>> leaves1;
     std::vector<std::shared_ptr<KDNode<P>>> leaves2;
-    
+
     leaves1.emplace_back(std::make_shared<KDNode<P>>(a_inputParticles));
     leaves1[0]->weight() = W;
 
@@ -324,22 +203,22 @@ namespace ParticleManagement {
       keepGoing = false;
 
       for (const auto& l : leaves1) {
-	if (l->weight() > 2.0 - std::numeric_limits<Real>::min()) {
-	  ParticleManagement::PartitionEqualWeight<P, weight, position>(*l);
+        if (l->weight() > 2.0 - std::numeric_limits<Real>::min()) {
+          ParticleManagement::partitionAndSplitEqualWeightKD<P, weight, position>(*l);
 
-	  leaves2.emplace_back(l->getLeft());
-	  leaves2.emplace_back(l->getRight());
+          leaves2.emplace_back(l->getLeft());
+          leaves2.emplace_back(l->getRight());
 
-	  keepGoing = true;
-	}
-	else {
-	  leaves2.emplace_back(l);
-	}
+          keepGoing = true;
+        }
+        else {
+          leaves2.emplace_back(l);
+        }
 
-	// Break out if we have sufficient leaf nodes.
-	if (leaves2.size() >= a_maxLeaves) {
-	  break;
-	}
+        // Break out if we have sufficient leaf nodes.
+        if (leaves2.size() >= a_maxLeaves) {
+          break;
+        }
       }
 
       leaves1 = leaves2;


### PR DESCRIPTION
## Summary

Add better abstractions for merging and splitting particles. After this, the API will use dependency injection and merge/split abstractions.

Closes #350 

## Intent

- [ ] Fix a bug or incorrect behavior.
- [ ] Add new capabilities.

## Checklist

- [ ] If relevant, add Sphinx documentation in the rst files. 
- [ ] Add doxygen documentation. 
