### PR TITLE
Let ItoKMC print rates in simple ASCII format

### DIFF
--- a/Docs/Sphinx/source/Applications/ItoKMC.rst
+++ b/Docs/Sphinx/source/Applications/ItoKMC.rst
@@ -1754,6 +1754,27 @@ A JSON specification that includes these
 	}	
     ]
 
+Printing rates
+______________
+
+``ItoKMCJSON`` can print the plasma reaction rates (including photon-generating ones) to file.
+This is done through an optional input argument ``print_rates`` in the input file (not the JSON specification).
+The following options are supported:
+
+.. code-block:: text
+
+   ItoKMCJSON.print_rates            = true
+   ItoKMCJSON.print_rates_minEN      = 1
+   ItoKMCJSON.print_rates_maxEN      = 1000
+   ItoKMCJSON.print_rates_num_points = 200
+   ItoKMCJSON.print_rates_spacing    = exponential
+   ItoKMCJSON.print_rates_filename   = fluid_rates.dat
+   ItoKMCJSON.print_rates_pos        = 0 0 0
+
+Setting ``ItoKMCJSON.print_rates`` to true in the input file will write all reaction rates as column data :math:`E/N, k(E/N)`.
+Here, :math:`k` indicates the *fluid rate*, so for a reaction :math:`A + B + C \xrightarrow{k}\ldots` it will include the rate :math:`k`.
+Reactions are ordered identical to the order of the reactions in the JSON specification.
+This feature is mostly used for debugging or development efforts. 
 
 
 Photoionization

--- a/Exec/Examples/ItoKMC/AirBasic/simple_air_chemistry.json
+++ b/Exec/Examples/ItoKMC/AirBasic/simple_air_chemistry.json
@@ -67,7 +67,8 @@
     },
     "eta": {
 	"type": "auto",
-	"species": "e"
+	"species": "e",
+	"preview": "eta.dat"
     },    
     "plasma species" :
     [
@@ -194,8 +195,8 @@
 	    }		
 	},
 	{
-	    // Definition of O2- plasma species.
-            "id": "O2-",            // Species ID
+	    // Definition of O- plasma species.
+            "id": "O-",            // Species ID
 	    "Z" : -1,               // Charge number
 	    "solver" : "ito",       // Solver type. Either 'ito' or 'cdr'
 	    "mobile" : false,       // Mobile or not
@@ -290,9 +291,9 @@
 	    "plot": true                                     // Optional. If true, the reaction rate will be plotted.
 	},
 	{
-	    // Tabulated reaction rate for e + O2 -> e + e + O2+	    
-	    "reaction": "e + O2 -> O2-",         // Reaction. Must contain the '->'
-	    "description": "Rate/O2 attachment", // Optional description of the reaction. Used when plotting the rate
+	    // Tabulated reaction rate for e + O2 -> O + O-
+	    "reaction": "e + O2 -> O-",         // Reaction. Must contain the '->'
+	    "description": "Rate/Dissociative attachment", // Optional description of the reaction. Used when plotting the rate
 	    "type": "table vs E/N",              // Specification of reaction rate type
 	    "file" : "bolsig_air.dat",           // File containing the data
 	    "header" : "C27   O2    Attachment", // Header line preceding data
@@ -308,26 +309,6 @@
             "gradient correction": "e",          // Use gradient correction to rate
 	    "plot": true                         // Optional. If true, the reaction rate will be plotted.
 	},
-	{
-	    // Tabulated reaction rate for e + O2 -> e + e + O2+	    
-	    "reaction": "e + O2 + O2 -> O2- + O2",         // Reaction. Must contain the '->'
-	    "description": "Rate/O2 attachment", // Optional description of the reaction. Used when plotting the rate
-	    "type": "table vs E/N",              // Specification of reaction rate type
-	    "file" : "bolsig_air.dat",           // File containing the data
-	    "header" : "C26   O2    Attachment", // Header line preceding data
-	    "E/N column" : 0,                    // Optional specification of column containing E/N (defaults to 0)
-	    "rate/N column" : 1,                 // Optional specification of column containing alpha/N (defaults to 1)
-	    "min E/N" : 1.0,                     // Optional truncation of minium E/N kept when resampling the table (occurs after scaling)
-	    "max E/N" : 1000.0,                  // Optional truncation of maximum E/N kept when resampling the table (happens after scaling)
-	    "num points" : 1000,                 // Optional number of points kept when resamplnig the table (defaults to 1000)
-	    "spacing" : "exponential",           // Optional spcification of table representation. Defaults to 'exponential' but can also be 'linear'
-	    "scale E/N" : 1.0,                   // Optional scaling of the column containing E/N
-	    "scale rate/N" : 1.0,                // Optional scaling of the column containing rate/E
-	    // "dump" : "debug_r4.dat",          // Optional dump of internalized table to file. Useful for debugging.
-	    "scale": 1.0E-6,                     // Scaling as per BOLSIG+
-            "gradient correction": "e",          // Use gradient correction to rate
-	    "plot": true                         // Optional. If true, the reaction rate will be plotted.
-	},	
 	{
 	    // Tabulated reaction rate for e + N2 -> e + Y + N2
 	    "reaction": "e + N2 -> e + Y + (N2)",            // Reaction. Must contain the '->'

--- a/Exec/Examples/ItoKMC/AirDBD/simple_air_chemistry.json
+++ b/Exec/Examples/ItoKMC/AirDBD/simple_air_chemistry.json
@@ -221,8 +221,8 @@
 	    }		
 	},
 	{
-	    // Definition of O2- plasma species.
-            "id": "O2-",            // Species ID
+	    // Definition of O- plasma species.
+            "id": "O-",            // Species ID
 	    "Z" : -1,               // Charge number
 	    "solver" : "ito",       // Solver type. Either 'ito' or 'cdr'
 	    "mobile" : false,       // Mobile or not
@@ -317,8 +317,8 @@
 	    "plot": true                                     // Optional. If true, the reaction rate will be plotted.
 	},
 	{
-	    // Tabulated reaction rate for e + O2 -> e + e + O2+	    
-	    "reaction": "e + O2 -> O2-",         // Reaction. Must contain the '->'
+	    // Tabulated reaction rate for e + O2 -> O + O-
+	    "reaction": "e + O2 -> O + O-",         // Reaction. Must contain the '->'
 	    "description": "Rate/O2 attachment", // Optional description of the reaction. Used when plotting the rate
 	    "type": "table vs E/N",              // Specification of reaction rate type
 	    "file" : "bolsig_air.dat",           // File containing the data

--- a/Exec/Examples/ItoKMC/PartialDischarge/simple_air_chemistry.json
+++ b/Exec/Examples/ItoKMC/PartialDischarge/simple_air_chemistry.json
@@ -188,8 +188,8 @@
 	    }
 	},
 	{
-	    // Definition of O2- plasma species.
-            "id": "O2-",            // Species ID
+	    // Definition of O- plasma species.
+            "id": "O-",            // Species ID
 	    "Z" : -1,               // Charge number
 	    "solver" : "ito",       // Solver type. Either 'ito' or 'cdr'
 	    "mobile" : true,       // Mobile or not
@@ -284,8 +284,8 @@
 	    "plot": true                                     // Optional. If true, the reaction rate will be plotted.
 	},
 	{
-	    // Tabulated reaction rate for e + O2 -> e + e + O2+	    
-	    "reaction": "e + O2 -> O2-",         // Reaction. Must contain the '->'
+	    // Tabulated reaction rate for e + O2 -> O + O-
+	    "reaction": "e + O2 -> O-",         // Reaction. Must contain the '->'
 	    "description": "Rate/O2 attachment", // Optional description of the reaction. Used when plotting the rate
 	    "type": "table vs E/N",              // Specification of reaction rate type
 	    "file" : "bolsig_air.dat",           // File containing the data

--- a/Exec/Examples/ItoKMC/WireWire/chemistry.json
+++ b/Exec/Examples/ItoKMC/WireWire/chemistry.json
@@ -128,8 +128,8 @@
 	    }
 	},
 	{
-	    // Definition of O2- plasma species.
-            "id": "O2-",            // Species ID
+	    // Definition of O- plasma species.
+            "id": "O-",            // Species ID
 	    "Z" : -1,               // Charge number
 	    "solver" : "ito",       // Solver type. Either 'ito' or 'cdr'
 	    "mobile" : false,       // Mobile or not
@@ -224,8 +224,8 @@
 	    "plot": true                                     // Optional. If true, the reaction rate will be plotted.
 	},
 	{
-	    // Tabulated reaction rate for e + O2 -> e + e + O2+	    
-	    "reaction": "e + O2 -> O2-",         // Reaction. Must contain the '->'
+	    // Tabulated reaction rate for e + O2 -> O + O-
+	    "reaction": "e + O2 -> O + O-",         // Reaction. Must contain the '->'
 	    "description": "Rate/O2 attachment", // Optional description of the reaction. Used when plotting the rate
 	    "type": "table vs E/N",              // Specification of reaction rate type
 	    "file" : "bolsig_air.dat",           // File containing the data

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.H
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.H
@@ -562,6 +562,12 @@ namespace Physics {
       previewFunctionEX(const nlohmann::json& a_json, const FunctionEX& a_function) const;
 
       /*!
+	@brief Print the fluid-representation of the reaction rates.
+      */
+      virtual void
+      printFluidRates() const noexcept;
+
+      /*!
 	@brief Initialize the plasma species
       */
       virtual void

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -848,7 +848,7 @@ ItoKMCJSON::printFluidRates() const noexcept
     Vector<Real> pos;
     pp.query("print_rates_minEN", minEByN);
     pp.query("print_rates_maxEN", maxEByN);
-    pp.query("print_rates_num_point", numPoints);
+    pp.query("print_rates_num_points", numPoints);
     pp.query("print_rates_spacing", spacing);
     pp.query("print_rates_filename", filename);
     pp.queryarr("print_rates_pos", pos, 0, SpaceDim);


### PR DESCRIPTION
## Summary

ItoKMC can plot rates, but this feature permits it to print them to file, parametrized as E/N, k(E/N). Useful for development or debugging efforts.

Closes #429 

## Intent

- [ ] Fix a bug or incorrect behavior.
- [x] Add new capabilities.

## Checklist

- [x] If relevant, add Sphinx documentation in the rst files. 
- [x] Add doxygen documentation. 
