### PR TITLE
Bug fix when running without memory tracking

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
     needs: Formatting
     name: Linux-GNU
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     strategy:
       matrix:
         ver: [10,12]

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ Exec/Examples/StreamerInception/ElectrodeRoughness/report.txt
 Exec/Tests/StreamerInception/Vessel/report.txt
 
 pout.*
-time.table.*
+time.table*
 
 myApplications/*
 MyApplications/*

--- a/Source/Utilities/CD_MemoryReport.cpp
+++ b/Source/Utilities/CD_MemoryReport.cpp
@@ -23,7 +23,7 @@ void
 MemoryReport::getMaxMinMemoryUsage()
 {
   CH_TIME("MemoryReport::getMaxMinMemoryUsage");
-
+#ifdef CH_USE_MEMORY_TRACKING
   Real maxPeak;
   Real minPeak;
   Real maxUnfreed;
@@ -34,6 +34,7 @@ MemoryReport::getMaxMinMemoryUsage()
   pout() << "MemoryReport::getMaxMinMemoryUsage:"
          << "\t Max peak = " << 1.0 * maxPeak << "\t Min peak = " << 1.0 * minPeak
          << "\t Max unfreed = " << 1.0 * maxUnfreed << "\t Min unfreed = " << 1.0 * minUnfreed << endl;
+#endif
 }
 
 void
@@ -44,17 +45,19 @@ MemoryReport::getMaxMinMemoryUsage(Real& a_maxPeak, Real& a_minPeak, Real& a_max
   constexpr int BytesPerMB = 1024 * 1024;
 
   // Gets usage in bytes.
-  long long curMemLL;
-  long long peakMemLL;
+  long long curMemLL  = 0LL;
+  long long peakMemLL = 0LL;
+#ifdef CH_USE_MEMORY_TRACKING
   overallMemoryUsage(curMemLL, peakMemLL);
+#endif
 
   const int unfreedMem = int(curMemLL);
   const int peakMem    = int(peakMemLL);
 
-  int maxPeakMem;
-  int minPeakMem;
-  int maxUnfreedMem;
-  int minUnfreedMem;
+  int maxPeakMem    = 0;
+  int minPeakMem    = 0;
+  int maxUnfreedMem = 0;
+  int minUnfreedMem = 0;
 
   // Find maximum/minimum usage.
 #ifdef CH_MPI
@@ -83,9 +86,11 @@ MemoryReport::getMemoryUsage(Vector<Real>& a_peak, Vector<Real>& a_unfreed)
 
   constexpr int BytesPerMB = 1024 * 1024;
 
-  long long curMemLL;
-  long long peakMemLL;
+  long long curMemLL  = 0LL;
+  long long peakMemLL = 0LL;
+#ifdef CH_USE_MEMORY_TRACKING
   overallMemoryUsage(curMemLL, peakMemLL);
+#endif
 
   const int unfreedMem = int(curMemLL);
   const int peakMem    = int(peakMemLL);


### PR DESCRIPTION
## Summary

There was a missing preprocessor flag for when CH_USE_MEMORY_TRACKING was turned off.

Closes #365 

## Intent

- [x] Fix a bug or incorrect behavior.
- [ ] Add new capabilities.

## Checklist

- [ ] If relevant, add Sphinx documentation in the rst files. 
- [ ] Add doxygen documentation. 
