### PR TITLE
Update Chombo with particle scatter fix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
     needs: Formatting
     name: Linux-GNU
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     strategy:
       matrix:
         ver: [10,12]
@@ -96,7 +96,7 @@ jobs:
     needs: Formatting
     name: Linux-Intel
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     strategy:
       matrix:
         dim: [2, 3]

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ Exec/Examples/StreamerInception/ElectrodeRoughness/report.txt
 Exec/Tests/StreamerInception/Vessel/report.txt
 
 pout.*
-time.table.*
+time.table*
 
 myApplications/*
 MyApplications/*

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -2491,6 +2491,10 @@ ItoKMCJSON::secondaryEmissionEB(Vector<List<ItoParticle>>&       a_secondaryPart
   if (m_verbose) {
     pout() << m_className + "::secondaryEmissionEB" << endl;
   }
+
+  for (int i = 0; i < a_primaryCDRFluxes.size(); i++) {
+    a_secondaryCDRFluxes[i] = std::max(a_primaryCDRFluxes[i], 0.0);
+  }
 }
 
 int

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -1463,6 +1463,7 @@ ItoSolver::writeData(LevelData<EBCellFAB>& a_output,
 
   CH_START(t2);
   m_amr->copyData(scratch, *a_data[a_level], a_level, m_realm, m_realm);
+  scratch.exchange();
   CH_START(t2);
 
   // Interpolate ghost cells
@@ -1484,7 +1485,16 @@ ItoSolver::writeData(LevelData<EBCellFAB>& a_output,
   const Interval srcInterv(0, numComp - 1);
   const Interval dstInterv(a_comp, a_comp + numComp - 1);
 
-  m_amr->copyData(a_output, scratch, a_level, a_outputRealm, m_realm, dstInterv, srcInterv);
+  m_amr->copyData(a_output,
+                  scratch,
+                  a_level,
+                  a_outputRealm,
+                  m_realm,
+                  dstInterv,
+                  srcInterv,
+                  CopyStrategy::ValidGhost,
+                  CopyStrategy::ValidGhost);
+
   CH_STOP(t5);
 
   a_comp += numComp;


### PR DESCRIPTION
## Summary

Closes #369 

Also adds ghost cell copying for the ItoSolver plot routine and enables outflow for CDR fluxes in ItoKMC

## Intent

- [ ] Fix a bug or incorrect behavior.
- [ ] Add new capabilities.

## Checklist

- [ ] If relevant, add Sphinx documentation in the rst files. 
- [ ] Add doxygen documentation. 
