### PR TITLE
Add support for H5Part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.ex
 *.hdf5
+*.h5part
 *.MPI
 *.session*
 **/Make.defs.local

--- a/Docs/Sphinx/source/Source/Particles.rst
+++ b/Docs/Sphinx/source/Source/Particles.rst
@@ -710,7 +710,42 @@ Likewise, to interpolate onto these fields we can call
    RefCountedPtr<AmrMesh> amr;
 
    amr->interpolateParticles<KineticParticle, &KineticParticle::mass >(...);
-   amr->interpolateParticles<KineticParticle, &KineticParticle::velocity>(...);		
+   amr->interpolateParticles<KineticParticle, &KineticParticle::velocity>(...);
+
+.. _Chap:ParticleVisualization:   
+
+Particle visualization
+----------------------
+
+.. note::
+
+   Particle visualization is currently a work in progress.
+
+Simple particle visualization can be performed by writing ``H5Part`` compatible files which can be read by VisIt.
+This is done through the function ``writeH5Part`` in the ``DischargeIO`` namespace, with the following signature:
+
+.. code-block:: c++
+
+  template <size_t M, size_t N>
+  void
+  writeH5Part(const std::string                               a_filename,
+              const ParticleContainer<GenericParticle<M, N>>& a_particles,
+              const std::vector<std::string>                  a_realVars = std::vector<std::string>(),
+              const std::vector<std::string>                  a_vectVars = std::vector<std::string>(),
+              const RealVect                                  a_shift    = RealVect::Zero) noexcept;
+
+This routine permits particles to be written (in parallel, when using MPI) into a file readable by VisIt.
+While users will typically not work directly with ``GenericParticle``, casting to a proper format is quite simple, e.g.
+
+.. code-block:: c++
+
+   // ItoParticle inherits GenericParticle<5,3>		
+   ParticleContainer<ItoParticle> myParticles;
+
+   DischargeIO::writeH5Part("my_particles.h5part", (const ParticleContainer<GenericParticle<5,3>>&) myParticles);
+
+The optional arguments ``a_realVars`` and ``a_vectVars`` permit the user to set the output variable names for the ``M`` scalar variables and the ``N`` vector variables.
+The argument ``a_shift`` will simply shift the particle positions in the output HDF5 file. 
 
 .. _Chap:SuperParticles:
 

--- a/Exec/Examples/ItoKMC/PartialDischarge/example.inputs
+++ b/Exec/Examples/ItoKMC/PartialDischarge/example.inputs
@@ -231,7 +231,7 @@ ItoKMCGodunovStepper.load_balance_particles                = false           # T
 ItoKMCGodunovStepper.load_indices                          = -1             # Which particle containers to use for load balancing (-1 => all)
 ItoKMCGodunovStepper.load_per_cell                         = 1.0            # Default load per grid cell.
 ItoKMCGodunovStepper.box_sorting                           = morton         # Box sorting when load balancing
-ItoKMCGodunovStepper.particles_per_cell                    = 64             # Max computational particles per cell
+ItoKMCGodunovStepper.particles_per_cell                    = 32             # Max computational particles per cell
 ItoKMCGodunovStepper.merge_interval                        = 1              # Time steps between superparticle merging
 ItoKMCGodunovStepper.regrid_superparticles                 = false          # Make superparticles during regrids
 ItoKMCGodunovStepper.min_particle_advection_cfl            = 0.0            # Advective time step CFL restriction
@@ -262,8 +262,8 @@ ItoKMCJSON.chemistry_file     = simple_air_chemistry.json ## Chemistry file
 ItoKMCJSON.dX                 = 2.0                     ## Maximum relative change Xnew/Xold during one time step.
 
 # Kinetic Monte Carlo solver settings. 
-ItoKMCJSON.max_new_particles  = 64                      ## Maximum number of computational particles to produce in reaction step
-ItoKMCJSON.max_new_photons    = 64                      ## Maximum number of computational photons to produce in reaction step	
+ItoKMCJSON.max_new_particles  = 32                      ## Maximum number of computational particles to produce in reaction step
+ItoKMCJSON.max_new_photons    = 32                      ## Maximum number of computational photons to produce in reaction step	
 ItoKMCJSON.Ncrit              = 5                       ## How many firings away from a Negative particle number?
 ItoKMCJSON.prop_eps           = 1.E99                   ## Maximum relative change in propensity function
 ItoKMCJSON.NSSA               = 10                      ## How many SSA steps to run when tau-leaping is inefficient

--- a/Exec/Examples/ItoKMC/PartialDischarge/example.inputs
+++ b/Exec/Examples/ItoKMC/PartialDischarge/example.inputs
@@ -231,7 +231,7 @@ ItoKMCGodunovStepper.load_balance_particles                = false           # T
 ItoKMCGodunovStepper.load_indices                          = -1             # Which particle containers to use for load balancing (-1 => all)
 ItoKMCGodunovStepper.load_per_cell                         = 1.0            # Default load per grid cell.
 ItoKMCGodunovStepper.box_sorting                           = morton         # Box sorting when load balancing
-ItoKMCGodunovStepper.particles_per_cell                    = 16             # Max computational particles per cell
+ItoKMCGodunovStepper.particles_per_cell                    = 64             # Max computational particles per cell
 ItoKMCGodunovStepper.merge_interval                        = 1              # Time steps between superparticle merging
 ItoKMCGodunovStepper.regrid_superparticles                 = false          # Make superparticles during regrids
 ItoKMCGodunovStepper.min_particle_advection_cfl            = 0.0            # Advective time step CFL restriction
@@ -262,8 +262,8 @@ ItoKMCJSON.chemistry_file     = simple_air_chemistry.json ## Chemistry file
 ItoKMCJSON.dX                 = 2.0                     ## Maximum relative change Xnew/Xold during one time step.
 
 # Kinetic Monte Carlo solver settings. 
-ItoKMCJSON.max_new_particles  = 32                      ## Maximum number of computational particles to produce in reaction step
-ItoKMCJSON.max_new_photons    = 32                      ## Maximum number of computational photons to produce in reaction step	
+ItoKMCJSON.max_new_particles  = 64                      ## Maximum number of computational particles to produce in reaction step
+ItoKMCJSON.max_new_photons    = 64                      ## Maximum number of computational photons to produce in reaction step	
 ItoKMCJSON.Ncrit              = 5                       ## How many firings away from a Negative particle number?
 ItoKMCJSON.prop_eps           = 1.E99                   ## Maximum relative change in propensity function
 ItoKMCJSON.NSSA               = 10                      ## How many SSA steps to run when tau-leaping is inefficient

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -20,6 +20,7 @@
 #include <CD_Units.H>
 #include <CD_DataParser.H>
 #include <CD_ParticleManagement.H>
+#include <CD_DataOps.H>
 #include <CD_NamespaceHeader.H>
 
 using namespace Physics::ItoKMC;
@@ -2931,7 +2932,10 @@ ItoKMCJSON::secondaryEmissionEB(Vector<List<ItoParticle>>&       a_secondaryPart
   const bool isCathode = a_E.dotProduct(a_bndryNormal) <= 0.0;
   const bool isAnode   = !isCathode;
 
-  const RealVect releasePosition = a_cellCenter + a_dx * a_cellCentroid;
+  RealVect lo = -0.5 * RealVect::Unit;
+  RealVect hi = +0.5 * RealVect::Unit;
+
+  DataOps::computeMinValidBox(lo, hi, a_bndryNormal, a_bndryCentroid);
 
   // Outflow for all CDR fluxes.
   for (int i = 0; i < a_primaryCDRFluxes.size(); i++) {
@@ -2967,6 +2971,9 @@ ItoKMCJSON::secondaryEmissionEB(Vector<List<ItoParticle>>&       a_secondaryPart
       // Release the particles.
       for (int i = 0; i < X.size(); i++) {
         if (X[i] > 0) {
+          const RealVect releasePosition =
+            Random::randomPosition(a_cellCenter, lo, hi, a_bndryCentroid, a_bndryNormal, a_dx, 0.0);
+
           for (const auto& p : plasmaProducts[i]) {
             const int Z = m_itoSpecies[p]->getChargeNumber();
 
@@ -2999,6 +3006,9 @@ ItoKMCJSON::secondaryEmissionEB(Vector<List<ItoParticle>>&       a_secondaryPart
       // Release the particles.
       for (int i = 0; i < X.size(); i++) {
         if (X[i] > 0) {
+          const RealVect releasePosition =
+            Random::randomPosition(a_cellCenter, lo, hi, a_bndryCentroid, a_bndryNormal, a_dx, 0.0);
+
           for (const auto& p : plasmaProducts[i]) {
             const int Z = m_itoSpecies[p]->getChargeNumber();
 

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepper.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepper.H
@@ -376,6 +376,12 @@ namespace Physics {
       */
       virtual void
       stepEulerMaruyamaCDR(const Real a_dt) noexcept;
+
+      /*!
+	@brief Utility function for plotting the ItoSolver particles. These are written in a particles folder
+      */
+      virtual void
+      plotParticles() const noexcept;
     };
   } // namespace ItoKMC
 } // namespace Physics

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepper.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepper.H
@@ -126,6 +126,12 @@ namespace Physics {
       readCheckpointData(HDF5Handle& a_handle, const int a_lvl) noexcept override;
 #endif
 
+      /*!
+	@brief Perform post-plot operations
+      */
+      virtual void
+      postPlot() noexcept override;
+
     protected:
       /*!
 	@brief Simple enum for distinguishing between algorithms

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
@@ -22,6 +22,7 @@
 #include <CD_DataOps.H>
 #include <CD_Units.H>
 #include <CD_Photon.H>
+#include <CD_DischargeIO.H>
 #include <CD_NamespaceHeader.H>
 
 using namespace Physics::ItoKMC;
@@ -201,7 +202,8 @@ ItoKMCGodunovStepper<I, C, R, F>::advance(const Real a_dt)
     pout() << this->m_name + "::advance" << endl;
   }
 
-  //  MayDay::Warning("ItoKMCGodunovStepper::advance -- missing hard conservation for extended conductivity");
+  // Option for plotting the Ito particles.
+  this->plotParticles();
 
   auto debugCharge = [this](const std::string a_message) -> void {
     const Real Qtot = this->computeTotalCharge();
@@ -1595,6 +1597,54 @@ ItoKMCGodunovStepper<I, C, R, F>::readCheckpointData(HDF5Handle& a_handle, const
   }
 }
 #endif
+
+template <typename I, typename C, typename R, typename F>
+void
+ItoKMCGodunovStepper<I, C, R, F>::plotParticles() const noexcept
+{
+  CH_TIME("ItoKMCGodunovStepper::plotParticles");
+  if (this->m_verbosity > 2) {
+    pout() << this->m_name + "::plotParticles" << endl;
+  }
+
+  bool plotParticles = false;
+
+  ParmParse pp(this->m_name.c_str());
+
+  pp.query("plot_particles", plotParticles);
+
+  if (plotParticles) {
+
+    // Create the output folder
+    std::string cmd;
+    int         success = 0;
+    if (procID() == 0) {
+      success = system("mkdir -p particles");
+    }
+
+    if (success != 0) {
+      MayDay::Error("ItoKMCGodunovStepper::plotParticles - could not create 'particles' directory");
+    }
+
+    for (auto solverIt = (this->m_ito)->iterator(); solverIt.ok(); ++solverIt) {
+      const RefCountedPtr<ItoSolver>&       solver    = solverIt();
+      const ParticleContainer<ItoParticle>& particles = solver->getParticles(ItoSolver::WhichContainer::Bulk);
+
+      // Set plot file name
+      const std::string prefix = "./particles/" + solver->getName();
+      char              fileChar[1000];
+      sprintf(fileChar, "%s.step%07d.%dd.h5part", prefix.c_str(), this->m_timeStep, SpaceDim);
+
+      // Plot the particles
+      DischargeIO::writeH5Part(std::string(fileChar),
+                               (const ParticleContainer<GenericParticle<5, 3>>&)particles,
+                               ItoParticle::s_realVariables,
+                               ItoParticle::s_vectVariables,
+                               this->m_amr->getProbLo(),
+                               this->m_time);
+    }
+  }
+}
 
 #include <CD_NamespaceFooter.H>
 

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
@@ -202,9 +202,6 @@ ItoKMCGodunovStepper<I, C, R, F>::advance(const Real a_dt)
     pout() << this->m_name + "::advance" << endl;
   }
 
-  // Option for plotting the Ito particles.
-  this->plotParticles();
-
   auto debugCharge = [this](const std::string a_message) -> void {
     const Real Qtot = this->computeTotalCharge();
     if (procID() == 0) {
@@ -1597,6 +1594,20 @@ ItoKMCGodunovStepper<I, C, R, F>::readCheckpointData(HDF5Handle& a_handle, const
   }
 }
 #endif
+
+template <typename I, typename C, typename R, typename F>
+void
+ItoKMCGodunovStepper<I, C, R, F>::postPlot() noexcept
+{
+  CH_TIME("ItoKMCGodunovStepper::postPlot");
+  if (this->m_verbosity > 5) {
+    pout() << this->m_name + "::postPlot" << endl;
+  }
+
+  this->m_physicsPlotVariables.clear();
+
+  this->plotParticles();
+}
 
 template <typename I, typename C, typename R, typename F>
 void

--- a/Source/ItoDiffusion/CD_ItoParticle.H
+++ b/Source/ItoDiffusion/CD_ItoParticle.H
@@ -40,6 +40,16 @@ class ItoParticle : public GenericParticle<5, 3>
 {
 public:
   /*!
+    @brief Naming convention for scalar fields
+  */
+  static std::vector<std::string> s_realVariables;
+
+  /*!
+    @brief Naming convention for vector fields
+  */
+  static std::vector<std::string> s_vectVariables;
+
+  /*!
     @brief Default constructor -- user should subsequently set the variables or call define.
     @note If the user has called setNumRuntimeScalars/Vectors then  will allocate runtime buffers
   */

--- a/Source/ItoDiffusion/CD_ItoParticle.cpp
+++ b/Source/ItoDiffusion/CD_ItoParticle.cpp
@@ -1,0 +1,19 @@
+/* chombo-discharge
+ * Copyright © 2021 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_ItoParticleImplem.cpp
+  @brief  Implementation of CD_ItoParticle.H
+  @author Robert Marskar
+*/
+
+// Our includes
+#include <CD_ItoParticle.H>
+#include <CD_NamespaceHeader.H>
+
+std::vector<std::string> ItoParticle::s_realVariables = {"weight", "mobility", "diffusion", "energy", "tmpReal"};
+std::vector<std::string> ItoParticle::s_vectVariables = {"oldPos", "velocity", "tmpVect"};
+
+#include <CD_NamespaceFooter.H>

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -21,6 +21,7 @@
 // Our includes
 #include <CD_SimpleItoParticle.H>
 #include <CD_NonCommParticle.H>
+#include <CD_DischargeIO.H>
 #include <CD_ItoSolver.H>
 #include <CD_Random.H>
 #include <CD_DataOps.H>
@@ -533,6 +534,12 @@ ItoSolver::initialData()
 
   // Add particles, remove the ones that are inside the EB, and then deposit
   this->removeCoveredParticles(bulkParticles, EBRepresentation::ImplicitFunction, tolerance);
+  const std::string fname = m_name + ".h5part";
+
+  //  const auto& outputParticles =
+
+  DischargeIO::writeH5Part(fname, (const ParticleContainer<GenericParticle<5, 3>>&)bulkParticles);
+
   this->depositParticles<ItoParticle, &ItoParticle::weight>(m_phi, bulkParticles, m_deposition, m_coarseFineDeposition);
 }
 

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -21,7 +21,6 @@
 // Our includes
 #include <CD_SimpleItoParticle.H>
 #include <CD_NonCommParticle.H>
-#include <CD_DischargeIO.H>
 #include <CD_ItoSolver.H>
 #include <CD_Random.H>
 #include <CD_DataOps.H>
@@ -534,12 +533,6 @@ ItoSolver::initialData()
 
   // Add particles, remove the ones that are inside the EB, and then deposit
   this->removeCoveredParticles(bulkParticles, EBRepresentation::ImplicitFunction, tolerance);
-  const std::string fname = m_name + ".h5part";
-
-  //  const auto& outputParticles =
-
-  DischargeIO::writeH5Part(fname, (const ParticleContainer<GenericParticle<5, 3>>&)bulkParticles);
-
   this->depositParticles<ItoParticle, &ItoParticle::weight>(m_phi, bulkParticles, m_deposition, m_coarseFineDeposition);
 }
 

--- a/Source/Particle/CD_GenericParticle.H
+++ b/Source/Particle/CD_GenericParticle.H
@@ -63,6 +63,34 @@ public:
   position() const;
 
   /*!
+    @brief Get the M scalars
+    @return m_scalars
+  */
+  inline const std::array<Real, M>&
+  getReals() const noexcept;
+
+  /*!
+    @brief Get the M scalars
+    @return m_scalars
+  */
+  inline std::array<Real, M>&
+  getReals() noexcept;
+
+  /*!
+    @brief Get the N vectors
+    @return m_vects
+  */
+  inline const std::array<RealVect, N>&
+  getVects() const noexcept;
+
+  /*!
+    @brief Get the N vectors
+    @return m_vects
+  */
+  inline std::array<RealVect, N>&
+  getVects() noexcept;
+
+  /*!
     @brief Get one of the scalars. 
     @details Template parameter is the position in the m_scalars array. This is templated so that compilers may throw
     compile-time errors if trying to fetch elements out of range. 

--- a/Source/Particle/CD_GenericParticleImplem.H
+++ b/Source/Particle/CD_GenericParticleImplem.H
@@ -57,6 +57,34 @@ GenericParticle<M, N>::position() const
 }
 
 template <size_t M, size_t N>
+inline const std::array<Real, M>&
+GenericParticle<M, N>::getReals() const noexcept
+{
+  return m_scalars;
+}
+
+template <size_t M, size_t N>
+inline std::array<Real, M>&
+GenericParticle<M, N>::getReals() noexcept
+{
+  return m_scalars;
+}
+
+template <size_t M, size_t N>
+inline const std::array<RealVect, N>&
+GenericParticle<M, N>::getVects() const noexcept
+{
+  return m_vectors;
+}
+
+template <size_t M, size_t N>
+inline std::array<RealVect, N>&
+GenericParticle<M, N>::getVects() noexcept
+{
+  return m_vectors;
+}
+
+template <size_t M, size_t N>
 template <size_t K>
 inline Real&
 GenericParticle<M, N>::real()

--- a/Source/Utilities/CD_DischargeIO.H
+++ b/Source/Utilities/CD_DischargeIO.H
@@ -28,6 +28,8 @@
 
 // Our includes
 #include <CD_EBAMRData.H>
+#include <CD_ParticleContainer.H>
+#include <CD_GenericParticle.H>
 #include <CD_NamespaceHeader.H>
 
 /*!
@@ -133,8 +135,33 @@ namespace DischargeIO {
   writeEBHDF5(const EBAMRCellData& a_data, const std::string& a_file);
 #endif
 
+#ifdef CH_USE_HDF5
+  /*!
+    @brief Write a particle container to an H5Part file. Good for quick and dirty visualization of particles
+    @details Use case is pretty straightforward but the user might need to cast particle types. E.g. call
+
+    writeH5Part<M,N>(a_filename, (const ParticleContainer<GenericParticle<M,N>>&) a_particles, ...)
+
+    Template substitution is not straightforward for this one. 
+    @param[in] a_filename File name
+    @param[in] a_particles Particles. Particle type must derive from GenericParticle<M, N>
+    @param[in] a_shift     Particle position shift
+    @param[in] a_realVars Variable names for the M real variables
+    @param[in] a_vectVars Variable names for the N vector variables
+  */
+  template <size_t M, size_t N>
+  void
+  writeH5Part(const std::string                               a_filename,
+              const ParticleContainer<GenericParticle<M, N>>& a_particles,
+              const RealVect&                                 a_shift    = RealVect::Zero,
+              const std::vector<std::string>&                 a_realVars = std::vector<std::string>(),
+              const std::vector<std::string>&                 a_vectVars = std::vector<std::string>()) noexcept;
+#endif
+
 } // namespace DischargeIO
 
 #include <CD_NamespaceFooter.H>
+
+#include <CD_DischargeIOImplem.H>
 
 #endif

--- a/Source/Utilities/CD_DischargeIO.H
+++ b/Source/Utilities/CD_DischargeIO.H
@@ -135,7 +135,6 @@ namespace DischargeIO {
   writeEBHDF5(const EBAMRCellData& a_data, const std::string& a_file);
 #endif
 
-#ifdef CH_USE_HDF5
   /*!
     @brief Write a particle container to an H5Part file. Good for quick and dirty visualization of particles
     @details Use case is pretty straightforward but the user might need to cast particle types. E.g. call
@@ -156,8 +155,6 @@ namespace DischargeIO {
               const std::vector<std::string>                  a_realVars = std::vector<std::string>(),
               const std::vector<std::string>                  a_vectVars = std::vector<std::string>(),
               const RealVect                                  a_shift    = RealVect::Zero) noexcept;
-
-#endif
 
 } // namespace DischargeIO
 

--- a/Source/Utilities/CD_DischargeIO.H
+++ b/Source/Utilities/CD_DischargeIO.H
@@ -143,19 +143,20 @@ namespace DischargeIO {
     writeH5Part<M,N>(a_filename, (const ParticleContainer<GenericParticle<M,N>>&) a_particles, ...)
 
     Template substitution is not straightforward for this one. 
-    @param[in] a_filename File name
+    @param[in] a_filename  File name
     @param[in] a_particles Particles. Particle type must derive from GenericParticle<M, N>
+    @param[in] a_realVars  Variable names for the M real variables
+    @param[in] a_vectVars  Variable names for the N vector variables
     @param[in] a_shift     Particle position shift
-    @param[in] a_realVars Variable names for the M real variables
-    @param[in] a_vectVars Variable names for the N vector variables
   */
   template <size_t M, size_t N>
   void
   writeH5Part(const std::string                               a_filename,
               const ParticleContainer<GenericParticle<M, N>>& a_particles,
-              const RealVect&                                 a_shift    = RealVect::Zero,
-              const std::vector<std::string>&                 a_realVars = std::vector<std::string>(),
-              const std::vector<std::string>&                 a_vectVars = std::vector<std::string>()) noexcept;
+              const std::vector<std::string>                  a_realVars = std::vector<std::string>(),
+              const std::vector<std::string>                  a_vectVars = std::vector<std::string>(),
+              const RealVect                                  a_shift    = RealVect::Zero) noexcept;
+
 #endif
 
 } // namespace DischargeIO

--- a/Source/Utilities/CD_DischargeIO.H
+++ b/Source/Utilities/CD_DischargeIO.H
@@ -147,6 +147,7 @@ namespace DischargeIO {
     @param[in] a_realVars  Variable names for the M real variables
     @param[in] a_vectVars  Variable names for the N vector variables
     @param[in] a_shift     Particle position shift
+    @param[in] a_shift     Time 
   */
   template <size_t M, size_t N>
   void
@@ -154,7 +155,8 @@ namespace DischargeIO {
               const ParticleContainer<GenericParticle<M, N>>& a_particles,
               const std::vector<std::string>                  a_realVars = std::vector<std::string>(),
               const std::vector<std::string>                  a_vectVars = std::vector<std::string>(),
-              const RealVect                                  a_shift    = RealVect::Zero) noexcept;
+              const RealVect                                  a_shift    = RealVect::Zero,
+              const Real                                      a_time     = 0.0) noexcept;
 
 } // namespace DischargeIO
 

--- a/Source/Utilities/CD_DischargeIOImplem.H
+++ b/Source/Utilities/CD_DischargeIOImplem.H
@@ -13,13 +13,14 @@
 #define CD_DischargeIOImplem_H
 
 // Std includes
+#ifdef CH_USE_HDF5
 #include <hdf5.h>
+#endif
 
 // Our includes
 #include <CD_DischargeIO.H>
 #include <CD_NamespaceHeader.H>
 
-#ifdef CH_USE_HDF5
 template <size_t M, size_t N>
 void
 DischargeIO::writeH5Part(const std::string                               a_filename,
@@ -28,10 +29,11 @@ DischargeIO::writeH5Part(const std::string                               a_filen
                          const std::vector<std::string>                  a_vectVars,
                          const RealVect                                  a_shift) noexcept
 {
+#ifdef CH_USE_HDF5
   CH_TIME("DischargeIO::writeH5Part");
 
   CH_assert(a_realVars.size() == 0 || a_realVars.size() == M);
-  CH_assert(a_vectVars.size() == 0 || a_vecVars.size() == N);
+  CH_assert(a_vectVars.size() == 0 || a_vectVars.size() == N);
 
   std::vector<std::string> realVariables(M);
   std::vector<std::string> vectVariables(N);
@@ -250,8 +252,8 @@ DischargeIO::writeH5Part(const std::string                               a_filen
   // Close top group and file
   H5Gclose(grp);
   H5Fclose(fileID);
-}
 #endif
+}
 
 #include <CD_NamespaceFooter.H>
 

--- a/Source/Utilities/CD_DischargeIOImplem.H
+++ b/Source/Utilities/CD_DischargeIOImplem.H
@@ -1,0 +1,248 @@
+/* chombo-discharge
+ * Copyright © 2024 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_DischargeIOImplem.H
+  @brief  Implementation of CD_DischargeIO.H
+  @author Robert Marskar
+*/
+
+#ifndef CD_DischargeIOImplem_H
+#define CD_DischargeIOImplem_H
+
+// Std includes
+#include <hdf5.h>
+
+// Our includes
+#include <CD_DischargeIO.H>
+#include <CD_NamespaceHeader.H>
+
+#ifdef CH_USE_HDF5
+template <size_t M, size_t N>
+void
+DischargeIO::writeH5Part(const std::string                               a_filename,
+                         const ParticleContainer<GenericParticle<M, N>>& a_particles,
+                         const RealVect&                                 a_shift,
+                         const std::vector<std::string>&                 a_realVars,
+                         const std::vector<std::string>&                 a_vectVars) noexcept
+{
+  CH_TIME("DischargeIO::writeH5Part");
+
+  MayDay::Warning("DischargeIOwriteH5Part -- should support header including time step and time");
+  MayDay::Warning("DischargeIOwriteH5Part -- add assertions if realVars > 0 && != M");
+  MayDay::Warning("DischargeIOwriteH5Part -- add assertions if vectVars > 0 && != N");
+  MayDay::Warning("DischargeIOwriteH5Part -- shift should be laster argument");
+
+  std::vector<std::string> realVariables(M);
+  std::vector<std::string> vectVariables(N);
+
+  if (a_realVars.size() == M) {
+    realVariables = a_realVars;
+  }
+  else {
+    for (int i = 0; i < M; i++) {
+      realVariables[i] = "real-" + std::to_string(i);
+    }
+  }
+
+  if (a_vectVars.size() == N) {
+    vectVariables = a_vectVars;
+  }
+  else {
+    for (int i = 0; i < N; i++) {
+      vectVariables[i] = "vect-" + std::to_string(i);
+    }
+  }
+
+  // Figure out the number of particles on each rank
+  const unsigned long long numParticlesLocal  = a_particles.getNumberOfValidParticlesLocal();
+  const unsigned long long numParticlesGlobal = a_particles.getNumberOfValidParticlesGlobal();
+
+  std::vector<unsigned long long> particlesPerRank;
+#ifdef CH_MPI
+  particlesPerRank.resize(numProc(), 0ULL);
+
+  std::vector<int> recv(numProc(), 1);
+  std::vector<int> displ(numProc(), 0);
+  for (int i = 0; i < numProc(); i++) {
+    displ[i] = i;
+  }
+  MPI_Allgatherv(&numParticlesLocal,
+                 1,
+                 MPI_UNSIGNED_LONG_LONG,
+                 &particlesPerRank[0],
+                 &recv[0],
+                 &displ[0],
+                 MPI_UNSIGNED_LONG_LONG,
+                 Chombo_MPI::comm);
+#else
+  particlesPerRank.resize(1);
+  particlesPerRank[0] = numParticlesGlobal;
+#endif
+
+  // Set up file access and create the file.
+  hid_t fileAccess = 0;
+#ifdef CH_MPI
+  fileAccess = H5Pcreate(H5P_FILE_ACCESS);
+  H5Pset_fapl_mpio(fileAccess, Chombo_MPI::comm, MPI_INFO_NULL);
+#endif
+
+  hid_t fileID = H5Fcreate(a_filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fileAccess);
+  H5Pclose(fileAccess);
+
+  // Define the top group necessary for the H5Part file format
+  hid_t grp = H5Gcreate2(fileID, "Step#0", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+  // Define dataspace dimensions.
+  hsize_t dims[1];
+  dims[0] = numParticlesGlobal;
+
+  hid_t fileSpaceID = H5Screate_simple(1, dims, nullptr);
+
+  // Memory space
+  hsize_t memDims[1];
+  memDims[0]       = numParticlesLocal;
+  hid_t memSpaceID = H5Screate_simple(1, memDims, nullptr);
+
+  // Set hyperslabs for file and memory
+  hsize_t fileStart[1];
+  hsize_t fileCount[1];
+
+  hsize_t memStart[1];
+  hsize_t memCount[1];
+
+  memStart[0]  = 0;
+  fileStart[0] = 0;
+  for (int i = 0; i < procID(); i++) {
+    fileStart[0] += particlesPerRank[i];
+  }
+  fileCount[0] = particlesPerRank[procID()];
+  memCount[0]  = particlesPerRank[procID()];
+
+  H5Sselect_hyperslab(fileSpaceID, H5S_SELECT_SET, fileStart, nullptr, fileCount, nullptr);
+  H5Sselect_hyperslab(memSpaceID, H5S_SELECT_SET, memStart, nullptr, memCount, nullptr);
+
+  // Create the ID and positional data sets
+  hid_t datasetID = H5Dcreate2(grp, "id", H5T_NATIVE_ULLONG, fileSpaceID, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  hid_t datasetX  = H5Dcreate2(grp, "x", H5T_NATIVE_DOUBLE, fileSpaceID, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  hid_t datasetY  = H5Dcreate2(grp, "y", H5T_NATIVE_DOUBLE, fileSpaceID, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+#if CH_SPACEDIM == 3
+  hid_t datasetZ = H5Dcreate2(grp, "z", H5T_NATIVE_DOUBLE, fileSpaceID, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+#endif
+
+  // Write ID data set
+  std::vector<unsigned long long> id;
+  std::vector<double>             x;
+  std::vector<double>             y;
+  std::vector<double>             z;
+
+  for (int lvl = 0; lvl <= a_particles.getFinestLevel(); lvl++) {
+    for (DataIterator dit(a_particles.getGrids()[lvl]); dit.ok(); ++dit) {
+      const List<GenericParticle<M, N>>& particles = a_particles[lvl][dit()].listItems();
+
+      for (ListIterator<GenericParticle<M, N>> lit(particles); lit.ok(); ++lit) {
+        id.push_back(procID());
+        x.push_back(lit().position()[0]);
+        y.push_back(lit().position()[1]);
+#if CH_SPACEDIM == 3
+        z.push_back(lit().position()[2]);
+#endif
+      }
+    }
+  }
+
+  H5Dwrite(datasetID, H5Dget_type(datasetID), memSpaceID, fileSpaceID, H5P_DEFAULT, &id[0]);
+  H5Dwrite(datasetX, H5Dget_type(datasetX), memSpaceID, fileSpaceID, H5P_DEFAULT, &x[0]);
+  H5Dwrite(datasetY, H5Dget_type(datasetY), memSpaceID, fileSpaceID, H5P_DEFAULT, &y[0]);
+#if CH_SPACEDIM == 3
+  H5Dwrite(datasetZ, H5Dget_type(datasetY), memSpaceID, fileSpaceID, H5P_DEFAULT, &z[0]);
+#endif
+
+  id.resize(0);
+  x.resize(0);
+  y.resize(0);
+  z.resize(0);
+
+  // Close the ID and positional data sets
+  H5Dclose(datasetID);
+  H5Dclose(datasetX);
+  H5Dclose(datasetY);
+#if CH_SPACEDIM == 3
+  H5Dclose(datasetZ);
+#endif
+
+  // Write the M real-variables
+  for (int curVar = 0; curVar < M; curVar++) {
+    hid_t dataset = H5Dcreate2(grp,
+                               realVariables[curVar].c_str(),
+                               H5T_NATIVE_DOUBLE,
+                               fileSpaceID,
+                               H5P_DEFAULT,
+                               H5P_DEFAULT,
+                               H5P_DEFAULT);
+
+    std::vector<double> ds;
+
+    for (int lvl = 0; lvl <= a_particles.getFinestLevel(); lvl++) {
+      for (DataIterator dit(a_particles.getGrids()[lvl]); dit.ok(); ++dit) {
+        const List<GenericParticle<M, N>>& particles = a_particles[lvl][dit()].listItems();
+
+        for (ListIterator<GenericParticle<M, N>> lit(particles); lit.ok(); ++lit) {
+          ds.push_back(lit().getReals()[curVar]);
+        }
+      }
+    }
+
+    // Write and clsoe dataset
+    H5Dwrite(dataset, H5Dget_type(dataset), memSpaceID, fileSpaceID, H5P_DEFAULT, &ds[0]);
+    H5Dclose(dataset);
+  }
+
+  // Write the N vector variables
+  for (int curVar = 0; curVar < N; curVar++) {
+    for (int dir = 0; dir < SpaceDim; dir++) {
+      std::string varName;
+      if (dir == 0) {
+        varName = vectVariables[curVar] + "-x";
+      }
+      else if (dir == 1) {
+        varName = vectVariables[curVar] + "-y";
+      }
+      else if (dir == 2) {
+        varName = vectVariables[curVar] + "-z";
+      }
+
+      hid_t dataset =
+        H5Dcreate2(grp, varName.c_str(), H5T_NATIVE_DOUBLE, fileSpaceID, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+      std::vector<double> ds;
+
+      for (int lvl = 0; lvl <= a_particles.getFinestLevel(); lvl++) {
+        for (DataIterator dit(a_particles.getGrids()[lvl]); dit.ok(); ++dit) {
+          const List<GenericParticle<M, N>>& particles = a_particles[lvl][dit()].listItems();
+
+          for (ListIterator<GenericParticle<M, N>> lit(particles); lit.ok(); ++lit) {
+            const RealVect var = lit().getVects()[curVar];
+
+            ds.push_back(var[dir]);
+          }
+        }
+      }
+
+      // Write and close dataset
+      H5Dwrite(dataset, H5Dget_type(dataset), memSpaceID, fileSpaceID, H5P_DEFAULT, &ds[0]);
+      H5Dclose(dataset);
+    }
+  }
+
+  // Close top group and file
+  H5Gclose(grp);
+  H5Fclose(fileID);
+}
+#endif
+
+#include <CD_NamespaceFooter.H>
+
+#endif

--- a/Source/Utilities/CD_DischargeIOImplem.H
+++ b/Source/Utilities/CD_DischargeIOImplem.H
@@ -108,6 +108,14 @@ DischargeIO::writeH5Part(const std::string                               a_filen
   // Define the top group necessary for the H5Part file format
   hid_t grp = H5Gcreate2(fileID, "Step#0", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
+  // Write the time attribute
+  hid_t scal = H5Screate(H5S_SCALAR);  
+  hid_t attr = H5Acreate(grp, "time", H5T_NATIVE_DOUBLE, scal, H5P_DEFAULT, H5P_DEFAULT);
+  herr_t err = H5Awrite(attr, H5T_NATIVE_DOUBLE, &a_time);
+
+  H5Sclose(scal);
+  H5Aclose(attr);    
+
   // Define dataspace dimensions.
   hsize_t dims[1];
   dims[0] = numParticlesGlobal;

--- a/Source/Utilities/CD_DischargeIOImplem.H
+++ b/Source/Utilities/CD_DischargeIOImplem.H
@@ -24,22 +24,26 @@ template <size_t M, size_t N>
 void
 DischargeIO::writeH5Part(const std::string                               a_filename,
                          const ParticleContainer<GenericParticle<M, N>>& a_particles,
-                         const RealVect&                                 a_shift,
-                         const std::vector<std::string>&                 a_realVars,
-                         const std::vector<std::string>&                 a_vectVars) noexcept
+                         const std::vector<std::string>                  a_realVars,
+                         const std::vector<std::string>                  a_vectVars,
+                         const RealVect                                  a_shift) noexcept
 {
   CH_TIME("DischargeIO::writeH5Part");
 
-  MayDay::Warning("DischargeIOwriteH5Part -- should support header including time step and time");
-  MayDay::Warning("DischargeIOwriteH5Part -- add assertions if realVars > 0 && != M");
-  MayDay::Warning("DischargeIOwriteH5Part -- add assertions if vectVars > 0 && != N");
-  MayDay::Warning("DischargeIOwriteH5Part -- shift should be laster argument");
+  CH_assert(a_realVars.size() == 0 || a_realVars.size() == M);
+  CH_assert(a_vectVars.size() == 0 || a_vecVars.size() == N);
 
   std::vector<std::string> realVariables(M);
   std::vector<std::string> vectVariables(N);
 
   if (a_realVars.size() == M) {
     realVariables = a_realVars;
+
+    for (int i = 0; i < M; i++) {
+      if (realVariables[i] == "") {
+        realVariables[i] = "real-" + std::to_string(i);
+      }
+    }
   }
   else {
     for (int i = 0; i < M; i++) {
@@ -49,6 +53,12 @@ DischargeIO::writeH5Part(const std::string                               a_filen
 
   if (a_vectVars.size() == N) {
     vectVariables = a_vectVars;
+
+    for (int i = 0; i < N; i++) {
+      if (vectVariables[i] == "") {
+        vectVariables[i] = "vect-" + std::to_string(i);
+      }
+    }
   }
   else {
     for (int i = 0; i < N; i++) {
@@ -144,10 +154,10 @@ DischargeIO::writeH5Part(const std::string                               a_filen
 
       for (ListIterator<GenericParticle<M, N>> lit(particles); lit.ok(); ++lit) {
         id.push_back(procID());
-        x.push_back(lit().position()[0]);
-        y.push_back(lit().position()[1]);
+        x.push_back(lit().position()[0] - a_shift[0]);
+        y.push_back(lit().position()[1] - a_shift[0]);
 #if CH_SPACEDIM == 3
-        z.push_back(lit().position()[2]);
+        z.push_back(lit().position()[2] - a_shift[0]);
 #endif
       }
     }

--- a/Source/Utilities/CD_DischargeIOImplem.H
+++ b/Source/Utilities/CD_DischargeIOImplem.H
@@ -109,12 +109,12 @@ DischargeIO::writeH5Part(const std::string                               a_filen
   hid_t grp = H5Gcreate2(fileID, "Step#0", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
   // Write the time attribute
-  hid_t scal = H5Screate(H5S_SCALAR);  
-  hid_t attr = H5Acreate(grp, "time", H5T_NATIVE_DOUBLE, scal, H5P_DEFAULT, H5P_DEFAULT);
-  herr_t err = H5Awrite(attr, H5T_NATIVE_DOUBLE, &a_time);
+  hid_t  scal = H5Screate(H5S_SCALAR);
+  hid_t  attr = H5Acreate(grp, "time", H5T_NATIVE_DOUBLE, scal, H5P_DEFAULT, H5P_DEFAULT);
+  herr_t err  = H5Awrite(attr, H5T_NATIVE_DOUBLE, &a_time);
 
   H5Sclose(scal);
-  H5Aclose(attr);    
+  H5Aclose(attr);
 
   // Define dataspace dimensions.
   hsize_t dims[1];

--- a/Source/Utilities/CD_DischargeIOImplem.H
+++ b/Source/Utilities/CD_DischargeIOImplem.H
@@ -27,7 +27,8 @@ DischargeIO::writeH5Part(const std::string                               a_filen
                          const ParticleContainer<GenericParticle<M, N>>& a_particles,
                          const std::vector<std::string>                  a_realVars,
                          const std::vector<std::string>                  a_vectVars,
-                         const RealVect                                  a_shift) noexcept
+                         const RealVect                                  a_shift,
+                         const Real                                      a_time) noexcept
 {
 #ifdef CH_USE_HDF5
   CH_TIME("DischargeIO::writeH5Part");

--- a/Source/Utilities/CD_RandomImplem.H
+++ b/Source/Utilities/CD_RandomImplem.H
@@ -258,7 +258,7 @@ Random::randomPosition(const RealVect a_lo, const RealVect a_hi) noexcept
   RealVect pos = RealVect::Zero;
 
   for (int dir = 0; dir < SpaceDim; dir++) {
-    pos[dir] = a_lo[dir] + 0.5 * (1.0 + Random::getUniformReal11()) * (a_hi[dir] - a_lo[dir]);
+    pos[dir] = a_lo[dir] + Random::getUniformReal01() * (a_hi[dir] - a_lo[dir]);
   }
 
   return pos;


### PR DESCRIPTION
## Summary

This PR adds an H5Part write routine which can be applied to any ParticleContainer<GenericParticle<M, N>>. 

Todo: 

- [x] After tests pass, revert CD_ItoSolver.cpp to the main branch.
- [x] Add time attribute to H5Part files
- [x] Figure out where to release particles for secondary emission
- [x] Run experimental tests on particle merging

## Intent

- [ ] Fix a bug or incorrect behavior.
- [x] Add new capabilities.

## Checklist

- [x] If relevant, add Sphinx documentation in the rst files. 
- [x] Add doxygen documentation. 