### PR TITLE
Let ItoKMC merge particles in the reaction step

### DIFF
--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -4071,6 +4071,9 @@ ItoKMCStepper<I, C, R, F>::reconcileParticles(const EBCellFAB& a_newParticlesPer
   const RealVect probLo  = m_amr->getProbLo();
   const EBISBox& ebisbox = m_amr->getEBISLayout(m_particleRealm, m_plasmaPhase)[a_level][a_dit];
 
+  // Number of computational particles to make on this level
+  const int ppc = (a_level < m_particlesPerCell.size()) ? m_particlesPerCell[a_level] : m_particlesPerCell.back();
+
   // List of valid grid cells
   const BaseFab<bool>& validCells = (*m_amr->getValidCells(m_particleRealm)[a_level])[a_dit];
 
@@ -4193,6 +4196,15 @@ ItoKMCStepper<I, C, R, F>::reconcileParticles(const EBCellFAB& a_newParticlesPer
 
       // Add the photoionization term. This will adds new particles from the photoionization reactions.
       m_physics->reconcilePhotoionization(itoParticles, cdrParticles, bulkPhotons);
+
+      // Merge the particles together.
+      if ((this->m_timeStep + 1) % this->m_mergeInterval == 0 && this->m_mergeInterval > 0) {
+        for (auto solverIt = m_ito->iterator(); solverIt.ok(); ++solverIt) {
+          const int idx = solverIt.index();
+
+          solverIt()->makeSuperparticlesEqualWeightKD(*itoParticles[idx], ppc);
+        }
+      }
     }
   };
 
@@ -4266,6 +4278,15 @@ ItoKMCStepper<I, C, R, F>::reconcileParticles(const EBCellFAB& a_newParticlesPer
 
       // Add the photoionization term. This will adds new particles from the photoionization reactions.
       m_physics->reconcilePhotoionization(itoParticles, cdrParticles, bulkPhotons);
+
+      // Merge the particles together.
+      if ((this->m_timeStep + 1) % this->m_mergeInterval == 0 && this->m_mergeInterval > 0) {
+        for (auto solverIt = m_ito->iterator(); solverIt.ok(); ++solverIt) {
+          const int idx = solverIt.index();
+
+          solverIt()->makeSuperparticlesEqualWeightKD(*itoParticles[idx], ppc);
+        }
+      }
     }
   };
 

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
@@ -381,14 +381,6 @@ ItoKMCGodunovStepper<I, C, R, F>::advance(const Real a_dt)
   this->advanceReactionNetwork(a_dt);
   m_timer.stopEvent("Reaction network");
 
-  // Build superparticles.
-  if ((this->m_timeStep + 1) % this->m_mergeInterval == 0 && this->m_mergeInterval > 0) {
-    this->barrier();
-    m_timer.startEvent("Super-particle management");
-    (this->m_ito)->makeSuperparticles(ItoSolver::WhichContainer::Bulk, (this->m_particlesPerCell));
-    m_timer.stopEvent("Super-particle management");
-  }
-
   // Sort particles per patch.
   this->barrier();
   m_timer.startEvent("Sort by patch");

--- a/Source/ItoDiffusion/CD_ItoSolver.H
+++ b/Source/ItoDiffusion/CD_ItoSolver.H
@@ -829,6 +829,14 @@ public:
                      const DataIndex      a_dit);
 
   /*!
+    @brief Superparticle merging with KD/BVH trees
+    @param[inout] a_particles        Particles to be merged/split
+    @param[in]    a_particlesPerCell Target number of particles per cell
+  */
+  virtual void
+  makeSuperparticlesEqualWeightKD(List<ItoParticle>& a_particles, const int a_particlesPerCell);
+
+  /*!
     @brief Remap the bulk particle container.
   */
   virtual void
@@ -1444,14 +1452,6 @@ protected:
   */
   virtual void
   depositHybrid(EBAMRCellData& a_depositionH, EBAMRIVData& a_massDifference, const EBAMRIVData& a_depositionNC) const;
-
-  /*!
-    @brief Superparticle merging with KD/BVH trees
-    @param[inout] a_particles        Particles to be merged/split
-    @param[in]    a_particlesPerCell Target number of particles per cell
-  */
-  virtual void
-  makeSuperparticlesEqualWeightKD(List<ItoParticle>& a_particles, const int a_particlesPerCell);
 
   /*!
     @brief Interpolate mobilities -- this will switch between the two ways of computing the particle mobility.


### PR DESCRIPTION
## Summary

The current implementation merged the particles after the reaction step, which meant that all patches on all levels were populated with new particles. The current approach merges after filling individual patches. 

Closes #394 

## Intent

- [ ] Fix a bug or incorrect behavior.
- [ ] Add new capabilities.

## Checklist

- [ ] If relevant, add Sphinx documentation in the rst files. 
- [ ] Add doxygen documentation. 
