### PR TITLE
Add support for H5Part files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.ex
 *.hdf5
+*.h5part
 *.MPI
 *.session*
 **/Make.defs.local

--- a/Source/ItoDiffusion/CD_ItoParticle.H
+++ b/Source/ItoDiffusion/CD_ItoParticle.H
@@ -40,6 +40,16 @@ class ItoParticle : public GenericParticle<5, 3>
 {
 public:
   /*!
+    @brief Naming convention for scalar fields
+  */
+  static std::vector<std::string> s_realVariables;
+
+  /*!
+    @brief Naming convention for vector fields
+  */
+  static std::vector<std::string> s_vectVariables;
+
+  /*!
     @brief Default constructor -- user should subsequently set the variables or call define.
     @note If the user has called setNumRuntimeScalars/Vectors then  will allocate runtime buffers
   */

--- a/Source/ItoDiffusion/CD_ItoParticle.cpp
+++ b/Source/ItoDiffusion/CD_ItoParticle.cpp
@@ -1,0 +1,19 @@
+/* chombo-discharge
+ * Copyright © 2021 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_ItoParticleImplem.cpp
+  @brief  Implementation of CD_ItoParticle.H
+  @author Robert Marskar
+*/
+
+// Our includes
+#include <CD_ItoParticle.H>
+#include <CD_NamespaceHeader.H>
+
+std::vector<std::string> ItoParticle::s_realVariables = {"weight", "mobility", "diffusion", "energy", "tmpReal"};
+std::vector<std::string> ItoParticle::s_vectVariables = {"oldPos", "velocity", "tmpVect"};
+
+#include <CD_NamespaceFooter.H>

--- a/Source/Particle/CD_GenericParticle.H
+++ b/Source/Particle/CD_GenericParticle.H
@@ -63,6 +63,34 @@ public:
   position() const;
 
   /*!
+    @brief Get the M scalars
+    @return m_scalars
+  */
+  inline const std::array<Real, M>&
+  getReals() const noexcept;
+
+  /*!
+    @brief Get the M scalars
+    @return m_scalars
+  */
+  inline std::array<Real, M>&
+  getReals() noexcept;
+
+  /*!
+    @brief Get the N vectors
+    @return m_vects
+  */
+  inline const std::array<RealVect, N>&
+  getVects() const noexcept;
+
+  /*!
+    @brief Get the N vectors
+    @return m_vects
+  */
+  inline std::array<RealVect, N>&
+  getVects() noexcept;
+
+  /*!
     @brief Get one of the scalars. 
     @details Template parameter is the position in the m_scalars array. This is templated so that compilers may throw
     compile-time errors if trying to fetch elements out of range. 

--- a/Source/Particle/CD_GenericParticleImplem.H
+++ b/Source/Particle/CD_GenericParticleImplem.H
@@ -57,6 +57,34 @@ GenericParticle<M, N>::position() const
 }
 
 template <size_t M, size_t N>
+inline const std::array<Real, M>&
+GenericParticle<M, N>::getReals() const noexcept
+{
+  return m_scalars;
+}
+
+template <size_t M, size_t N>
+inline std::array<Real, M>&
+GenericParticle<M, N>::getReals() noexcept
+{
+  return m_scalars;
+}
+
+template <size_t M, size_t N>
+inline const std::array<RealVect, N>&
+GenericParticle<M, N>::getVects() const noexcept
+{
+  return m_vectors;
+}
+
+template <size_t M, size_t N>
+inline std::array<RealVect, N>&
+GenericParticle<M, N>::getVects() noexcept
+{
+  return m_vectors;
+}
+
+template <size_t M, size_t N>
 template <size_t K>
 inline Real&
 GenericParticle<M, N>::real()

--- a/Source/Utilities/CD_DischargeIO.H
+++ b/Source/Utilities/CD_DischargeIO.H
@@ -28,6 +28,8 @@
 
 // Our includes
 #include <CD_EBAMRData.H>
+#include <CD_ParticleContainer.H>
+#include <CD_GenericParticle.H>
 #include <CD_NamespaceHeader.H>
 
 /*!
@@ -133,8 +135,33 @@ namespace DischargeIO {
   writeEBHDF5(const EBAMRCellData& a_data, const std::string& a_file);
 #endif
 
+#ifdef CH_USE_HDF5
+  /*!
+    @brief Write a particle container to an H5Part file. Good for quick and dirty visualization of particles
+    @details Use case is pretty straightforward but the user might need to cast particle types. E.g. call
+
+    writeH5Part<M,N>(a_filename, (const ParticleContainer<GenericParticle<M,N>>&) a_particles, ...)
+
+    Template substitution is not straightforward for this one. 
+    @param[in] a_filename File name
+    @param[in] a_particles Particles. Particle type must derive from GenericParticle<M, N>
+    @param[in] a_shift     Particle position shift
+    @param[in] a_realVars Variable names for the M real variables
+    @param[in] a_vectVars Variable names for the N vector variables
+  */
+  template <size_t M, size_t N>
+  void
+  writeH5Part(const std::string                               a_filename,
+              const ParticleContainer<GenericParticle<M, N>>& a_particles,
+              const RealVect&                                 a_shift    = RealVect::Zero,
+              const std::vector<std::string>&                 a_realVars = std::vector<std::string>(),
+              const std::vector<std::string>&                 a_vectVars = std::vector<std::string>()) noexcept;
+#endif
+
 } // namespace DischargeIO
 
 #include <CD_NamespaceFooter.H>
+
+#include <CD_DischargeIOImplem.H>
 
 #endif

--- a/Source/Utilities/CD_DischargeIOImplem.H
+++ b/Source/Utilities/CD_DischargeIOImplem.H
@@ -1,0 +1,248 @@
+/* chombo-discharge
+ * Copyright © 2024 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_DischargeIOImplem.H
+  @brief  Implementation of CD_DischargeIO.H
+  @author Robert Marskar
+*/
+
+#ifndef CD_DischargeIOImplem_H
+#define CD_DischargeIOImplem_H
+
+// Std includes
+#include <hdf5.h>
+
+// Our includes
+#include <CD_DischargeIO.H>
+#include <CD_NamespaceHeader.H>
+
+#ifdef CH_USE_HDF5
+template <size_t M, size_t N>
+void
+DischargeIO::writeH5Part(const std::string                               a_filename,
+                         const ParticleContainer<GenericParticle<M, N>>& a_particles,
+                         const RealVect&                                 a_shift,
+                         const std::vector<std::string>&                 a_realVars,
+                         const std::vector<std::string>&                 a_vectVars) noexcept
+{
+  CH_TIME("DischargeIO::writeH5Part");
+
+  MayDay::Warning("DischargeIOwriteH5Part -- should support header including time step and time");
+  MayDay::Warning("DischargeIOwriteH5Part -- add assertions if realVars > 0 && != M");
+  MayDay::Warning("DischargeIOwriteH5Part -- add assertions if vectVars > 0 && != N");
+  MayDay::Warning("DischargeIOwriteH5Part -- shift should be laster argument");
+
+  std::vector<std::string> realVariables(M);
+  std::vector<std::string> vectVariables(N);
+
+  if (a_realVars.size() == M) {
+    realVariables = a_realVars;
+  }
+  else {
+    for (int i = 0; i < M; i++) {
+      realVariables[i] = "real-" + std::to_string(i);
+    }
+  }
+
+  if (a_vectVars.size() == N) {
+    vectVariables = a_vectVars;
+  }
+  else {
+    for (int i = 0; i < N; i++) {
+      vectVariables[i] = "vect-" + std::to_string(i);
+    }
+  }
+
+  // Figure out the number of particles on each rank
+  const unsigned long long numParticlesLocal  = a_particles.getNumberOfValidParticlesLocal();
+  const unsigned long long numParticlesGlobal = a_particles.getNumberOfValidParticlesGlobal();
+
+  std::vector<unsigned long long> particlesPerRank;
+#ifdef CH_MPI
+  particlesPerRank.resize(numProc(), 0ULL);
+
+  std::vector<int> recv(numProc(), 1);
+  std::vector<int> displ(numProc(), 0);
+  for (int i = 0; i < numProc(); i++) {
+    displ[i] = i;
+  }
+  MPI_Allgatherv(&numParticlesLocal,
+                 1,
+                 MPI_UNSIGNED_LONG_LONG,
+                 &particlesPerRank[0],
+                 &recv[0],
+                 &displ[0],
+                 MPI_UNSIGNED_LONG_LONG,
+                 Chombo_MPI::comm);
+#else
+  particlesPerRank.resize(1);
+  particlesPerRank[0] = numParticlesGlobal;
+#endif
+
+  // Set up file access and create the file.
+  hid_t fileAccess = 0;
+#ifdef CH_MPI
+  fileAccess = H5Pcreate(H5P_FILE_ACCESS);
+  H5Pset_fapl_mpio(fileAccess, Chombo_MPI::comm, MPI_INFO_NULL);
+#endif
+
+  hid_t fileID = H5Fcreate(a_filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fileAccess);
+  H5Pclose(fileAccess);
+
+  // Define the top group necessary for the H5Part file format
+  hid_t grp = H5Gcreate2(fileID, "Step#0", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+  // Define dataspace dimensions.
+  hsize_t dims[1];
+  dims[0] = numParticlesGlobal;
+
+  hid_t fileSpaceID = H5Screate_simple(1, dims, nullptr);
+
+  // Memory space
+  hsize_t memDims[1];
+  memDims[0]       = numParticlesLocal;
+  hid_t memSpaceID = H5Screate_simple(1, memDims, nullptr);
+
+  // Set hyperslabs for file and memory
+  hsize_t fileStart[1];
+  hsize_t fileCount[1];
+
+  hsize_t memStart[1];
+  hsize_t memCount[1];
+
+  memStart[0]  = 0;
+  fileStart[0] = 0;
+  for (int i = 0; i < procID(); i++) {
+    fileStart[0] += particlesPerRank[i];
+  }
+  fileCount[0] = particlesPerRank[procID()];
+  memCount[0]  = particlesPerRank[procID()];
+
+  H5Sselect_hyperslab(fileSpaceID, H5S_SELECT_SET, fileStart, nullptr, fileCount, nullptr);
+  H5Sselect_hyperslab(memSpaceID, H5S_SELECT_SET, memStart, nullptr, memCount, nullptr);
+
+  // Create the ID and positional data sets
+  hid_t datasetID = H5Dcreate2(grp, "id", H5T_NATIVE_ULLONG, fileSpaceID, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  hid_t datasetX  = H5Dcreate2(grp, "x", H5T_NATIVE_DOUBLE, fileSpaceID, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  hid_t datasetY  = H5Dcreate2(grp, "y", H5T_NATIVE_DOUBLE, fileSpaceID, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+#if CH_SPACEDIM == 3
+  hid_t datasetZ = H5Dcreate2(grp, "z", H5T_NATIVE_DOUBLE, fileSpaceID, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+#endif
+
+  // Write ID data set
+  std::vector<unsigned long long> id;
+  std::vector<double>             x;
+  std::vector<double>             y;
+  std::vector<double>             z;
+
+  for (int lvl = 0; lvl <= a_particles.getFinestLevel(); lvl++) {
+    for (DataIterator dit(a_particles.getGrids()[lvl]); dit.ok(); ++dit) {
+      const List<GenericParticle<M, N>>& particles = a_particles[lvl][dit()].listItems();
+
+      for (ListIterator<GenericParticle<M, N>> lit(particles); lit.ok(); ++lit) {
+        id.push_back(procID());
+        x.push_back(lit().position()[0]);
+        y.push_back(lit().position()[1]);
+#if CH_SPACEDIM == 3
+        z.push_back(lit().position()[2]);
+#endif
+      }
+    }
+  }
+
+  H5Dwrite(datasetID, H5Dget_type(datasetID), memSpaceID, fileSpaceID, H5P_DEFAULT, &id[0]);
+  H5Dwrite(datasetX, H5Dget_type(datasetX), memSpaceID, fileSpaceID, H5P_DEFAULT, &x[0]);
+  H5Dwrite(datasetY, H5Dget_type(datasetY), memSpaceID, fileSpaceID, H5P_DEFAULT, &y[0]);
+#if CH_SPACEDIM == 3
+  H5Dwrite(datasetZ, H5Dget_type(datasetY), memSpaceID, fileSpaceID, H5P_DEFAULT, &z[0]);
+#endif
+
+  id.resize(0);
+  x.resize(0);
+  y.resize(0);
+  z.resize(0);
+
+  // Close the ID and positional data sets
+  H5Dclose(datasetID);
+  H5Dclose(datasetX);
+  H5Dclose(datasetY);
+#if CH_SPACEDIM == 3
+  H5Dclose(datasetZ);
+#endif
+
+  // Write the M real-variables
+  for (int curVar = 0; curVar < M; curVar++) {
+    hid_t dataset = H5Dcreate2(grp,
+                               realVariables[curVar].c_str(),
+                               H5T_NATIVE_DOUBLE,
+                               fileSpaceID,
+                               H5P_DEFAULT,
+                               H5P_DEFAULT,
+                               H5P_DEFAULT);
+
+    std::vector<double> ds;
+
+    for (int lvl = 0; lvl <= a_particles.getFinestLevel(); lvl++) {
+      for (DataIterator dit(a_particles.getGrids()[lvl]); dit.ok(); ++dit) {
+        const List<GenericParticle<M, N>>& particles = a_particles[lvl][dit()].listItems();
+
+        for (ListIterator<GenericParticle<M, N>> lit(particles); lit.ok(); ++lit) {
+          ds.push_back(lit().getReals()[curVar]);
+        }
+      }
+    }
+
+    // Write and clsoe dataset
+    H5Dwrite(dataset, H5Dget_type(dataset), memSpaceID, fileSpaceID, H5P_DEFAULT, &ds[0]);
+    H5Dclose(dataset);
+  }
+
+  // Write the N vector variables
+  for (int curVar = 0; curVar < N; curVar++) {
+    for (int dir = 0; dir < SpaceDim; dir++) {
+      std::string varName;
+      if (dir == 0) {
+        varName = vectVariables[curVar] + "-x";
+      }
+      else if (dir == 1) {
+        varName = vectVariables[curVar] + "-y";
+      }
+      else if (dir == 2) {
+        varName = vectVariables[curVar] + "-z";
+      }
+
+      hid_t dataset =
+        H5Dcreate2(grp, varName.c_str(), H5T_NATIVE_DOUBLE, fileSpaceID, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+      std::vector<double> ds;
+
+      for (int lvl = 0; lvl <= a_particles.getFinestLevel(); lvl++) {
+        for (DataIterator dit(a_particles.getGrids()[lvl]); dit.ok(); ++dit) {
+          const List<GenericParticle<M, N>>& particles = a_particles[lvl][dit()].listItems();
+
+          for (ListIterator<GenericParticle<M, N>> lit(particles); lit.ok(); ++lit) {
+            const RealVect var = lit().getVects()[curVar];
+
+            ds.push_back(var[dir]);
+          }
+        }
+      }
+
+      // Write and close dataset
+      H5Dwrite(dataset, H5Dget_type(dataset), memSpaceID, fileSpaceID, H5P_DEFAULT, &ds[0]);
+      H5Dclose(dataset);
+    }
+  }
+
+  // Close top group and file
+  H5Gclose(grp);
+  H5Fclose(fileID);
+}
+#endif
+
+#include <CD_NamespaceFooter.H>
+
+#endif


### PR DESCRIPTION
## Summary

This PR adds an H5Part write routine which can be applied to any ParticleContainer<GenericParticle<M, N>>. 

Todo: 

- [ ] Add support for cycles/metadata
- [ ] add assertions for realVars and vectVars size mismatch
- [ ] positional shift should be last argument
- [ ] Add documentation

## Intent

- [ ] Fix a bug or incorrect behavior.
- [x] Add new capabilities.

## Checklist

- [ ] If relevant, add Sphinx documentation in the rst files. 
- [ ] Add doxygen documentation. 
