### PR TITLE
Support more than NGP for dirty photon sampling

### DIFF
--- a/Docs/Sphinx/source/Solvers/RTE.rst
+++ b/Docs/Sphinx/source/Solvers/RTE.rst
@@ -396,7 +396,7 @@ ___________________
 .. tip::
 
    The ``McPhoto`` class includes a hidden input parameter ``McPhoto.dirty_sampling = true/false`` which enables a cheaper sampling method for discrete photons when calling the ``advance`` method.
-   The caveat is that the method does not incorporate boundary intersect, only works for instantaneous propagation, forces NGP deposition of photons, and avoids filling the data holders that are necessary for load balancing.
+   The caveat is that the method does not incorporate boundary intersect, only works for instantaneous propagation, and avoids filling the data holders that are necessary for load balancing.
 
 Clarifications
 ^^^^^^^^^^^^^^

--- a/Source/RadiativeTransfer/CD_McPhoto.H
+++ b/Source/RadiativeTransfer/CD_McPhoto.H
@@ -204,7 +204,9 @@ public:
   */
   template <class P, const Real& (P::*particleScalarField)() const>
   void
-  depositPhotons(EBAMRCellData& a_phi, ParticleContainer<P>& a_particles, const DepositionType& a_deposition);
+  depositPhotons(EBAMRCellData&        a_phi,
+                 ParticleContainer<P>& a_particles,
+                 const DepositionType& a_deposition) const noexcept;
 
   /*!
     @brief Sort container by cell
@@ -604,12 +606,12 @@ protected:
   /*!
     @brief Scratch storage for holding the non-conservative deposition
   */
-  EBAMRIVData m_depositionNC;
+  mutable EBAMRIVData m_depositionNC;
 
   /*!
     @brief Scratch storage for holding the mass difference when using hybrid deposition
   */
-  EBAMRIVData m_massDiff;
+  mutable EBAMRIVData m_massDiff;
 
   /*!
     @brief All particles
@@ -673,7 +675,7 @@ protected:
   depositKappaConservative(EBAMRCellData&             a_phi,
                            ParticleContainer<P>&      a_particles,
                            const DepositionType       a_deposition,
-                           const CoarseFineDeposition a_coarseFineDeposition);
+                           const CoarseFineDeposition a_coarseFineDeposition) const noexcept;
 
   /*!
     @brief Make the "non-conservative" kappa deposition
@@ -681,7 +683,7 @@ protected:
     @param[in]  a_depositionKappaC Conservative deposition
   */
   void
-  depositNonConservative(EBAMRIVData& a_depositionNC, const EBAMRCellData& a_depositionKappaC);
+  depositNonConservative(EBAMRIVData& a_depositionNC, const EBAMRCellData& a_depositionKappaC) const noexcept;
 
   /*!
     @brief Make the hybrid deposition. Also compute the mass difference
@@ -690,7 +692,9 @@ protected:
     @param[in]    a_depositioNC    Non-conservative deposition
   */
   void
-  depositHybrid(EBAMRCellData& a_depositionH, EBAMRIVData& a_massDifference, const EBAMRIVData& a_depositionNC);
+  depositHybrid(EBAMRCellData&     a_depositionH,
+                EBAMRIVData&       a_massDifference,
+                const EBAMRIVData& a_depositionNC) const noexcept;
 
   /*!
     @brief Turn on/off transparent boundaries

--- a/Source/RadiativeTransfer/CD_McPhoto.H
+++ b/Source/RadiativeTransfer/CD_McPhoto.H
@@ -161,9 +161,9 @@ public:
 
   /*!
     @brief Dirty-sampling method for photons. 
-    @details This is a "dirty" routine in the sense that it does not respect the EB and deposits using an NGP scheme
-    (such that we don't have to communicate between sampling buckets). This is not something that we recommend using,
-    unless you have a geometry-less domain and NGP deposition is acceptable. If those are good for you, feel free to 
+    @details This is a "dirty" routine in the sense that it does not respect the EB and avoids filling m_bulkParticles.
+    If you also use an NGP scheme this avoids communication between sampling buckets. But this is not something that we recommend using,
+    unless you have a geometry-less domain. If those are good for you, feel free to 
     use this routine. 
     @param[inout] a_photons Computational photons. Will be populated and depleted inside the routine.
     @param[inout] a_phi Mesh-based density. Will be incremented by the generated photons.

--- a/Source/RadiativeTransfer/CD_McPhotoImplem.H
+++ b/Source/RadiativeTransfer/CD_McPhotoImplem.H
@@ -18,7 +18,9 @@
 
 template <class P, const Real& (P::*particleScalarField)() const>
 void
-McPhoto::depositPhotons(EBAMRCellData& a_phi, ParticleContainer<P>& a_photons, const DepositionType& a_deposition)
+McPhoto::depositPhotons(EBAMRCellData&        a_phi,
+                        ParticleContainer<P>& a_photons,
+                        const DepositionType& a_deposition) const noexcept
 {
   CH_TIME("McPhoto::depositPhotons(ParticleContainer)");
   if (m_verbosity > 5) {
@@ -65,7 +67,7 @@ void
 McPhoto::depositKappaConservative(EBAMRCellData&             a_phi,
                                   ParticleContainer<P>&      a_particles,
                                   const DepositionType       a_deposition,
-                                  const CoarseFineDeposition a_coarseFineDeposition)
+                                  const CoarseFineDeposition a_coarseFineDeposition) const noexcept
 {
   CH_TIME("McPhoto::depositKappaConservative");
   if (m_verbosity > 5) {


### PR DESCRIPTION
## Summary

As indicated in the title. User now has to explicitly select NGP if he wants the fastest dirty sampling method for McPhoto.

## Intent

- [ ] Fix a bug or incorrect behavior.
- [x] Add new capabilities.

## Checklist

- [x] If relevant, add Sphinx documentation in the rst files. 
- [x] Add doxygen documentation. 
