### PR TITLE
OpenMP-related improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.log
 *.aux
 *.0
+*.out
+compile_and_run.sh
 LB.txt
 
 

--- a/Source/Driver/CD_Driver.cpp
+++ b/Source/Driver/CD_Driver.cpp
@@ -432,9 +432,9 @@ Driver::getCellsAndBoxes(long long&                       a_numLocalCells,
     a_numTotalBoxes += boxesThisLevel;
 
     a_numLocalLevelBoxes[lvl] = numBoxes;
-    a_numTotalLevelBoxes[lvl] += boxesThisLevel;
+    a_numTotalLevelBoxes[lvl] = boxesThisLevel;
     a_numLocalLevelCells[lvl] = numCellsNoGhosts;
-    a_numTotalLevelCells[lvl] += numCellsNoGhosts;
+    a_numTotalLevelCells[lvl] = cellsThisLevel;
   }
 }
 

--- a/Source/Elliptic/CD_EBHelmholtzOp.H
+++ b/Source/Elliptic/CD_EBHelmholtzOp.H
@@ -465,6 +465,7 @@ public:
                    const EBCellFAB&       a_Acoef,
                    const EBFluxFAB&       a_Bcoef,
                    const BaseIVFAB<Real>& a_BcoefIrreg,
+                   const BaseIVFAB<Real>& a_alphaDiagWeight,
                    const Box&             a_cellBox,
                    const DataIndex&       a_dit,
                    const bool             a_homogeneousPhysBC);

--- a/Source/Elliptic/CD_EBHelmholtzOp.H
+++ b/Source/Elliptic/CD_EBHelmholtzOp.H
@@ -254,7 +254,7 @@ public:
                     const EBFluxFAB&       a_Bcoef,
                     const BaseIVFAB<Real>& a_BcoefIrreg,
                     const Box&             a_cellBox,
-                    const DataIndex&       a_dit);
+                    const DataIndex&       a_dit) const noexcept;
 
   /*!
     @brief Red-black Gauss-Seidel kernel
@@ -277,7 +277,7 @@ public:
                        const BaseIVFAB<Real>& a_BcoefIrreg,
                        const Box&             a_cellBox,
                        const DataIndex&       a_dit,
-                       const int&             a_redBlack);
+                       const int&             a_redBlack) const noexcept;
 
   /*!
     @brief Multi-color Gauss-Seidel kernel
@@ -300,7 +300,7 @@ public:
                          const BaseIVFAB<Real>& a_BcoefIrreg,
                          const Box&             a_cellBox,
                          const DataIndex&       a_dit,
-                         const IntVect&         a_color);
+                         const IntVect&         a_color) const noexcept;
 
   /*!
     @brief Compute residual on this level. 
@@ -403,7 +403,7 @@ public:
           const BaseIVFAB<Real>& a_BcoefIrreg,
           const Box&             a_cellBox,
           const DataIndex&       a_dit,
-          const bool             a_homogeneousPhysBC);
+          const bool             a_homogeneousPhysBC) const noexcept;
 
   /*!
     @brief Apply operator in regular cells.
@@ -421,7 +421,7 @@ public:
                  const BaseIVFAB<Real>& a_BcoefIrreg,
                  const Box&             a_cellBox,
                  const DataIndex&       a_dit,
-                 const bool             a_homogeneousPhysBC);
+                 const bool             a_homogeneousPhysBC) const noexcept;
 
   /*!
     @brief Apply domain flux. 
@@ -438,7 +438,7 @@ public:
                   const EBFluxFAB& a_Bcoef,
                   const Box&       a_cellBox,
                   const DataIndex& a_dit,
-                  const bool       a_homogeneousPhysBc);
+                  const bool       a_homogeneousPhysBc) const noexcept;
 
   /*!
     @brief Fill domain flux. This fills the flux on the domain face using centered differencing ala applyDomainFlux
@@ -468,7 +468,7 @@ public:
                    const BaseIVFAB<Real>& a_alphaDiagWeight,
                    const Box&             a_cellBox,
                    const DataIndex&       a_dit,
-                   const bool             a_homogeneousPhysBC);
+                   const bool             a_homogeneousPhysBC) const noexcept;
 
   /*!
     @brief Create data which clones the layout of the other

--- a/Source/Elliptic/CD_EBHelmholtzOp.H
+++ b/Source/Elliptic/CD_EBHelmholtzOp.H
@@ -923,6 +923,16 @@ protected:
   RealVect m_probLo;
 
   /*!
+    @brief Pre-built exchange copier
+  */
+  Copier m_exchangeCopier;
+
+  /*!
+    @brief Pre-built exchange copier
+  */
+  Copier m_exchangeCopierFine;
+
+  /*!
     @brief Fine level grid (if the operator has a fine level)
   */
   EBLevelGrid m_eblgFine;

--- a/Source/Elliptic/CD_EBHelmholtzOp.H
+++ b/Source/Elliptic/CD_EBHelmholtzOp.H
@@ -252,20 +252,26 @@ public:
 
   /*!
     @brief Red-black Gauss-Seidel kernel
-    @param[inout] a_Lcorr    Storage for computing L(a_corr)
-    @param[inout] a_corr     Correction
-    @param[in]    a_resid    Residual
-    @param[in]    a_redBlack Red or black
-    @param[in]    a_cellBox  Grid box
-    @param[in]    a_dit      Data index
+    @param[inout] a_Lcorr      Storage for computing L(a_corr)
+    @param[inout] a_corr       Correction
+    @param[in]    a_resid      Residual
+    @param[in]    a_Acoef      A-coefficient
+    @param[in]    a_Bcoef      B-coefficient
+    @param[in]    a_BcoefIrreg B-coefficient on EB faces
+    @param[in]    a_redBlack   Red or black
+    @param[in]    a_cellBox    Grid box
+    @param[in]    a_dit        Data index
   */
   void
-  gauSaiRedBlackKernel(EBCellFAB&       a_Lcorr,
-                       EBCellFAB&       a_corr,
-                       const EBCellFAB& a_resid,
-                       const Box&       a_cellBox,
-                       const DataIndex& a_dit,
-                       const int&       a_redBlack);
+  gauSaiRedBlackKernel(EBCellFAB&             a_Lcorr,
+                       EBCellFAB&             a_corr,
+                       const EBCellFAB&       a_resid,
+                       const EBCellFAB&       a_Acoef,
+                       const EBFluxFAB&       a_Bcoef,
+                       const BaseIVFAB<Real>& a_BcoefIrreg,
+                       const Box&             a_cellBox,
+                       const DataIndex&       a_dit,
+                       const int&             a_redBlack);
 
   /*!
     @brief Multi-color Gauss-Seidel kernel
@@ -376,11 +382,14 @@ public:
     @param[in]  a_homogeneousPhysBC Homogeneous physical BCs or not
   */
   void
-  applyOp(EBCellFAB&       a_Lphi,
-          EBCellFAB&       a_phi,
-          const Box&       a_cellBox,
-          const DataIndex& a_dit,
-          const bool       a_homogeneousPhysBC);
+  applyOp(EBCellFAB&             a_Lphi,
+          EBCellFAB&             a_phi,
+          const EBCellFAB&       a_Acoef,
+          const EBFluxFAB&       a_Bcoef,
+          const BaseIVFAB<Real>& a_BcoefIrreg,
+          const Box&             a_cellBox,
+          const DataIndex&       a_dit,
+          const bool             a_homogeneousPhysBC);
 
   /*!
     @brief Apply operator in regular cells.
@@ -391,11 +400,14 @@ public:
     @param[in]  a_homogeneousPhysBC Homogeneous physical BCs or not
   */
   void
-  applyOpRegular(EBCellFAB&       a_Lphi,
-                 EBCellFAB&       a_phi,
-                 const Box&       a_cellBox,
-                 const DataIndex& a_dit,
-                 const bool       a_homogeneousPhysBC);
+  applyOpRegular(EBCellFAB&             a_Lphi,
+                 EBCellFAB&             a_phi,
+                 const EBCellFAB&       a_Acoef,
+                 const EBFluxFAB&       a_Bcoef,
+                 const BaseIVFAB<Real>& a_BcoefIrreg,
+                 const Box&             a_cellBox,
+                 const DataIndex&       a_dit,
+                 const bool             a_homogeneousPhysBC);
 
   /*!
     @brief Apply domain flux. 
@@ -429,11 +441,14 @@ public:
     @param[in]  a_homogeneousPhysBC Homogeneous physical BCs or not
   */
   void
-  applyOpIrregular(EBCellFAB&       a_Lphi,
-                   const EBCellFAB& a_phi,
-                   const Box&       a_cellBox,
-                   const DataIndex& a_dit,
-                   const bool       a_homogeneousPhysBC);
+  applyOpIrregular(EBCellFAB&             a_Lphi,
+                   const EBCellFAB&       a_phi,
+                   const EBCellFAB&       a_Acoef,
+                   const EBFluxFAB&       a_Bcoef,
+                   const BaseIVFAB<Real>& a_BcoefIrreg,
+                   const Box&             a_cellBox,
+                   const DataIndex&       a_dit,
+                   const bool             a_homogeneousPhysBC);
 
   /*!
     @brief Create data which clones the layout of the other

--- a/Source/Elliptic/CD_EBHelmholtzOp.H
+++ b/Source/Elliptic/CD_EBHelmholtzOp.H
@@ -237,18 +237,24 @@ public:
 
   /*!
     @brief Point Jacobi kernel. 
-    @param[inout] a_Lcorr Storage for computing L(a_corr)
-    @param[inout] a_corr    Correction
-    @param[in]    a_resid   Residual
-    @param[in]    a_cellBox Grid box
-    @param[in]    a_dit     Data index
+    @param[inout] a_Lcorr      Storage for computing L(a_corr)
+    @param[inout] a_corr       Correction
+    @param[in]    a_resid      Residual
+    @param[in]    a_Acoef      A-coefficient
+    @param[in]    a_Bcoef      B-coefficient
+    @param[in]    a_BcoefIrreg B-coefficient on EB faces
+    @param[in]    a_cellBox    Grid box
+    @param[in]    a_dit        Data index
   */
   void
-  pointJacobiKernel(EBCellFAB&       a_Lcorr,
-                    EBCellFAB&       a_corr,
-                    const EBCellFAB& a_resid,
-                    const Box&       a_cellBox,
-                    const DataIndex& a_dit);
+  pointJacobiKernel(EBCellFAB&             a_Lcorr,
+                    EBCellFAB&             a_corr,
+                    const EBCellFAB&       a_resid,
+                    const EBCellFAB&       a_Acoef,
+                    const EBFluxFAB&       a_Bcoef,
+                    const BaseIVFAB<Real>& a_BcoefIrreg,
+                    const Box&             a_cellBox,
+                    const DataIndex&       a_dit);
 
   /*!
     @brief Red-black Gauss-Seidel kernel
@@ -275,18 +281,26 @@ public:
 
   /*!
     @brief Multi-color Gauss-Seidel kernel
-    @param[inout] a_Lcorr    Storage for computing L(a_corr)
-    @param[inout] a_corr     Correction
-    @param[in]    a_resid    Residual
-    @param[in]    a_color    Color
+    @param[inout] a_Lcorr      Storage for computing L(a_corr)
+    @param[inout] a_corr       Correction
+    @param[in]    a_resid      Residual
+    @param[in]    a_Acoef      A-coefficient
+    @param[in]    a_Bcoef      B-coefficient
+    @param[in]    a_BcoefIrreg B-coefficient on EB faces
+    @param[in]    a_cellBox    Grid box
+    @param[in]    a_dit        Data index
+    @param[in]    a_color      Color
   */
   void
-  gauSaiMultiColorKernel(EBCellFAB&       a_Lcorr,
-                         EBCellFAB&       a_corr,
-                         const EBCellFAB& a_resid,
-                         const Box&       a_cellBox,
-                         const DataIndex& a_dit,
-                         const IntVect&   a_color);
+  gauSaiMultiColorKernel(EBCellFAB&             a_Lcorr,
+                         EBCellFAB&             a_corr,
+                         const EBCellFAB&       a_resid,
+                         const EBCellFAB&       a_Acoef,
+                         const EBFluxFAB&       a_Bcoef,
+                         const BaseIVFAB<Real>& a_BcoefIrreg,
+                         const Box&             a_cellBox,
+                         const DataIndex&       a_dit,
+                         const IntVect&         a_color);
 
   /*!
     @brief Compute residual on this level. 
@@ -412,6 +426,7 @@ public:
   /*!
     @brief Apply domain flux. 
     @param[inout] a_phi               Cell data
+    @param[in]    a_Bcoef             Helmholtz B-coefficient
     @param[in]    a_cellBox           Computation box
     @param[in]    a_dit               Data index
     @param[in]    a_homogeneousPhysBC Homogeneous BC or not
@@ -419,7 +434,11 @@ public:
     -bco*(phi(i) - phi(i-1))/dx = F. 
   */
   void
-  applyDomainFlux(EBCellFAB& a_phi, const Box& a_cellBox, const DataIndex& a_dit, const bool a_homogeneousPhysBc);
+  applyDomainFlux(EBCellFAB&       a_phi,
+                  const EBFluxFAB& a_Bcoef,
+                  const Box&       a_cellBox,
+                  const DataIndex& a_dit,
+                  const bool       a_homogeneousPhysBc);
 
   /*!
     @brief Fill domain flux. This fills the flux on the domain face using centered differencing ala applyDomainFlux

--- a/Source/Elliptic/CD_EBHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_EBHelmholtzOp.cpp
@@ -1153,7 +1153,7 @@ EBHelmholtzOp::applyOp(EBCellFAB&             a_Lphi,
                        const BaseIVFAB<Real>& a_BcoefIrreg,
                        const Box&             a_cellBox,
                        const DataIndex&       a_dit,
-                       const bool             a_homogeneousPhysBC)
+                       const bool             a_homogeneousPhysBC) const noexcept
 {
   CH_TIME("EBHelmholtzOp::applyOp(patch)");
 
@@ -1183,7 +1183,7 @@ EBHelmholtzOp::applyOpRegular(EBCellFAB&             a_Lphi,
                               const BaseIVFAB<Real>& a_BcoefIrreg,
                               const Box&             a_cellBox,
                               const DataIndex&       a_dit,
-                              const bool             a_homogeneousPhysBC)
+                              const bool             a_homogeneousPhysBC) const noexcept
 {
   CH_TIMERS("EBHelmholtzOp::applyOpRegular");
   CH_TIMER("EBHelmholtzOp::applyOpRegular::domain_flux", t1);
@@ -1236,7 +1236,7 @@ EBHelmholtzOp::applyDomainFlux(EBCellFAB&       a_phi,
                                const EBFluxFAB& a_Bcoef,
                                const Box&       a_cellBox,
                                const DataIndex& a_dit,
-                               const bool       a_homogeneousPhysBC)
+                               const bool       a_homogeneousPhysBC) const noexcept
 {
   CH_TIME("EBHelmholtzOp::applyDomainFlux(EBCellFAB, Box, DataIndex, bool)");
 
@@ -1381,7 +1381,7 @@ EBHelmholtzOp::applyOpIrregular(EBCellFAB&             a_Lphi,
                                 const BaseIVFAB<Real>& a_alphaDiagWeight,
                                 const Box&             a_cellBox,
                                 const DataIndex&       a_dit,
-                                const bool             a_homogeneousPhysBC)
+                                const bool             a_homogeneousPhysBC) const noexcept
 {
   CH_TIMERS("EBHelmholtzOp::applyOpIrregular");
   CH_TIMER("AggStencil", t1);
@@ -1655,7 +1655,7 @@ EBHelmholtzOp::pointJacobiKernel(EBCellFAB&             a_Lcorr,
                                  const EBFluxFAB&       a_Bcoef,
                                  const BaseIVFAB<Real>& a_BcoefIrreg,
                                  const Box&             a_cellBox,
-                                 const DataIndex&       a_dit)
+                                 const DataIndex&       a_dit) const noexcept
 {
   CH_TIME("EBHelmholtzOp::pointJacobiKernel(EBCellFAB, EBCellFAB, EBCellFAB, Box, DataIndex)");
 
@@ -1729,7 +1729,7 @@ EBHelmholtzOp::gauSaiRedBlackKernel(EBCellFAB&             a_Lcorr,
                                     const BaseIVFAB<Real>& a_BcoefIrreg,
                                     const Box&             a_cellBox,
                                     const DataIndex&       a_dit,
-                                    const int&             a_redBlack)
+                                    const int&             a_redBlack) const noexcept
 {
   CH_TIMERS("EBHelmholtzOp::gauSaiRedBlackkernel");
   CH_TIMER("EBHelmholtzOp::regular_cells", t1);
@@ -1836,7 +1836,7 @@ EBHelmholtzOp::gauSaiMultiColorKernel(EBCellFAB&             a_Lcorr,
                                       const BaseIVFAB<Real>& a_BcoefIrreg,
                                       const Box&             a_cellBox,
                                       const DataIndex&       a_dit,
-                                      const IntVect&         a_color)
+                                      const IntVect&         a_color) const noexcept
 {
   CH_TIME("EBHelmholtzOp::gauSaiMultiColorKernel(EBCellFAB, EBCellFAB, EBCellFAB, Box, DataIndex, int)");
 

--- a/Source/Elliptic/CD_EBHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_EBHelmholtzOp.cpp
@@ -1185,14 +1185,18 @@ EBHelmholtzOp::applyOpRegular(EBCellFAB&             a_Lphi,
                               const DataIndex&       a_dit,
                               const bool             a_homogeneousPhysBC)
 {
-  CH_TIME("EBHelmholtzOp::applyOpRegular(EBCellFAB, EBCellFAB, Box, DataIndex, bool)");
+  CH_TIMERS("EBHelmholtzOp::applyOpRegular");
+  CH_TIMER("EBHelmholtzOp::applyOpRegular::domain_flux", t1);
+  CH_TIMER("EBHelmholtzOp::applyOpRegular::kernel", t2);
 
   // TLDR: This is the regular kernel which computes L(phi) using the standard 5/7 point stencil. Since we want a simple kernel,
   //       we first fill the ghost cells on the domain boundary so that the flux through the boundary is consistent with the flux
   //       from the BC object.
 
   // Fill a_phi such that centered differences pushes in the domain flux.
+  CH_START(t1);
   this->applyDomainFlux(a_phi, a_Bcoef, a_cellBox, a_dit, a_homogeneousPhysBC);
+  CH_STOP(t1);
 
   FArrayBox&       Lphi = a_Lphi.getFArrayBox();
   const FArrayBox& phi  = a_phi.getFArrayBox();
@@ -1222,7 +1226,9 @@ EBHelmholtzOp::applyOpRegular(EBCellFAB&             a_Lphi,
   };
 
   // Launch the kernel.
+  CH_START(t2);
   BoxLoops::loop(a_cellBox, kernel);
+  CH_STOP(t2);
 }
 
 void

--- a/Source/Elliptic/CD_EBHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_EBHelmholtzOp.cpp
@@ -268,12 +268,15 @@ EBHelmholtzOp::getFlux() const
 void
 EBHelmholtzOp::defineStencils()
 {
-  CH_TIME("EBHelmholtzOp::defineStencils()");
+  CH_TIMERS("EBHelmholtzOp::defineStencils");
+  CH_TIMER("EBHelmholtzOp::defineStencils::basic_define", t1);
+  CH_TIMER("EBHelmholtzOp::defineStencils::calc_stencils", t2);
 
   const DisjointBoxLayout& dbl   = m_eblg.getDBL();
   const EBISLayout&        ebisl = m_eblg.getEBISL();
 
   // Basic defines.
+  CH_START(t1);
   EBCellFactory cellFact(ebisl);
   EBFluxFactory fluxFact(ebisl);
 
@@ -304,11 +307,13 @@ EBHelmholtzOp::defineStencils()
       m_sideBox.emplace(std::make_pair(dir, sit()), sidebox);
     }
   }
+  CH_STOP(t1);
 
   // This contains the part of the eb flux that contains interior cells.
   const LayoutData<BaseIVFAB<VoFStencil>>& ebFluxStencil = m_ebBc->getGradPhiStencils();
 
-  // Define everything
+  // Define stencils
+  CH_START(t2);
   const DataIterator& dit = dbl.dataIterator();
 
   const int nbox = dit.size();
@@ -466,6 +471,7 @@ EBHelmholtzOp::defineStencils()
       opStencil(vof, m_comp) += ebSten;
     });
   }
+  CH_STOP(t2);
 
   // Compute relaxation weights.
   this->computeDiagWeight();

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
@@ -146,7 +146,6 @@ MFHelmholtzJumpBC::defineStencils()
     const DataIterator&      dit = dbl.dataIterator();
 
     const int nbox = dit.size();
-    ParallelOps::barrier();
     CH_START(t1);
     m_gradPhiStencils.define(dbl);
     m_gradPhiWeights.define(dbl);
@@ -171,7 +170,7 @@ MFHelmholtzJumpBC::defineStencils()
       m_avgVoFs[din].define(m_mflg, din);
     }
     CH_STOP(t1);
-    ParallelOps::barrier();
+
     // Build stencils and weights for each phase.
     CH_START(t2);
     for (int iphase = 0; iphase < m_numPhases; iphase++) {
@@ -271,11 +270,8 @@ MFHelmholtzJumpBC::defineStencils()
     CH_START(t2);
 
     // Build the average stencils.
-    ParallelOps::barrier();
     this->buildAverageStencils();
-    ParallelOps::barrier();
     this->resetBC();
-    ParallelOps::barrier();
   }
 }
 

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
@@ -267,7 +267,7 @@ MFHelmholtzJumpBC::defineStencils()
         BoxLoops::loop(vofit, kernel);
       }
     }
-    CH_START(t2);
+    CH_STOP(t2);
 
     // Build the average stencils.
     this->buildAverageStencils();

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
@@ -130,7 +130,9 @@ MFHelmholtzJumpBC::isMultiPhase() const noexcept
 void
 MFHelmholtzJumpBC::defineStencils()
 {
-  CH_TIME("MFHelmholtzJumpBC::defineStencils()");
+  CH_TIMERS("MFHelmholtzJumpBC::defineStencils");
+  CH_TIMER("MFHelmholtzJumpBC::defineStencils::define", t1);
+  CH_TIMER("MFHelmholtzJumpBC::defineStencils::compute_stencils", t2);
 
   CH_assert(m_order > 0);
   CH_assert(m_weight >= 0);
@@ -145,6 +147,7 @@ MFHelmholtzJumpBC::defineStencils()
 
     const int nbox = dit.size();
 
+    CH_START(t1);
     m_gradPhiStencils.define(dbl);
     m_gradPhiWeights.define(dbl);
     m_boundaryPhi.define(dbl);
@@ -167,8 +170,10 @@ MFHelmholtzJumpBC::defineStencils()
       m_denom[din].define(m_mflg, din);
       m_avgVoFs[din].define(m_mflg, din);
     }
+    CH_STOP(t1);
 
     // Build stencils and weights for each phase.
+    CH_START(t2);
     for (int iphase = 0; iphase < m_numPhases; iphase++) {
       const EBLevelGrid& eblg  = m_mflg.getEBLevelGrid(iphase);
       const EBISLayout&  ebisl = eblg.getEBISL();
@@ -263,6 +268,7 @@ MFHelmholtzJumpBC::defineStencils()
         BoxLoops::loop(vofit, kernel);
       }
     }
+    CH_START(t2);
 
     // Build the average stencils.
     this->buildAverageStencils();

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
@@ -642,7 +642,7 @@ MFHelmholtzJumpBC::matchBC(BaseIVFAB<Real>& a_jump,
       }
     }
   }
-  CH_START(t3);
+  CH_STOP(t3);
 }
 
 #include <CD_NamespaceFooter.H>

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
@@ -555,11 +555,9 @@ MFHelmholtzJumpBC::matchBC(BaseIVFAB<Real>& a_jump,
   CH_assert(m_multiPhase);
 
   CH_TIMERS("MFHelmholtzJumpBC::matchBC(patch)");
-  CH_TIMER("Setup", t1);
-  CH_TIMER("Apply stencils", t2);
-  CH_TIMER("Get vofs", t3);
-  CH_TIMER("Compute jump", t4);
-  CH_TIMER("Compute phiBndry", t5);
+  CH_TIMER("setup", t1);
+  CH_TIMER("aggsten", t2);
+  CH_TIMER("compute_phi_bndry", t3);
 
   // TLDR: This routine computes the boundary value of phi from an expression b1*dphi/dn1 + b2*dphi/dn2 = sigma, where dphi/dn can be represented as
   //
@@ -605,17 +603,14 @@ MFHelmholtzJumpBC::matchBC(BaseIVFAB<Real>& a_jump,
   aggSten1.apply(bndryPhiPhase1, phiPhase1, 0, false);
   CH_STOP(t2);
 
+  CH_START(t3);
   for (IVSIterator ivsIt(m_ivs[a_dit]); ivsIt.ok(); ++ivsIt) {
-    CH_START(t3);
     const IntVect  iv   = ivsIt();
     const VolIndex vof0 = VolIndex(iv, vofComp);
 
-    const Vector<VolIndex>& vofsPhase0 = avgVoFsPhase0(vof0, vofComp);
-    const Vector<VolIndex>& vofsPhase1 = avgVoFsPhase1(vof0, vofComp);
-    CH_STOP(t3);
-
-    CH_START(t4);
-    const Real& denomPhase0 = denomFactorPhase0(vof0, vofComp);
+    const Vector<VolIndex>& vofsPhase0  = avgVoFsPhase0(vof0, vofComp);
+    const Vector<VolIndex>& vofsPhase1  = avgVoFsPhase1(vof0, vofComp);
+    const Real&             denomPhase0 = denomFactorPhase0(vof0, vofComp);
 
     Real jump = 0.0;
     if (!a_homogeneousPhysBC) {
@@ -624,9 +619,7 @@ MFHelmholtzJumpBC::matchBC(BaseIVFAB<Real>& a_jump,
       }
       jump *= 1. / vofsPhase0.size();
     }
-    CH_STOP(t4);
 
-    CH_START(t5);
     for (int i = 0; i < vofsPhase0.size(); i++) {
       bndryPhiPhase0(vofsPhase0[i], m_comp) += bndryPhiPhase1(vof0, m_comp);
       bndryPhiPhase0(vofsPhase0[i], m_comp) *= -1.0;
@@ -643,9 +636,8 @@ MFHelmholtzJumpBC::matchBC(BaseIVFAB<Real>& a_jump,
         bndryPhiPhase1(vofsPhase1[i], m_comp) += denomPhase0 * jump;
       }
     }
-
-    CH_STOP(t5);
   }
+  CH_START(t3);
 }
 
 #include <CD_NamespaceFooter.H>

--- a/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzJumpBC.cpp
@@ -146,7 +146,7 @@ MFHelmholtzJumpBC::defineStencils()
     const DataIterator&      dit = dbl.dataIterator();
 
     const int nbox = dit.size();
-
+    ParallelOps::barrier();
     CH_START(t1);
     m_gradPhiStencils.define(dbl);
     m_gradPhiWeights.define(dbl);
@@ -171,7 +171,7 @@ MFHelmholtzJumpBC::defineStencils()
       m_avgVoFs[din].define(m_mflg, din);
     }
     CH_STOP(t1);
-
+    ParallelOps::barrier();
     // Build stencils and weights for each phase.
     CH_START(t2);
     for (int iphase = 0; iphase < m_numPhases; iphase++) {
@@ -271,8 +271,11 @@ MFHelmholtzJumpBC::defineStencils()
     CH_START(t2);
 
     // Build the average stencils.
+    ParallelOps::barrier();
     this->buildAverageStencils();
+    ParallelOps::barrier();
     this->resetBC();
+    ParallelOps::barrier();
   }
 }
 

--- a/Source/Elliptic/CD_MFHelmholtzOp.H
+++ b/Source/Elliptic/CD_MFHelmholtzOp.H
@@ -664,6 +664,11 @@ protected:
   RefCountedPtr<LevelData<MFBaseIVFAB>> m_BcoefIrreg;
 
   /*!
+    @brief Copier for exchange operation
+  */
+  Copier m_exchangeCopier;
+
+  /*!
     @brief Multifluid operator or not. 
   */
   bool m_multifluid;

--- a/Source/Elliptic/CD_MFHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzOp.cpp
@@ -90,6 +90,7 @@ MFHelmholtzOp::MFHelmholtzOp(const Location::Cell                             a_
   }
 
   m_interpolator = a_interpolator;
+  m_exchangeCopier.exchangeDefine(m_mflg.getGrids(), a_ghostPhi);
 
   if (m_hasMGObjects) {
     m_mflgCoarMG = a_mflgCoarMG;
@@ -698,9 +699,13 @@ MFHelmholtzOp::exchangeGhost(const LevelData<MFCellFAB>& a_phi) const
 {
   CH_TIME("MFHelmholtzOp::exchangeGhost");
 
+  if (!(a_phi.disjointBoxLayout() == m_mflg.getGrids())) {
+    MayDay::Abort("MFHelmholtzOp::exchangeGhost -- a_phi.disjointBoxLayout() != m_mflg.getGrids");
+  }
+
   LevelData<MFCellFAB>& phi = (LevelData<MFCellFAB>&)a_phi;
 
-  phi.exchange();
+  phi.exchange(m_exchangeCopier);
 }
 
 void

--- a/Source/Elliptic/CD_MFHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzOp.cpp
@@ -594,7 +594,11 @@ MFHelmholtzOp::applyOp(LevelData<MFCellFAB>&             a_Lphi,
       EBCellFAB& Lph = (EBCellFAB&)a_Lphi[din].getPhase(iphase);
       EBCellFAB& phi = (EBCellFAB&)a_phi[din].getPhase(iphase);
 
-      op.second->applyOp(Lph, phi, cellBox, din, a_homogeneousPhysBC);
+      const EBCellFAB&       Acoef      = (*m_Acoef)[din].getPhase(iphase);
+      const EBFluxFAB&       Bcoef      = (*m_Bcoef)[din].getPhase(iphase);
+      const BaseIVFAB<Real>& BcoefIrreg = *(*m_BcoefIrreg)[din].getPhasePtr(iphase);
+
+      op.second->applyOp(Lph, phi, Acoef, Bcoef, BcoefIrreg, cellBox, din, a_homogeneousPhysBC);
     }
   }
 }
@@ -831,7 +835,11 @@ MFHelmholtzOp::relaxGSRedBlack(LevelData<MFCellFAB>&       a_correction,
           EBCellFAB&       phi = a_correction[din].getPhase(iphase);
           const EBCellFAB& res = a_residual[din].getPhase(iphase);
 
-          op.second->gauSaiRedBlackKernel(Lph, phi, res, cellBox, din, redBlack);
+          const EBCellFAB&       aCoef      = (*m_Acoef)[din].getPhase(iphase);
+          const EBFluxFAB&       bCoef      = (*m_Bcoef)[din].getPhase(iphase);
+          const BaseIVFAB<Real>& bCoefIrreg = *(*m_BcoefIrreg)[din].getPhasePtr(iphase);
+
+          op.second->gauSaiRedBlackKernel(Lph, phi, res, aCoef, bCoef, bCoefIrreg, cellBox, din, redBlack);
         }
       }
     }

--- a/Source/Elliptic/CD_MFHelmholtzOp.cpp
+++ b/Source/Elliptic/CD_MFHelmholtzOp.cpp
@@ -785,7 +785,11 @@ MFHelmholtzOp::relaxPointJacobi(LevelData<MFCellFAB>&       a_correction,
         EBCellFAB&       phi = a_correction[din].getPhase(iphase);
         const EBCellFAB& res = a_residual[din].getPhase(iphase);
 
-        op.second->pointJacobiKernel(Lph, phi, res, cellBox, din);
+        const EBCellFAB&       Acoef      = (*m_Acoef)[din].getPhase(iphase);
+        const EBFluxFAB&       Bcoef      = (*m_Bcoef)[din].getPhase(iphase);
+        const BaseIVFAB<Real>& BcoefIrreg = *(*m_BcoefIrreg)[din].getPhasePtr(iphase);
+
+        op.second->pointJacobiKernel(Lph, phi, res, Acoef, Bcoef, BcoefIrreg, cellBox, din);
       }
     }
   }
@@ -835,11 +839,11 @@ MFHelmholtzOp::relaxGSRedBlack(LevelData<MFCellFAB>&       a_correction,
           EBCellFAB&       phi = a_correction[din].getPhase(iphase);
           const EBCellFAB& res = a_residual[din].getPhase(iphase);
 
-          const EBCellFAB&       aCoef      = (*m_Acoef)[din].getPhase(iphase);
-          const EBFluxFAB&       bCoef      = (*m_Bcoef)[din].getPhase(iphase);
-          const BaseIVFAB<Real>& bCoefIrreg = *(*m_BcoefIrreg)[din].getPhasePtr(iphase);
+          const EBCellFAB&       Acoef      = (*m_Acoef)[din].getPhase(iphase);
+          const EBFluxFAB&       Bcoef      = (*m_Bcoef)[din].getPhase(iphase);
+          const BaseIVFAB<Real>& BcoefIrreg = *(*m_BcoefIrreg)[din].getPhasePtr(iphase);
 
-          op.second->gauSaiRedBlackKernel(Lph, phi, res, aCoef, bCoef, bCoefIrreg, cellBox, din, redBlack);
+          op.second->gauSaiRedBlackKernel(Lph, phi, res, Acoef, Bcoef, BcoefIrreg, cellBox, din, redBlack);
         }
       }
     }
@@ -893,7 +897,11 @@ MFHelmholtzOp::relaxGSMultiColor(LevelData<MFCellFAB>&       a_correction,
           EBCellFAB&       phi = a_correction[din].getPhase(iphase);
           const EBCellFAB& res = a_residual[din].getPhase(iphase);
 
-          op.second->gauSaiMultiColorKernel(Lph, phi, res, cellBox, din, m_colors[icolor]);
+          const EBCellFAB&       Acoef      = (*m_Acoef)[din].getPhase(iphase);
+          const EBFluxFAB&       Bcoef      = (*m_Bcoef)[din].getPhase(iphase);
+          const BaseIVFAB<Real>& BcoefIrreg = *(*m_BcoefIrreg)[din].getPhasePtr(iphase);
+
+          op.second->gauSaiMultiColorKernel(Lph, phi, res, Acoef, Bcoef, BcoefIrreg, cellBox, din, m_colors[icolor]);
         }
       }
     }

--- a/Source/Elliptic/CD_MFHelmholtzOpImplem.H
+++ b/Source/Elliptic/CD_MFHelmholtzOpImplem.H
@@ -72,7 +72,7 @@ MFHelmholtzOp::computeOperatorLoads(LevelData<MFCellFAB>& a_phi, const int a_num
         EBCellFAB& Lph = Lphi[din].getPhase(iphase);
         EBCellFAB& phi = a_phi[din].getPhase(iphase);
 
-        op.second->applyOp(Lph, phi, cellBox, din, true);
+	//        op.second->applyOp(Lph, phi, cellBox, din, true);
       }
     }
 

--- a/Source/Elliptic/CD_MFHelmholtzOpImplem.H
+++ b/Source/Elliptic/CD_MFHelmholtzOpImplem.H
@@ -72,7 +72,11 @@ MFHelmholtzOp::computeOperatorLoads(LevelData<MFCellFAB>& a_phi, const int a_num
         EBCellFAB& Lph = Lphi[din].getPhase(iphase);
         EBCellFAB& phi = a_phi[din].getPhase(iphase);
 
-	//        op.second->applyOp(Lph, phi, cellBox, din, true);
+        const EBCellFAB&       Acoef      = (*m_Acoef)[din].getPhase(iphase);
+        const EBFluxFAB&       Bcoef      = (*m_Bcoef)[din].getPhase(iphase);
+        const BaseIVFAB<Real>& BcoefIrreg = *(*m_BcoefIrreg)[din].getPhasePtr(iphase);
+
+        op.second->applyOp(Lph, phi, Acoef, Bcoef, BcoefIrreg, cellBox, din, true);
       }
     }
 


### PR DESCRIPTION
## Summary

Various OpenMP-related improvements for enhanced MPI+OpenMP scalability. These are changes that are based on performance evaluations on Betzy.

Fixes:

- [x] Update Chombo to use faster exchangeDefine Copiers. 
- [x] Use prebuilt exchange Copiers in EBHelmholtzOp and MFHelmholtzOp.
- [x] Grid report bug.

Experiments:

- [x] Pass Aco and Bco through functions instead of DataIndex access in EBHelmholtzOp

Closes #445 

## Intent

- [ ] Fix a bug or incorrect behavior.
- [x] Add new capabilities.

## Checklist

- [ ] If relevant, add Sphinx documentation in the rst files. 
- [ ] Add doxygen documentation. 
