### PR TITLE
More flexible particle merging routines

### DIFF
--- a/Exec/Examples/ItoKMC/AirBasic/example.inputs
+++ b/Exec/Examples/ItoKMC/AirBasic/example.inputs
@@ -107,6 +107,7 @@ FieldSolverMultigrid.gmg_smoother      = red_black         # Relaxation type. 'j
 # ItoSolver class options
 # ====================================================================================================
 ItoSolver.verbosity           = -1            # Class verbosity
+ItoSolver.merge_algorithm     = reinitialize  # Particle merging algorithm (see documentation)
 ItoSolver.plt_vars            = phi mu vel dco   # 'phi', 'vel', 'dco', 'part', 'eb_part', 'dom_part', 'src_part', 'energy_density', 'energy'
 ItoSolver.intersection_alg    = bisection     # Intersection algorithm for EB-particle intersections.
 ItoSolver.bisect_step         = 1.E-4         # Bisection step length for intersection tests

--- a/Exec/Examples/ItoKMC/AirBasic/example.inputs
+++ b/Exec/Examples/ItoKMC/AirBasic/example.inputs
@@ -246,7 +246,7 @@ ItoKMCGodunovStepper.load_balance_particles                = true           # Tu
 ItoKMCGodunovStepper.load_indices                          = -1             # Which particle containers to use for load balancing (-1 => all)
 ItoKMCGodunovStepper.load_per_cell                         = 1.0            # Default load per grid cell.
 ItoKMCGodunovStepper.box_sorting                           = morton         # Box sorting when load balancing
-ItoKMCGodunovStepper.particles_per_cell                    = 16             # Max computational particles per cell
+ItoKMCGodunovStepper.particles_per_cell                    = 32             # Max computational particles per cell
 ItoKMCGodunovStepper.merge_interval                        = 1              # Time steps between superparticle merging
 ItoKMCGodunovStepper.regrid_superparticles                 = false          # Make superparticles during regrids
 ItoKMCGodunovStepper.min_particle_advection_cfl            = 0.0            # Advective time step CFL restriction
@@ -283,7 +283,7 @@ ItoKMCJSON.Ncrit              = 5                       ## How many firings away
 ItoKMCJSON.prop_eps           = 1.E99                   ## Maximum relative change in propensity function
 ItoKMCJSON.NSSA               = 10                      ## How many SSA steps to run when tau-leaping is inefficient
 ItoKMCJSON.SSAlim             = 1.0                     ## When to enter SSA instead of tau-leaping
-ItoKMCJSON.algorithm          = hybrid_midpoint         ## 'ssa', 'tau_plain', 'tau_midpoint', 'hybrid_plain', or 'hybrid_midpoint'
+ItoKMCJSON.algorithm          = tau_plain         ## 'ssa', 'tau_plain', 'tau_midpoint', 'hybrid_plain', or 'hybrid_midpoint'
 
 # ====================================================================================================
 # ITO_PLASMA_STREAMER_TAGGER CLASS OPTIONS

--- a/Exec/Examples/ItoKMC/AirDBD/example.inputs
+++ b/Exec/Examples/ItoKMC/AirDBD/example.inputs
@@ -107,6 +107,7 @@ FieldSolverMultigrid.gmg_smoother      = red_black         # Relaxation type. 'j
 # ItoSolver class options
 # ====================================================================================================
 ItoSolver.verbosity           = -1            # Class verbosity
+ItoSolver.merge_algorithm     = reinitialize  # Particle merging algorithm (see documentation)
 ItoSolver.plt_vars            = phi mu vel dco   # 'phi', 'vel', 'dco', 'part', 'eb_part', 'dom_part', 'src_part', 'energy_density', 'energy'
 ItoSolver.intersection_alg    = bisection     # Intersection algorithm for EB-particle intersections.
 ItoSolver.bisect_step         = 1.E-4         # Bisection step length for intersection tests

--- a/Exec/Examples/ItoKMC/OldAir/development.inputs
+++ b/Exec/Examples/ItoKMC/OldAir/development.inputs
@@ -107,6 +107,7 @@ FieldSolverMultigrid.gmg_smoother      = red_black         # Relaxation type. 'j
 # ItoSolver class options
 # ====================================================================================================
 ItoSolver.verbosity           = -1            # Class verbosity
+ItoSolver.merge_algorithm     = reinitialize  # Particle merging algorithm (see documentation)
 ItoSolver.plt_vars            = phi vel dco   # 'phi', 'vel', 'dco', 'part', 'eb_part', 'dom_part', 'src_part', 'energy_density', 'energy'
 ItoSolver.intersection_alg    = bisection     # Intersection algorithm for EB-particle intersections.
 ItoSolver.bisect_step         = 1.E-4         # Bisection step length for intersection tests

--- a/Exec/Examples/ItoKMC/PartialDischarge/example.inputs
+++ b/Exec/Examples/ItoKMC/PartialDischarge/example.inputs
@@ -107,6 +107,7 @@ FieldSolverMultigrid.gmg_smoother      = red_black         # Relaxation type. 'j
 # ItoSolver class options
 # ====================================================================================================
 ItoSolver.verbosity           = -1            # Class verbosity
+ItoSolver.merge_algorithm     = reinitialize  # Particle merging algorithm (see documentation)
 ItoSolver.plt_vars            = phi mu vel dco   # 'phi', 'vel', 'dco', 'part', 'eb_part', 'dom_part', 'src_part', 'energy_density', 'energy'
 ItoSolver.intersection_alg    = bisection     # Intersection algorithm for EB-particle intersections.
 ItoSolver.bisect_step         = 1.E-4         # Bisection step length for intersection tests

--- a/Exec/Examples/ItoKMC/PartialDischarge/example.inputs
+++ b/Exec/Examples/ItoKMC/PartialDischarge/example.inputs
@@ -232,8 +232,8 @@ ItoKMCGodunovStepper.load_balance_particles                = false           # T
 ItoKMCGodunovStepper.load_indices                          = -1             # Which particle containers to use for load balancing (-1 => all)
 ItoKMCGodunovStepper.load_per_cell                         = 1.0            # Default load per grid cell.
 ItoKMCGodunovStepper.box_sorting                           = morton         # Box sorting when load balancing
-ItoKMCGodunovStepper.particles_per_cell                    = 32             # Max computational particles per cell
-ItoKMCGodunovStepper.merge_interval                        = -1             # Time steps between superparticle merging
+ItoKMCGodunovStepper.particles_per_cell                    = 64             # Max computational particles per cell
+ItoKMCGodunovStepper.merge_interval                        = 1             # Time steps between superparticle merging
 ItoKMCGodunovStepper.regrid_superparticles                 = false          # Make superparticles during regrids
 ItoKMCGodunovStepper.min_particle_advection_cfl            = 0.0            # Advective time step CFL restriction
 ItoKMCGodunovStepper.max_particle_advection_cfl            = 10.0           # Advective time step CFL restriction
@@ -263,8 +263,8 @@ ItoKMCJSON.chemistry_file     = simple_air_chemistry.json ## Chemistry file
 ItoKMCJSON.dX                 = 2.0                     ## Maximum relative change Xnew/Xold during one time step.
 
 # Kinetic Monte Carlo solver settings. 
-ItoKMCJSON.max_new_particles  = 16                      ## Maximum number of computational particles to produce in reaction step
-ItoKMCJSON.max_new_photons    = 16                      ## Maximum number of computational photons to produce in reaction step	
+ItoKMCJSON.max_new_particles  = 64                      ## Maximum number of computational particles to produce in reaction step
+ItoKMCJSON.max_new_photons    = 64                      ## Maximum number of computational photons to produce in reaction step	
 ItoKMCJSON.Ncrit              = 5                       ## How many firings away from a Negative particle number?
 ItoKMCJSON.prop_eps           = 1.E99                   ## Maximum relative change in propensity function
 ItoKMCJSON.NSSA               = 10                      ## How many SSA steps to run when tau-leaping is inefficient

--- a/Exec/Examples/ItoKMC/WireWire/example.inputs
+++ b/Exec/Examples/ItoKMC/WireWire/example.inputs
@@ -137,6 +137,7 @@ FieldSolverMultigrid.gmg_smoother      = red_black         # Relaxation type. 'j
 # ItoSolver class options
 # ====================================================================================================
 ItoSolver.verbosity           = -1            # Class verbosity
+ItoSolver.merge_algorithm     = reinitialize  # Particle merging algorithm (see documentation)
 ItoSolver.plt_vars            = phi vel dco   # 'phi', 'vel', 'dco', 'part', 'eb_part', 'dom_part', 'src_part', 'energy_density', 'energy'
 ItoSolver.intersection_alg    = bisection     # Intersection algorithm for EB-particle intersections.
 ItoSolver.bisect_step         = 1.E-4         # Bisection step length for intersection tests

--- a/Exec/Tests/BrownianWalker/DriftDiffusion/regression2d.inputs
+++ b/Exec/Tests/BrownianWalker/DriftDiffusion/regression2d.inputs
@@ -66,6 +66,7 @@ Driver.refine_dielectrics              = -1            # Refine dielectric surfa
 # ITO_SOLVER CLASS OPTIONS
 # ====================================================================================================
 ItoSolver.verbosity           = -1            # Class verbosity
+ItoSolver.merge_algorithm     = reinitialize  # Particle merging algorithm (see documentation)
 ItoSolver.plt_vars            = phi vel dco   # 'phi', 'vel', 'dco', 'part', 'eb_part', 'dom_part', 'src_part', 'energy_density', 'energy'
 ItoSolver.intersection_alg    = bisection     # Intersection algorithm for EB-particle intersections.
 ItoSolver.bisect_step         = 1.E-4         # Bisection step length for intersection tests

--- a/Exec/Tests/BrownianWalker/DriftDiffusion/regression3d.inputs
+++ b/Exec/Tests/BrownianWalker/DriftDiffusion/regression3d.inputs
@@ -66,6 +66,7 @@ Driver.refine_dielectrics              = -1            # Refine dielectric surfa
 # ITO_SOLVER CLASS OPTIONS
 # ====================================================================================================
 ItoSolver.verbosity           = -1            # Class verbosity
+ItoSolver.merge_algorithm     = reinitialize  # Particle merging algorithm (see documentation)
 ItoSolver.plt_vars            = phi vel dco   # 'phi', 'vel', 'dco', 'part', 'eb_part', 'dom_part', 'src_part', 'energy_density', 'energy'
 ItoSolver.intersection_alg    = bisection     # Intersection algorithm for EB-particle intersections.
 ItoSolver.bisect_step         = 1.E-4         # Bisection step length for intersection tests

--- a/Exec/Tests/ItoKMC/JSON/development.inputs
+++ b/Exec/Tests/ItoKMC/JSON/development.inputs
@@ -107,6 +107,7 @@ FieldSolverMultigrid.gmg_smoother      = red_black         # Relaxation type. 'j
 # ItoSolver class options
 # ====================================================================================================
 ItoSolver.verbosity           = -1            # Class verbosity
+ItoSolver.merge_algorithm     = reinitialize  # Particle merging algorithm (see documentation)
 ItoSolver.plt_vars            = phi mu vel dco   # 'phi', 'vel', 'dco', 'part', 'eb_part', 'dom_part', 'src_part', 'energy_density', 'energy'
 ItoSolver.intersection_alg    = bisection     # Intersection algorithm for EB-particle intersections.
 ItoSolver.bisect_step         = 1.E-4         # Bisection step length for intersection tests

--- a/Exec/Tests/ItoKMC/JSON/regression2d.inputs
+++ b/Exec/Tests/ItoKMC/JSON/regression2d.inputs
@@ -107,6 +107,7 @@ FieldSolverMultigrid.gmg_smoother      = red_black         # Relaxation type. 'j
 # ItoSolver class options
 # ====================================================================================================
 ItoSolver.verbosity           = -1            # Class verbosity
+ItoSolver.merge_algorithm     = reinitialize  # Particle merging algorithm (see documentation)
 ItoSolver.plt_vars            = phi mu vel dco   # 'phi', 'vel', 'dco', 'part', 'eb_part', 'dom_part', 'src_part', 'energy_density', 'energy'
 ItoSolver.intersection_alg    = bisection     # Intersection algorithm for EB-particle intersections.
 ItoSolver.bisect_step         = 1.E-4         # Bisection step length for intersection tests

--- a/Exec/Tests/ItoKMC/JSON/regression3d.inputs
+++ b/Exec/Tests/ItoKMC/JSON/regression3d.inputs
@@ -107,6 +107,7 @@ FieldSolverMultigrid.gmg_smoother      = red_black         # Relaxation type. 'j
 # ItoSolver class options
 # ====================================================================================================
 ItoSolver.verbosity           = -1            # Class verbosity
+ItoSolver.merge_algorithm     = reinitialize  # Particle merging algorithm (see documentation)
 ItoSolver.plt_vars            = phi mu vel dco   # 'phi', 'vel', 'dco', 'part', 'eb_part', 'dom_part', 'src_part', 'energy_density', 'energy'
 ItoSolver.intersection_alg    = bisection     # Intersection algorithm for EB-particle intersections.
 ItoSolver.bisect_step         = 1.E-4         # Bisection step length for intersection tests

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -4235,7 +4235,7 @@ ItoKMCStepper<I, C, R, F>::reconcileParticles(const EBCellFAB& a_newParticlesPer
           for (auto solverIt = m_ito->iterator(); solverIt.ok(); ++solverIt) {
             const int idx = solverIt.index();
 
-            solverIt()->makeSuperparticlesEqualWeightKD(*itoParticles[idx], ppc);
+            solverIt()->mergeParticles(*itoParticles[idx], CellInfo(iv, a_dx), ppc);
 
 #if 0 // Re-initialize particles
             List<ItoParticle>& oldParticles = *itoParticles[idx];
@@ -4338,7 +4338,9 @@ ItoKMCStepper<I, C, R, F>::reconcileParticles(const EBCellFAB& a_newParticlesPer
           for (auto solverIt = m_ito->iterator(); solverIt.ok(); ++solverIt) {
             const int idx = solverIt.index();
 
-            solverIt()->makeSuperparticlesEqualWeightKD(*itoParticles[idx], ppc);
+            const CellInfo cellInfo(iv, a_dx, kappa, bndryCentroid, bndryNormal);
+
+            solverIt()->mergeParticles(*itoParticles[idx], cellInfo, ppc);
           }
         }
       }

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -4236,6 +4236,25 @@ ItoKMCStepper<I, C, R, F>::reconcileParticles(const EBCellFAB& a_newParticlesPer
             const int idx = solverIt.index();
 
             solverIt()->makeSuperparticlesEqualWeightKD(*itoParticles[idx], ppc);
+
+#if 1 // Re-initialize particles
+            List<ItoParticle>& oldParticles = *itoParticles[idx];
+            long long          numPhysPart  = 0;
+            for (ListIterator<ItoParticle> lit(oldParticles); lit.ok(); ++lit) {
+              numPhysPart += (long long)(lit().weight());
+            }
+
+            const std::vector<long long> particleWeights = ParticleManagement::partitionParticleWeights(numPhysPart,
+                                                                                                        (long long)ppc);
+
+            oldParticles.clear();
+            for (int i = 0; i < particleWeights.size(); i++) {
+              const Real     w = 1.0 * particleWeights[i];
+              const RealVect p = Random::randomPosition(cellPos, lo, hi, bndryCentroid, bndryNormal, a_dx, kappa);
+
+              oldParticles.add(ItoParticle(w, p));
+            }
+#endif
           }
         }
       }
@@ -4315,7 +4334,7 @@ ItoKMCStepper<I, C, R, F>::reconcileParticles(const EBCellFAB& a_newParticlesPer
 
       // Merge the particles together.
       if (this->m_mergeInterval > 0) {
-        if ((this->m_timeStep + 1) % this->m_mergeInterval) {
+        if ((this->m_timeStep + 1) % this->m_mergeInterval == 0) {
           for (auto solverIt = m_ito->iterator(); solverIt.ok(); ++solverIt) {
             const int idx = solverIt.index();
 

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -4237,7 +4237,7 @@ ItoKMCStepper<I, C, R, F>::reconcileParticles(const EBCellFAB& a_newParticlesPer
 
             solverIt()->makeSuperparticlesEqualWeightKD(*itoParticles[idx], ppc);
 
-#if 1 // Re-initialize particles
+#if 0 // Re-initialize particles
             List<ItoParticle>& oldParticles = *itoParticles[idx];
             long long          numPhysPart  = 0;
             for (ListIterator<ItoParticle> lit(oldParticles); lit.ok(); ++lit) {

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -4236,25 +4236,6 @@ ItoKMCStepper<I, C, R, F>::reconcileParticles(const EBCellFAB& a_newParticlesPer
             const int idx = solverIt.index();
 
             solverIt()->mergeParticles(*itoParticles[idx], CellInfo(iv, a_dx), ppc);
-
-#if 0 // Re-initialize particles
-            List<ItoParticle>& oldParticles = *itoParticles[idx];
-            long long          numPhysPart  = 0;
-            for (ListIterator<ItoParticle> lit(oldParticles); lit.ok(); ++lit) {
-              numPhysPart += (long long)(lit().weight());
-            }
-
-            const std::vector<long long> particleWeights = ParticleManagement::partitionParticleWeights(numPhysPart,
-                                                                                                        (long long)ppc);
-
-            oldParticles.clear();
-            for (int i = 0; i < particleWeights.size(); i++) {
-              const Real     w = 1.0 * particleWeights[i];
-              const RealVect p = Random::randomPosition(cellPos, lo, hi, bndryCentroid, bndryNormal, a_dx, kappa);
-
-              oldParticles.add(ItoParticle(w, p));
-            }
-#endif
           }
         }
       }

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
@@ -1626,23 +1626,23 @@ ItoKMCGodunovStepper<I, C, R, F>::plotParticles() const noexcept
 
   if (plotParticles) {
 
-    // Create the output folder
-    std::string cmd;
-    int         success = 0;
-    if (procID() == 0) {
-      success = system("mkdir -p particles");
-    }
-
-    if (success != 0) {
-      MayDay::Error("ItoKMCGodunovStepper::plotParticles - could not create 'particles' directory");
-    }
-
     for (auto solverIt = (this->m_ito)->iterator(); solverIt.ok(); ++solverIt) {
       const RefCountedPtr<ItoSolver>&       solver    = solverIt();
       const ParticleContainer<ItoParticle>& particles = solver->getParticles(ItoSolver::WhichContainer::Bulk);
 
+      // Create the output folder
+      std::string cmd     = "mkdir -p particles/" + solver->getName();
+      int         success = 0;
+      if (procID() == 0) {
+        success = system(cmd.c_str());
+      }
+
+      if (success != 0) {
+        MayDay::Error("ItoKMCGodunovStepper::plotParticles - could not create 'particles' directory");
+      }
+
       // Set plot file name
-      const std::string prefix = "./particles/" + solver->getName();
+      const std::string prefix = "./particles/" + solver->getName() + "/" + solver->getName();
       char              fileChar[1000];
       sprintf(fileChar, "%s.step%07d.%dd.h5part", prefix.c_str(), this->m_timeStep, SpaceDim);
 

--- a/Source/AmrMesh/CD_CellInfo.H
+++ b/Source/AmrMesh/CD_CellInfo.H
@@ -25,27 +25,59 @@ class CellInfo
 {
 public:
   /*!
-    @brief Info for a regular cell
-  */
-  static const CellInfo Regular;
-
-  /*!
     @brief Default constructor - creates a regular cell
   */
-  CellInfo() noexcept;
+  CellInfo() = delete;
+
+  /*!
+    @brief Constructor which creates a regular cell 
+    @param[in] a_gridIndex     Grid index
+    @param[in] a_dx            Grid resolution
+  */
+  CellInfo(const IntVect a_gridIndex, const Real a_dx) noexcept;
 
   /*!
     @brief Constructor which automatically constructs an approximation to the minimum box enclosing the valid region of the cell
+    @param[in] a_gridIndex     Grid index
+    @param[in] a_dx            Grid resolution
     @param[in] a_volFrac       Volume fraction. 
     @param[in] a_bndryCentroid Boundary centroid
     @param[in] a_bndryNormal   Boundary normal
   */
-  CellInfo(const Real a_volFrac, const RealVect a_bndryCentroid, const RealVect a_bndryNormal) noexcept;
+  CellInfo(const IntVect  a_gridIndex,
+           const Real     a_dx,
+           const Real     a_volFrac,
+           const RealVect a_bndryCentroid,
+           const RealVect a_bndryNormal) noexcept;
 
   /*!
     @brief Destructor
   */
   virtual ~CellInfo() noexcept;
+
+  /*!
+    @brief Get the grid index
+  */
+  IntVect&
+  getGridIndex() noexcept;
+
+  /*!
+    @brief Get the grid index
+  */
+  const IntVect&
+  getGridIndex() const noexcept;
+
+  /*!
+    @brief Get the grid spacing
+  */
+  Real&
+  getDx() noexcept;
+
+  /*!
+    @brief Get the grid spacing
+  */
+  const Real&
+  getDx() const noexcept;
 
   /*!
     @brief Get the volume fraction
@@ -108,6 +140,16 @@ public:
   getValidHi() const noexcept;
 
 protected:
+  /*!
+    @brief Grid index
+  */
+  IntVect m_gridIndex;
+
+  /*!
+    @brief Grid spacing
+  */
+  Real m_dx;
+
   /*!
     @brief Volume fraction
   */

--- a/Source/AmrMesh/CD_CellInfo.H
+++ b/Source/AmrMesh/CD_CellInfo.H
@@ -1,0 +1,139 @@
+/* chombo-discharge
+ * Copyright © 2024 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_CellInfo.H
+  @brief  Simple class for holding some quantities relevant in a grid cell. 
+  @author Robert Marskar
+*/
+
+#ifndef CD_CellInfo_H
+#define CD_CellInfo_H
+
+// Chombo includes
+#include <RealVect.H>
+
+// Our includes
+#include <CD_NamespaceHeader.H>
+
+/*!
+  @brief Class for the cell-information that is often queried when merging particles inside a cell. 
+*/
+class CellInfo
+{
+public:
+  /*!
+    @brief Info for a regular cell
+  */
+  static const CellInfo Regular;
+
+  /*!
+    @brief Default constructor - creates a regular cell
+  */
+  CellInfo() noexcept;
+
+  /*!
+    @brief Constructor which automatically constructs an approximation to the minimum box enclosing the valid region of the cell
+    @param[in] a_volFrac       Volume fraction. 
+    @param[in] a_bndryCentroid Boundary centroid
+    @param[in] a_bndryNormal   Boundary normal
+  */
+  CellInfo(const Real a_volFrac, const RealVect a_bndryCentroid, const RealVect a_bndryNormal) noexcept;
+
+  /*!
+    @brief Destructor
+  */
+  virtual ~CellInfo() noexcept;
+
+  /*!
+    @brief Get the volume fraction
+  */
+  Real&
+  getVolFrac() noexcept;
+
+  /*!
+    @brief Get the volume fraction
+  */
+  const Real&
+  getVolFrac() const noexcept;
+
+  /*!
+    @brief Get the boundary centroid
+  */
+  RealVect&
+  getBndryCentroid() noexcept;
+
+  /*!
+    @brief Get the boundary centroid
+  */
+  const RealVect&
+  getBndryCentroid() const noexcept;
+
+  /*!
+    @brief Get the boundary normal
+  */
+  RealVect&
+  getBndryNormal() noexcept;
+
+  /*!
+    @brief Get the boundary normal
+  */
+  const RealVect&
+  getBndryNormal() const noexcept;
+
+  /*!
+    @brief Get the lower valid region
+  */
+  RealVect&
+  getValidLo() noexcept;
+
+  /*!
+    @brief Get the lower valid region
+  */
+  const RealVect&
+  getValidLo() const noexcept;
+
+  /*!
+    @brief Get the upper valid region
+  */
+  RealVect&
+  getValidHi() noexcept;
+
+  /*!
+    @brief Get the upper valid region
+  */
+  const RealVect&
+  getValidHi() const noexcept;
+
+protected:
+  /*!
+    @brief Volume fraction
+  */
+  Real m_volFrac;
+
+  /*!
+    @brief Boundary centroid
+  */
+  RealVect m_bndryCentroid;
+
+  /*!
+    @brief EB boundary normal
+  */
+  RealVect m_bndryNormal;
+
+  /*!
+    @brief Valid region in each direction (lower limit)
+  */
+  RealVect m_validLo;
+
+  /*!
+    @brief Valid region in each direction (upper limit)
+  */
+  RealVect m_validHi;
+};
+
+#include <CD_NamespaceFooter.H>
+
+#endif

--- a/Source/AmrMesh/CD_CellInfo.cpp
+++ b/Source/AmrMesh/CD_CellInfo.cpp
@@ -14,10 +14,10 @@
 #include <CD_CellInfo.H>
 #include <CD_NamespaceHeader.H>
 
-const CellInfo CellInfo::Regular = CellInfo();
-
-CellInfo::CellInfo() noexcept
+CellInfo::CellInfo(const IntVect a_gridIndex, const Real a_dx) noexcept
 {
+  m_gridIndex     = a_gridIndex;
+  m_dx            = a_dx;
   m_volFrac       = 1.0;
   m_bndryCentroid = RealVect::Zero;
   m_bndryNormal   = RealVect::Zero;
@@ -25,15 +25,50 @@ CellInfo::CellInfo() noexcept
   m_validHi       = 0.5 * RealVect::Unit;
 }
 
-CellInfo::CellInfo(const Real a_volFrac, const RealVect a_bndryCentroid, const RealVect a_bndryNormal) noexcept {
-  m_volFrac = a_volFrac;
+CellInfo::CellInfo(const IntVect  a_gridIndex,
+                   const Real     a_dx,
+                   const Real     a_volFrac,
+                   const RealVect a_bndryCentroid,
+                   const RealVect a_bndryNormal) noexcept
+{
+  m_gridIndex     = a_gridIndex;
+  m_dx            = a_dx;
+  m_volFrac       = a_volFrac;
   m_bndryCentroid = a_bndryCentroid;
-  m_bndryNormal = a_bndryNormal;
-  
-  DataOps::computeMinValidBox(m_validLo, m_validHi, m_bndryNormal, m_bndryCentroid);
+  m_bndryNormal   = a_bndryNormal;
+  m_validLo       = -0.5 * RealVect::Unit;
+  m_validHi       = 0.5 * RealVect::Unit;
+
+  if (a_volFrac < 1.0) {
+    DataOps::computeMinValidBox(m_validLo, m_validHi, m_bndryNormal, m_bndryCentroid);
+  }
 }
 
 CellInfo::~CellInfo() noexcept {}
+
+IntVect&
+CellInfo::getGridIndex() noexcept
+{
+  return m_gridIndex;
+}
+
+const IntVect&
+CellInfo::getGridIndex() const noexcept
+{
+  return m_gridIndex;
+}
+
+Real&
+CellInfo::getDx() noexcept
+{
+  return m_dx;
+}
+
+const Real&
+CellInfo::getDx() const noexcept
+{
+  return m_dx;
+}
 
 Real&
 CellInfo::getVolFrac() noexcept

--- a/Source/AmrMesh/CD_CellInfo.cpp
+++ b/Source/AmrMesh/CD_CellInfo.cpp
@@ -1,0 +1,98 @@
+/* chombo-discharge
+ * Copyright © 2024 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_CellInfo.cpp
+  @brief  Implementation of CD_CellInfo.H
+  @author Robert Marskar
+*/
+
+// Our includes
+#include <CD_DataOps.H>
+#include <CD_CellInfo.H>
+#include <CD_NamespaceHeader.H>
+
+const CellInfo CellInfo::Regular = CellInfo();
+
+CellInfo::CellInfo() noexcept
+{
+  m_volFrac       = 1.0;
+  m_bndryCentroid = RealVect::Zero;
+  m_bndryNormal   = RealVect::Zero;
+  m_validLo       = -0.5 * RealVect::Unit;
+  m_validHi       = 0.5 * RealVect::Unit;
+}
+
+CellInfo::CellInfo(const Real a_volFrac, const RealVect a_bndryCentroid, const RealVect a_bndryNormal) noexcept {
+  m_volFrac = a_volFrac;
+  m_bndryCentroid = a_bndryCentroid;
+  m_bndryNormal = a_bndryNormal;
+  
+  DataOps::computeMinValidBox(m_validLo, m_validHi, m_bndryNormal, m_bndryCentroid);
+}
+
+CellInfo::~CellInfo() noexcept {}
+
+Real&
+CellInfo::getVolFrac() noexcept
+{
+  return (m_volFrac);
+}
+
+const Real&
+CellInfo::getVolFrac() const noexcept
+{
+  return (m_volFrac);
+}
+
+RealVect&
+CellInfo::getBndryCentroid() noexcept
+{
+  return (m_bndryCentroid);
+}
+
+const RealVect&
+CellInfo::getBndryCentroid() const noexcept
+{
+  return (m_bndryCentroid);
+}
+
+RealVect&
+CellInfo::getBndryNormal() noexcept
+{
+  return (m_bndryNormal);
+}
+
+const RealVect&
+CellInfo::getBndryNormal() const noexcept
+{
+  return (m_bndryNormal);
+}
+
+RealVect&
+CellInfo::getValidLo() noexcept
+{
+  return (m_validLo);
+}
+
+const RealVect&
+CellInfo::getValidLo() const noexcept
+{
+  return (m_validLo);
+}
+
+RealVect&
+CellInfo::getValidHi() noexcept
+{
+  return (m_validHi);
+}
+
+const RealVect&
+CellInfo::getValidHi() const noexcept
+{
+  return (m_validHi);
+}
+
+#include <CD_NamespaceFooter.H>

--- a/Source/ItoDiffusion/CD_ItoSolver.H
+++ b/Source/ItoDiffusion/CD_ItoSolver.H
@@ -21,6 +21,7 @@
 #include <CD_ParticleContainer.H>
 #include <CD_EBRepresentation.H>
 #include <CD_EBIntersection.H>
+#include <CD_CellInfo.H>
 #include <CD_NamespaceHeader.H>
 
 /*!

--- a/Source/ItoDiffusion/CD_ItoSolver.H
+++ b/Source/ItoDiffusion/CD_ItoSolver.H
@@ -22,6 +22,7 @@
 #include <CD_EBRepresentation.H>
 #include <CD_EBIntersection.H>
 #include <CD_CellInfo.H>
+#include <CD_ParticleManagement.H>
 #include <CD_NamespaceHeader.H>
 
 /*!
@@ -33,13 +34,6 @@
 class ItoSolver
 {
 public:
-  /*!
-    @brief Concept for splitting/merging particles
-    @param[inout] a_particles Particles to be merged/split
-    @param[in] a_numTargetParticles Number of target particles
-  */
-  using ParticleMerger = std::function<void(List<ItoParticle>& a_particles, const int a_numTargetParticles)>;
-
   /*!
     @brief Enum class for distinguishing various types of particle containers.
     @details This exists because the ItoSolver can partition particles into various containers, which is very useful when one wants to add particles from
@@ -72,17 +66,11 @@ public:
   virtual ~ItoSolver();
 
   /*!
-    @brief Set a default particle merger. This defaults to KD-tree merging following an "equal weight" principle.
-  */
-  virtual void
-  setDefaultParticleMerger() noexcept;
-
-  /*!
     @brief Set the particle merger. This will get called when merging particles using makeSuperparticles.
     @param[in] a_particleMerger Particle merger
   */
   virtual void
-  setParticleMerger(const ParticleMerger& a_particleMerger) noexcept;
+  setParticleMerger(const ParticleManagement::ParticleMerger<ItoParticle>& a_particleMerger) noexcept;
 
   /*!
     @brief Get this solver's name 
@@ -830,12 +818,33 @@ public:
                      const DataIndex      a_dit);
 
   /*!
-    @brief Superparticle merging with KD/BVH trees
+    @brief General superparticle merging with underlying algorithm through m_particleMerger
     @param[inout] a_particles        Particles to be merged/split
+    @param[in]    a_cellInfo         Arithmetic information about the current grid cell. 
     @param[in]    a_particlesPerCell Target number of particles per cell
   */
   virtual void
-  makeSuperparticlesEqualWeightKD(List<ItoParticle>& a_particles, const int a_particlesPerCell);
+  mergeParticles(List<ItoParticle>& a_particles, const CellInfo& a_cellInfo, const int a_particlesPerCell);
+
+  /*!
+    @brief Superparticle merging with KD/BVH trees
+    @param[inout] a_particles        Particles to be merged/split
+    @param[in]    a_cellInfo         Arithmetic information about the current grid cell. 
+    @param[in]    a_particlesPerCell Target number of particles per cell
+  */
+  virtual void
+  makeSuperparticlesEqualWeightKD(List<ItoParticle>& a_particles,
+                                  const CellInfo&    a_cellInfo,
+                                  const int          a_particlesPerCell);
+
+  /*!
+    @brief Particle re-initialization algorithm
+    @param[inout] a_particles        Particles to be merged/split
+    @param[in]    a_cellInfo         Arithmetic information about the current grid cell. 
+    @param[in]    a_particlesPerCell Target number of particles per cell
+  */
+  virtual void
+  reinitializeParticles(List<ItoParticle>& a_particles, const CellInfo& a_cellInfo, const int a_particlesPerCell);
 
   /*!
     @brief Remap the bulk particle container.
@@ -1058,7 +1067,7 @@ protected:
   /*!
     @brief Particle merger
   */
-  ParticleMerger m_particleMerger;
+  ParticleManagement::ParticleMerger<ItoParticle> m_particleMerger;
 
   /*!
     @brief Number of particles used when restarting a simulation -- this is relevant only when restarting from a "fluid" checkpoint file. 
@@ -1294,6 +1303,12 @@ protected:
   */
   void
   parseDeposition();
+
+  /*!
+    @brief Parse the super-particle merger
+  */
+  void
+  parseParticleMerger();
 
   /*!
     @brief Parse EB intersection algorithms

--- a/Source/ItoDiffusion/CD_ItoSolver.options
+++ b/Source/ItoDiffusion/CD_ItoSolver.options
@@ -2,6 +2,7 @@
 # ItoSolver class options
 # ====================================================================================================
 ItoSolver.verbosity           = -1            # Class verbosity
+ItoSolver.merge_algorithm     = reinitialize  # Particle merging algorithm (see documentation)
 ItoSolver.plt_vars            = phi vel dco   # 'phi', 'vel', 'dco', 'part', 'eb_part', 'dom_part', 'src_part', 'energy_density', 'energy'
 ItoSolver.intersection_alg    = bisection     # Intersection algorithm for EB-particle intersections.
 ItoSolver.bisect_step         = 1.E-4         # Bisection step length for intersection tests

--- a/Source/Particle/CD_ParticleManagement.H
+++ b/Source/Particle/CD_ParticleManagement.H
@@ -22,12 +22,22 @@
 
 // Our includes
 #include <CD_KDNode.H>
+#include <CD_CellInfo.H>
 #include <CD_NamespaceHeader.H>
 
 /*!
   @brief Namespace for various particle management tools. 
 */
 namespace ParticleManagement {
+
+  /*!
+    @brief Concept for splitting/merging particles
+    @param[inout] a_particles Particles to be merged/split
+    @param[in] a_numTargetParticles Number of target particles
+  */
+  template <class P>
+  using ParticleMerger =
+    std::function<void(List<P>& a_particles, const CellInfo& a_cellInfo, const int a_numTargetParticles)>;
 
   /*!
     @brief Declaration of a reconciliation function when splitting particles.

--- a/Source/Particle/CD_ParticleManagementImplem.H
+++ b/Source/Particle/CD_ParticleManagementImplem.H
@@ -375,12 +375,15 @@ namespace ParticleManagement {
       }
       else {
         const T W = a_numPhysicalParticles / a_maxCompParticles;
-        const T r = a_numPhysicalParticles % a_maxCompParticles;
+        T       r = a_numPhysicalParticles % a_maxCompParticles;
 
         if (W > zero) {
           ret.resize(a_maxCompParticles, W);
 
-          ret.back() += r;
+          for (int i = 0; i < ret.size() && r > zero; i++) {
+            ret[i] += one;
+            r--;
+          }
         }
         else {
           ret.resize(1, r);


### PR DESCRIPTION
## Summary

More flexible particle merging for ItoSolver. Also adds particle re-initialization instead of kd-based.

## Intent

- [ ] Fix a bug or incorrect behavior.
- [x] Add new capabilities.

## Checklist

- [x] If relevant, add Sphinx documentation in the rst files. 
- [x] Add doxygen documentation. 
