### PR TITLE
OpenMP threading for ItoKMCPhysics

### DIFF
--- a/Exec/Examples/ItoKMC/AirBasic/example.inputs
+++ b/Exec/Examples/ItoKMC/AirBasic/example.inputs
@@ -239,11 +239,11 @@ ItoKMCGodunovStepper.checkpoint_particles                  = true           # If
 ItoKMCGodunovStepper.verbosity                             = -1             # Verbosity
 ItoKMCGodunovStepper.abort_on_failure                      = true           # Abort on Poisson solver failure or not
 ItoKMCGodunovStepper.redistribute_cdr                      = true           # Turn on/off reactive redistribution
-ItoKMCGodunovStepper.profile                               = true          # Turn on/off run-time profiling
+ItoKMCGodunovStepper.profile                               = true           # Turn on/off run-time profiling
 ItoKMCGodunovStepper.plt_vars                              = none           # 'conductivity', 'current_density', 'particles_per_patch'
-ItoKMCGodunovStepper.dual_grid                             = true           # Turn on/off dual-grid functionality
+ItoKMCGodunovStepper.dual_grid                             = false          # Turn on/off dual-grid functionality
 ItoKMCGodunovStepper.load_balance_fluid                    = false          # Turn on/off fluid realm load balancing. 
-ItoKMCGodunovStepper.load_balance_particles                = true           # Turn on/off particle load balancing
+ItoKMCGodunovStepper.load_balance_particles                = false          # Turn on/off particle load balancing
 ItoKMCGodunovStepper.load_indices                          = -1             # Which particle containers to use for load balancing (-1 => all)
 ItoKMCGodunovStepper.load_per_cell                         = 1.0            # Default load per grid cell.
 ItoKMCGodunovStepper.box_sorting                           = morton         # Box sorting when load balancing

--- a/Physics/ItoKMC/CD_ItoKMCPhysics.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysics.H
@@ -425,6 +425,11 @@ namespace Physics {
       bool m_isDefined;
 
       /*!
+	@brief Is the KMC solver defined or not.
+      */
+      mutable bool m_hasKMCSolver;
+
+      /*!
 	@brief Kinetic Monte Carlo solver used in advanceReactionNetwork.
       */
       static thread_local KMCSolverType m_kmcSolver;
@@ -444,12 +449,12 @@ namespace Physics {
       /*!
 	@brief List of reactions for the KMC solver
       */
-      std::vector<std::shared_ptr<const KMCReaction>> m_kmcReactions;
+      std::vector<KMCReaction> m_kmcReactions;
 
       /*!
 	@brief List of photoionization reactions
       */
-      std::vector<std::shared_ptr<const ItoKMCPhotoReaction>> m_photoReactions;
+      std::vector<ItoKMCPhotoReaction> m_photoReactions;
 
       /*!
 	@brief Random number generators for photoionization pathways. 

--- a/Physics/ItoKMC/CD_ItoKMCPhysics.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysics.H
@@ -427,7 +427,7 @@ namespace Physics {
       /*!
 	@brief Is the KMC solver defined or not.
       */
-      mutable bool m_hasKMCSolver;
+      static thread_local bool m_hasKMCSolver;
 
       /*!
 	@brief Kinetic Monte Carlo solver used in advanceReactionNetwork.

--- a/Physics/ItoKMC/CD_ItoKMCPhysics.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysics.H
@@ -87,6 +87,18 @@ namespace Physics {
       inline virtual ~ItoKMCPhysics() noexcept;
 
       /*!
+	@brief Define the KMC solver and state
+      */
+      inline void
+      defineKMC() const noexcept;
+
+      /*!
+	@brief Kill the KMC solver
+      */
+      inline void
+      killKMC() const noexcept;
+
+      /*!
 	@brief Compute a time step to use. 
 	@param[in] a_E            Electric field. 
 	@param[in] a_pos          Position
@@ -413,9 +425,21 @@ namespace Physics {
       bool m_isDefined;
 
       /*!
-	@brief Kinetic Monte Carlo solver. 
+	@brief Kinetic Monte Carlo solver used in advanceReactionNetwork.
       */
-      mutable KMCSolverType m_kmcSolver;
+      static thread_local KMCSolverType m_kmcSolver;
+
+      /*!
+	@brief KMC state used in advanceReactionNetwork.
+      */
+      static thread_local KMCState m_kmcState;
+
+      /*!
+	@brief KMC reactions used in advanceReactionNetowkr
+	@note This is set up via setupKMC in order toi ensure OpenMP thread safety when calling advanceReactionNetwork. The vector
+	is later depopulated in killKMC().
+      */
+      static thread_local std::vector<std::shared_ptr<const KMCReaction>> m_kmcReactionsThreadLocal;
 
       /*!
 	@brief List of reactions for the KMC solver
@@ -501,12 +525,6 @@ namespace Physics {
       */
       inline void
       defineSpeciesMap() noexcept;
-
-      /*!
-	@brief Define the KMC solver and state
-      */
-      inline void
-      defineKMC() noexcept;
 
       /*!
 	@brief Define pathways for photo-reactions

--- a/Physics/ItoKMC/CD_ItoKMCPhysics.cpp
+++ b/Physics/ItoKMC/CD_ItoKMCPhysics.cpp
@@ -18,6 +18,7 @@
 
 using namespace Physics::ItoKMC;
 
+thread_local bool                                            ItoKMCPhysics::m_hasKMCSolver;
 thread_local KMCSolverType                                   ItoKMCPhysics::m_kmcSolver;
 thread_local KMCState                                        ItoKMCPhysics::m_kmcState;
 thread_local std::vector<std::shared_ptr<const KMCReaction>> ItoKMCPhysics::m_kmcReactionsThreadLocal;

--- a/Physics/ItoKMC/CD_ItoKMCPhysics.cpp
+++ b/Physics/ItoKMC/CD_ItoKMCPhysics.cpp
@@ -18,6 +18,10 @@
 
 using namespace Physics::ItoKMC;
 
+thread_local KMCSolverType                                   ItoKMCPhysics::m_kmcSolver;
+thread_local KMCState                                        ItoKMCPhysics::m_kmcState;
+thread_local std::vector<std::shared_ptr<const KMCReaction>> ItoKMCPhysics::m_kmcReactionsThreadLocal;
+
 Vector<std::string>
 ItoKMCPhysics::getPlotVariableNames() const noexcept
 {

--- a/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
@@ -67,8 +67,26 @@ ItoKMCPhysics::define() noexcept
   CH_TIME("ItoKMCPhysics::define");
 
   this->defineSpeciesMap();
-  this->defineKMC();
   this->definePhotoPathways();
+
+  // Safety hook -- make sure no one defines reactions using an out-of-range species index.
+#ifndef NDEBUG
+  for (const auto& R : m_kmcReactions) {
+    const auto& lhsReactants = R->getReactants();
+    const auto& rhsReactants = R->getReactiveProducts();
+    const auto& rhsPhotons   = R->getNonReactiveProducts();
+
+    for (const auto& r : lhsReactants) {
+      CH_assert(r < m_itoSpecies.size() + m_cdrSpecies.size());
+    }
+    for (const auto& r : rhsReactants) {
+      CH_assert(r < m_itoSpecies.size() + m_cdrSpecies.size());
+    }
+    for (const auto& r : rhsPhotons) {
+      CH_assert(r < m_rtSpecies.size());
+    }
+  }
+#endif
 
   m_isDefined = true;
 }
@@ -92,31 +110,28 @@ ItoKMCPhysics::defineSpeciesMap() noexcept
 }
 
 inline void
-ItoKMCPhysics::defineKMC() noexcept
+ItoKMCPhysics::defineKMC() const noexcept
 {
   CH_TIME("ItoKMCPhysics::defineKMC");
 
-  m_kmcSolver.define(m_kmcReactions);
-  m_kmcSolver.setSolverParameters(m_Ncrit, m_NSSA, m_eps, m_SSAlim);
-
-  // Safety hook -- make sure no one defines reactions using an out-of-range species index.
-#ifndef NDEBUG
-  for (const auto& R : m_kmcReactions) {
-    const auto& lhsReactants = R->getReactants();
-    const auto& rhsReactants = R->getReactiveProducts();
-    const auto& rhsPhotons   = R->getNonReactiveProducts();
-
-    for (const auto& r : lhsReactants) {
-      CH_assert(r < m_itoSpecies.size() + m_cdrSpecies.size());
-    }
-    for (const auto& r : rhsReactants) {
-      CH_assert(r < m_itoSpecies.size() + m_cdrSpecies.size());
-    }
-    for (const auto& r : rhsPhotons) {
-      CH_assert(r < m_rtSpecies.size());
-    }
+  // Deep copy of reaction rates
+  m_kmcReactionsThreadLocal.resize(0);
+  for (const auto& r : m_kmcReactions) {
+    m_kmcReactionsThreadLocal.emplace_back(std::make_shared<const KMCReaction>(*r));
   }
-#endif
+
+  m_kmcSolver.define(m_kmcReactionsThreadLocal);
+  m_kmcSolver.setSolverParameters(m_Ncrit, m_NSSA, m_eps, m_SSAlim);
+  m_kmcState.define(m_itoSpecies.size() + m_cdrSpecies.size(), m_rtSpecies.size());
+}
+
+inline void
+ItoKMCPhysics::killKMC() const noexcept
+{
+  CH_TIME("ItoKMCPhysics::defineKMC");
+
+  // Deep copy of reaction rates
+  m_kmcReactionsThreadLocal.resize(0);
 }
 
 inline void
@@ -198,9 +213,6 @@ ItoKMCPhysics::parseRuntimeOptions() noexcept
   this->parsePPC();
   this->parseDebug();
   this->parseAlgorithm();
-
-  // Define solver parameters in case they've been changed since last time.
-  m_kmcSolver.setSolverParameters(m_Ncrit, m_NSSA, m_eps, m_SSAlim);
 }
 
 inline void
@@ -322,14 +334,8 @@ ItoKMCPhysics::advanceKMC(Vector<FPR>&            a_numParticles,
 
   CH_assert(m_isDefined);
 
-  KMCState      kmcState;
-  KMCSolverType kmcSolver;
-
-  // Define and populate the KMC solver state.
-  kmcState.define(m_itoSpecies.size() + m_cdrSpecies.size(), m_rtSpecies.size());
-
-  std::vector<FPR>& kmcParticles = kmcState.getReactiveState();
-  std::vector<FPR>& kmcPhotons   = kmcState.getNonReactiveState();
+  std::vector<FPR>& kmcParticles = m_kmcState.getReactiveState();
+  std::vector<FPR>& kmcPhotons   = m_kmcState.getNonReactiveState();
 
   for (size_t i = 0; i < a_numParticles.size(); i++) {
     kmcParticles[i] = a_numParticles[i];
@@ -339,43 +345,33 @@ ItoKMCPhysics::advanceKMC(Vector<FPR>&            a_numParticles,
     p = 0LL;
   }
 
-  // Deep copy of reaction rates
-  std::vector<std::shared_ptr<const KMCReaction>> kmcReactions;
-  for (const auto& r : m_kmcReactions) {
-    kmcReactions.emplace_back(std::make_shared<const KMCReaction>(*r));
-  }
-
-  // Define the KMC solver
-  kmcSolver.define(kmcReactions);
-  kmcSolver.setSolverParameters(m_Ncrit, m_NSSA, m_eps, m_SSAlim);
-
   // Update the reaction rates to be used by the KMC solver.
-  this->updateReactionRates(kmcReactions, a_E, a_pos, a_phi, a_gradPhi, a_dx, a_kappa);
+  this->updateReactionRates(m_kmcReactionsThreadLocal, a_E, a_pos, a_phi, a_gradPhi, a_dx, a_kappa);
 
   // Run the KMC solver.
   switch (m_algorithm) {
   case Algorithm::SSA: {
-    kmcSolver.advanceSSA(kmcState, a_dt);
+    m_kmcSolver.advanceSSA(m_kmcState, a_dt);
 
     break;
   }
   case Algorithm::TauPlain: {
-    kmcSolver.advanceTauPlain(kmcState, a_dt);
+    m_kmcSolver.advanceTauPlain(m_kmcState, a_dt);
 
     break;
   }
   case Algorithm::TauMidpoint: {
-    kmcSolver.advanceTauMidpoint(kmcState, a_dt);
+    m_kmcSolver.advanceTauMidpoint(m_kmcState, a_dt);
 
     break;
   }
   case Algorithm::HybridPlain: {
-    kmcSolver.advanceHybrid(kmcState, a_dt, KMCLeapPropagator::TauPlain);
+    m_kmcSolver.advanceHybrid(m_kmcState, a_dt, KMCLeapPropagator::TauPlain);
 
     break;
   }
   case Algorithm::HybridMidpoint: {
-    kmcSolver.advanceHybrid(kmcState, a_dt, KMCLeapPropagator::TauMidpoint);
+    m_kmcSolver.advanceHybrid(m_kmcState, a_dt, KMCLeapPropagator::TauMidpoint);
 
     break;
   }

--- a/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
@@ -72,9 +72,9 @@ ItoKMCPhysics::define() noexcept
   // Safety hook -- make sure no one defines reactions using an out-of-range species index.
 #ifndef NDEBUG
   for (const auto& R : m_kmcReactions) {
-    const auto& lhsReactants = R->getReactants();
-    const auto& rhsReactants = R->getReactiveProducts();
-    const auto& rhsPhotons   = R->getNonReactiveProducts();
+    const auto& lhsReactants = R.getReactants();
+    const auto& rhsReactants = R.getReactiveProducts();
+    const auto& rhsPhotons   = R.getNonReactiveProducts();
 
     for (const auto& r : lhsReactants) {
       CH_assert(r < m_itoSpecies.size() + m_cdrSpecies.size());
@@ -114,10 +114,12 @@ ItoKMCPhysics::defineKMC() const noexcept
 {
   CH_TIME("ItoKMCPhysics::defineKMC");
 
+  CH_assert(!m_hasKMCSolver);
+
   // Deep copy of reaction rates
   m_kmcReactionsThreadLocal.resize(0);
   for (const auto& r : m_kmcReactions) {
-    m_kmcReactionsThreadLocal.emplace_back(std::make_shared<const KMCReaction>(*r));
+    m_kmcReactionsThreadLocal.emplace_back(std::make_shared<const KMCReaction>(r));
   }
 
   m_kmcSolver.define(m_kmcReactionsThreadLocal);
@@ -130,8 +132,13 @@ ItoKMCPhysics::killKMC() const noexcept
 {
   CH_TIME("ItoKMCPhysics::defineKMC");
 
-  // Deep copy of reaction rates
+  CH_assert(m_hasKMCSolver);
+
   m_kmcReactionsThreadLocal.resize(0);
+  m_kmcSolver.define(m_kmcReactionsThreadLocal);
+  m_kmcState.define(0, 0);
+
+  m_hasKMCSolver = false;
 }
 
 inline void
@@ -151,7 +158,7 @@ ItoKMCPhysics::definePhotoPathways() noexcept
   std::map<int, std::vector<std::pair<int, Real>>> pathways;
 
   for (int i = 0; i < m_photoReactions.size(); i++) {
-    const ItoKMCPhotoReaction& r = *m_photoReactions[i];
+    const ItoKMCPhotoReaction& r = m_photoReactions[i];
 
     const size_t& src        = r.getSourcePhoton();
     const Real    efficiency = r.getEfficiency();
@@ -332,7 +339,10 @@ ItoKMCPhysics::advanceKMC(Vector<FPR>&            a_numParticles,
 {
   CH_TIME("ItoKMCPhysics::advanceKMC");
 
+  // Note: This is called PER GRID CELL, i.e. within OpenMP parallel regions. For this reason the KMC solver
+  //       must be defined through defineKMC() (which must be later killed).
   CH_assert(m_isDefined);
+  CH_assert(m_hasKMCSolver);
 
   std::vector<FPR>& kmcParticles = m_kmcState.getReactiveState();
   std::vector<FPR>& kmcPhotons   = m_kmcState.getNonReactiveState();
@@ -592,7 +602,7 @@ ItoKMCPhysics::reconcilePhotoionization(Vector<List<ItoParticle>*>&   a_itoParti
         const int localReaction  = Random::get(d);
         const int globalReaction = localToGlobalMap.at(localReaction);
 
-        const ItoKMCPhotoReaction& photoReaction = *m_photoReactions[globalReaction];
+        const ItoKMCPhotoReaction& photoReaction = m_photoReactions[globalReaction];
         const std::list<size_t>&   plasmaTargets = photoReaction.getTargetSpecies();
 
         for (const auto& t : plasmaTargets) {

--- a/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
@@ -36,6 +36,7 @@ inline ItoKMCPhysics::ItoKMCPhysics() noexcept
   // Some default settings in case user forgets to call the parsing algorithms.
   m_isDefined         = false;
   m_debug             = true;
+  m_hasKMCSolver      = false;
   m_maxNewParticles   = 32;
   m_maxNewPhotons     = 32;
   m_Ncrit             = 5;
@@ -125,6 +126,8 @@ ItoKMCPhysics::defineKMC() const noexcept
   m_kmcSolver.define(m_kmcReactionsThreadLocal);
   m_kmcSolver.setSolverParameters(m_Ncrit, m_NSSA, m_eps, m_SSAlim);
   m_kmcState.define(m_itoSpecies.size() + m_cdrSpecies.size(), m_rtSpecies.size());
+
+  m_hasKMCSolver = true;
 }
 
 inline void

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -3876,18 +3876,26 @@ ItoKMCStepper<I, C, R, F>::advanceReactionNetwork(LevelData<EBCellFAB>&       a_
 
   const int nbox = dit.size();
 
-#pragma omp parallel for schedule(runtime)
-  for (int mybox = 0; mybox < nbox; mybox++) {
-    const DataIndex& din = dit[mybox];
+#pragma omp parallel
+  {
 
-    this->advanceReactionNetwork(a_particlesPerCell[din],
-                                 a_newPhotonsPerCell[din],
-                                 a_electricField[din],
-                                 a_level,
-                                 din,
-                                 dbl[din],
-                                 m_amr->getDx()[a_level],
-                                 a_dt);
+    m_physics->defineKMC();
+
+#pragma omp for schedule(runtime)
+    for (int mybox = 0; mybox < nbox; mybox++) {
+      const DataIndex& din = dit[mybox];
+
+      this->advanceReactionNetwork(a_particlesPerCell[din],
+                                   a_newPhotonsPerCell[din],
+                                   a_electricField[din],
+                                   a_level,
+                                   din,
+                                   dbl[din],
+                                   m_amr->getDx()[a_level],
+                                   a_dt);
+    }
+
+    m_physics->killKMC();
   }
 }
 

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -3878,7 +3878,6 @@ ItoKMCStepper<I, C, R, F>::advanceReactionNetwork(LevelData<EBCellFAB>&       a_
 
 #pragma omp parallel
   {
-
     m_physics->defineKMC();
 
 #pragma omp for schedule(runtime)

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -32,6 +32,7 @@ ItoKMCJSON::ItoKMCJSON()
   m_verbose      = false;
   m_previewRates = false;
   m_className    = "ItoKMCJSON";
+  m_hasKMCSolver = false;
 
   this->parseVerbose();
   this->parsePPC();

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -780,7 +780,7 @@ ItoKMCJSON::initializeAutomaticTownsend(const std::string a_coeff)
       const std::list<size_t>& plasmaProducts  = m_plasmaReactionPlasmaProducts[i];
 
       if (plasmaReactants.size() == 1 && plasmaReactants.front() == speciesIdx) {
-        const FPR stateChange = m_kmcReactions[i]->getStateChange(speciesIdx);
+        const FPR stateChange = m_kmcReactions[i].getStateChange(speciesIdx);
 
         if (sign * stateChange > (FPR)0) {
           const FunctionEX& fluidRate = m_fluidRates[i];
@@ -1720,7 +1720,7 @@ ItoKMCJSON::initializePlasmaReactions()
       const auto reactionPlot       = this->parsePlasmaReactionPlot(reactionJSON);
       const auto gradientCorrection = this->parsePlasmaReactionGradientCorrection(reactionJSON);
 
-      m_kmcReactions.emplace_back(std::make_shared<KMCReaction>(plasmaReactants, plasmaProducts, photonProducts));
+      m_kmcReactions.emplace_back(KMCReaction(plasmaReactants, plasmaProducts, photonProducts));
       m_kmcReactionRates.emplace_back(reactionRates.first);
       m_kmcReactionRatePlots.emplace_back(reactionPlot);
       m_kmcReactionGradientCorrections.emplace_back(gradientCorrection);
@@ -1811,8 +1811,7 @@ ItoKMCJSON::initializePhotoReactions()
                                trimmedProducts);
 
       // Add the reaction
-      m_photoReactions.emplace_back(
-        std::make_shared<ItoKMCPhotoReaction>(photonReactants.front(), plasmaProducts, photoiEfficiency));
+      m_photoReactions.emplace_back(ItoKMCPhotoReaction(photonReactants.front(), plasmaProducts, photoiEfficiency));
     }
   }
 }


### PR DESCRIPTION
## Summary

ItoKMCPhysics had a local copy of the KMC integrator, which led to unecessary overhead (albeit not a huge one). This PR adds thread local copies of the KMC integrator so that this should compile and run without local copies.

Closes #452 

## Intent

- [ ] Fix a bug or incorrect behavior.
- [ ] Add new capabilities.

## Checklist

- [ ] If relevant, add Sphinx documentation in the rst files. 
- [ ] Add doxygen documentation. 
