### PR TITLE
Fix compiler warnings

### DIFF
--- a/Physics/CdrPlasma/CD_CdrPlasmaFieldTagger.H
+++ b/Physics/CdrPlasma/CD_CdrPlasmaFieldTagger.H
@@ -48,7 +48,7 @@ namespace Physics {
 	@brief Parse options. Must be implemented by users. 
       */
       virtual void
-      parseOptions() = 0;
+      parseOptions() override = 0;
 
     protected:
       /*!
@@ -125,7 +125,7 @@ namespace Physics {
                   const Real             a_dx,
                   const int              a_lvl,
                   const Vector<Real>     a_tracers,
-                  const Vector<RealVect> a_gradTracers) const = 0;
+                  const Vector<RealVect> a_gradTracers) const override = 0;
 
       /*!
 	@brief Refine a cell based on a tracer field
@@ -143,7 +143,7 @@ namespace Physics {
                  const Real             a_dx,
                  const int              a_lvl,
                  const Vector<Real>     a_tracers,
-                 const Vector<RealVect> a_gradTracers) const = 0;
+                 const Vector<RealVect> a_gradTracers) const override = 0;
     };
   } // namespace CdrPlasma
 } // namespace Physics

--- a/Physics/CdrPlasma/CD_CdrPlasmaStepper.H
+++ b/Physics/CdrPlasma/CD_CdrPlasmaStepper.H
@@ -100,7 +100,7 @@ namespace Physics {
 	@brief Parse runtime options. Subclasses must implement this.
       */
       virtual void
-      parseRuntimeOptions() = 0;
+      parseRuntimeOptions() override = 0;
 
       /*!
 	@brief Compute some thing that go into plot files
@@ -160,7 +160,7 @@ namespace Physics {
 	@details Subclasses must implement this one. 
       */
       virtual Real
-      computeDt() = 0;
+      computeDt() override = 0;
 
       /*!
 	@brief Advance method, advances equations.
@@ -168,7 +168,7 @@ namespace Physics {
 	@returns Actual time step used (can be different from a_dt for adaptive methods)
       */
       virtual Real
-      advance(const Real a_dt) = 0;
+      advance(const Real a_dt) override = 0;
 
       /*!
 	@brief Synchronize solver times

--- a/Physics/CdrPlasma/CD_CdrPlasmaTagger.H
+++ b/Physics/CdrPlasma/CD_CdrPlasmaTagger.H
@@ -80,7 +80,7 @@ namespace Physics {
 	@brief Parse class options -- must be implemented by user. 
       */
       virtual void
-      parseOptions() = 0;
+      parseOptions() override = 0;
 
       /*!
 	@brief Pre-plot magic for Driver

--- a/Physics/CdrPlasma/PlasmaModels/CdrPlasmaJSON/CD_CdrPlasmaJSON.H
+++ b/Physics/CdrPlasma/PlasmaModels/CdrPlasmaJSON/CD_CdrPlasmaJSON.H
@@ -103,7 +103,7 @@ namespace Physics {
 	@brief Parse run-time class options.
       */
       virtual void
-      parseRuntimeOptions();
+      parseRuntimeOptions() override;
 
       /*!
 	@brief Get number of plot variables for this physics class. 

--- a/Physics/CdrPlasma/Timesteppers/CdrPlasmaImExSdcStepper/CD_CdrPlasmaImExSdcStepper.H
+++ b/Physics/CdrPlasma/Timesteppers/CdrPlasmaImExSdcStepper/CD_CdrPlasmaImExSdcStepper.H
@@ -333,7 +333,7 @@ namespace Physics {
       void
       computeCdrVelo(const Vector<EBAMRCellData*>& a_phis, const Real a_time);
       Real
-      computeDt();
+      computeDt() override;
       void
       computeSigmaFlux();
 

--- a/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
+++ b/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
@@ -587,13 +587,13 @@ DischargeInceptionStepper<P, F, C>::parseTransportAlgorithm() noexcept
   CH_assert(m_firstDt > 0.0);
 
   if (str == "euler") {
-    m_transportAlgorithm == TransportAlgorithm::Euler;
+    m_transportAlgorithm = TransportAlgorithm::Euler;
   }
   else if (str == "heun") {
-    m_transportAlgorithm == TransportAlgorithm::Heun;
+    m_transportAlgorithm = TransportAlgorithm::Heun;
   }
   else if (str == "imex") {
-    m_transportAlgorithm == TransportAlgorithm::ImExCTU;
+    m_transportAlgorithm = TransportAlgorithm::ImExCTU;
   }
   else {
     MayDay::Error("Expected 'euler', 'heun', or 'imex' for 'DischargeInceptionStepper.transport_alg'");

--- a/Physics/DischargeInception/CD_DischargeInceptionTagger.H
+++ b/Physics/DischargeInception/CD_DischargeInceptionTagger.H
@@ -84,7 +84,7 @@ namespace Physics {
 	@return Returns number of plot variables that Driver will write to plot files. 
       */
       virtual int
-      getNumberOfPlotVariables() const;
+      getNumberOfPlotVariables() const override;
 
       /*!
 	@brief Write plot data.

--- a/Physics/ItoKMC/CD_ItoKMCFieldTagger.H
+++ b/Physics/ItoKMC/CD_ItoKMCFieldTagger.H
@@ -49,13 +49,13 @@ namespace Physics {
 	@brief Parse options
       */
       virtual void
-      parseOptions() = 0;
+      parseOptions() override = 0;
 
       /*!
 	@brief Parse run-time configurable options
       */
       virtual void
-      parseRuntimeOptions() = 0;
+      parseRuntimeOptions() override = 0;
 
     protected:
       /*!
@@ -131,7 +131,7 @@ namespace Physics {
                   const Real             a_dx,
                   const int              a_lvl,
                   const Vector<Real>     a_tagFields,
-                  const Vector<RealVect> a_gradTagFields) const noexcept = 0;
+                  const Vector<RealVect> a_gradTagFields) const noexcept override = 0;
 
       /*!
 	@brief Determine if a particular cell should be refined or not. 
@@ -148,7 +148,7 @@ namespace Physics {
                  const Real             a_dx,
                  const int              a_lvl,
                  const Vector<Real>     a_tagFields,
-                 const Vector<RealVect> a_gradTagFields) const noexcept = 0;
+                 const Vector<RealVect> a_gradTagFields) const noexcept override = 0;
     };
   } // namespace ItoKMC
 } // namespace Physics

--- a/Physics/ItoKMC/CD_ItoKMCStepper.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepper.H
@@ -204,7 +204,7 @@ namespace Physics {
 	@return    Returns the time step that was used. 
       */
       virtual Real
-      advance(const Real a_dt) = 0;
+      advance(const Real a_dt) override = 0;
 
       /*!
 	@brief Compute a time step used for the advance method

--- a/Physics/ItoKMC/CD_ItoKMCTagger.H
+++ b/Physics/ItoKMC/CD_ItoKMCTagger.H
@@ -65,13 +65,13 @@ namespace Physics {
 	@return Returns number of plot variables that Driver will write to plot files. 
       */
       virtual int
-      getNumberOfPlotVariables() const noexcept;
+      getNumberOfPlotVariables() const noexcept override;
 
       /*!
 	@brief Get plot variable names. 
       */
       virtual Vector<std::string>
-      getPlotVariableNames() const noexcept;
+      getPlotVariableNames() const noexcept override;
 
       /*!
 	@brief Write plot data.
@@ -83,7 +83,7 @@ namespace Physics {
       writePlotData(LevelData<EBCellFAB>& a_output,
                     int&                  a_icomp,
                     const std::string     a_outputRealm,
-                    const int             a_level) const noexcept;
+                    const int             a_level) const noexcept override;
 
       /*!
 	@brief Compute tagging fields.
@@ -95,13 +95,13 @@ namespace Physics {
 	@brief Parse class options
       */
       virtual void
-      parseOptions() = 0;
+      parseOptions() override = 0;
 
       /*!
 	@brief Parse run-time configurable class options
       */
       virtual void
-      parseRuntimeOptions() = 0;
+      parseRuntimeOptions() override = 0;
 
       /*!
 	@brief Regrid this class. Note that there is no preRegrid method.

--- a/Source/AmrMesh/CD_EBAddOp.H
+++ b/Source/AmrMesh/CD_EBAddOp.H
@@ -60,7 +60,7 @@ public:
      const Interval&  a_dstVars,
      const Box&       a_regionTo,
      const EBCellFAB& a_src,
-     const Interval&  a_srcVars) const;
+     const Interval&  a_srcVars) const override;
 };
 
 #include <CD_NamespaceFooter.H>

--- a/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.H
+++ b/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.H
@@ -124,7 +124,7 @@ public:
     contain enough ghost cells. 
   */
   virtual void
-  coarseFineInterpH(EBCellFAB& a_phiFine, const Interval a_variables, const DataIndex& a_dit) const noexcept;
+  coarseFineInterpH(EBCellFAB& a_phiFine, const Interval a_variables, const DataIndex& a_dit) const noexcept override;
 
 protected:
   /*!

--- a/Source/AmrMesh/CD_IrregAddOp.H
+++ b/Source/AmrMesh/CD_IrregAddOp.H
@@ -60,7 +60,7 @@ public:
      const Interval&        a_dstVars,
      const Box&             a_regionTo,
      const BaseIVFAB<Real>& a_src,
-     const Interval&        a_srcVars) const;
+     const Interval&        a_srcVars) const override;
 };
 
 #include <CD_NamespaceFooter.H>

--- a/Source/ConvectionDiffusionReaction/CD_CdrMultigrid.H
+++ b/Source/ConvectionDiffusionReaction/CD_CdrMultigrid.H
@@ -68,13 +68,13 @@ public:
     @brief Parse class options
   */
   virtual void
-  parseOptions() = 0;
+  parseOptions() override = 0;
 
   /*!
     @brief Parse class options
   */
   virtual void
-  parseRuntimeOptions() = 0;
+  parseRuntimeOptions() override = 0;
 
   /*!
     @brief Register operator
@@ -288,7 +288,7 @@ protected:
     @brief Advection-only extrapolation to faces
   */
   virtual void
-  advectToFaces(EBAMRFluxData& a_facePhi, const EBAMRCellData& a_phi, const Real a_extrapDt) = 0;
+  advectToFaces(EBAMRFluxData& a_facePhi, const EBAMRCellData& a_phi, const Real a_extrapDt) override = 0;
 
   /*!
     @brief Set up diffusion solver

--- a/Source/Electrostatics/CD_FieldSolverMultigrid.H
+++ b/Source/Electrostatics/CD_FieldSolverMultigrid.H
@@ -140,7 +140,7 @@ public:
     @param[in] a_oldFinestLevel Finest AMR level before regrid. 
   */
   virtual void
-  preRegrid(const int a_lbase, const int a_oldFinestLevel);
+  preRegrid(const int a_lbase, const int a_oldFinestLevel) override;
 
   /*!
     @brief Regrid method. 

--- a/Source/Elliptic/CD_EBHelmholtzOp.H
+++ b/Source/Elliptic/CD_EBHelmholtzOp.H
@@ -313,7 +313,7 @@ public:
   residual(LevelData<EBCellFAB>&       a_residual,
            const LevelData<EBCellFAB>& a_phi,
            const LevelData<EBCellFAB>& a_rhs,
-           const bool                  a_homogeneousPhysBc);
+           const bool                  a_homogeneousPhysBc) override;
 
   /*!
     @brief Precondition system before bottom solve
@@ -625,7 +625,7 @@ public:
               const LevelData<EBCellFAB>&       a_phi,
               const LevelData<EBCellFAB>&       a_phiCoar,
               const bool                        a_homogeneousPhysBC,
-              AMRLevelOp<LevelData<EBCellFAB>>* a_finerOp);
+              AMRLevelOp<LevelData<EBCellFAB>>* a_finerOp) override final;
 
   /*!
     @brief Apply the AMR operator, i.e. compute L(phi) in an AMR context. 
@@ -783,7 +783,7 @@ public:
     @param[in]    a_kappaWeighted Use kappa-weighted scaling or not
   */
   void
-  diagonalScale(LevelData<EBCellFAB>& a_rhs, bool a_kappaWeighted);
+  diagonalScale(LevelData<EBCellFAB>& a_rhs, bool a_kappaWeighted) override final;
 
   /*!
     @brief Divide by the a-coefficient

--- a/Source/Elliptic/CD_MFHelmholtzOp.H
+++ b/Source/Elliptic/CD_MFHelmholtzOp.H
@@ -252,7 +252,7 @@ public:
   residual(LevelData<MFCellFAB>&       a_residual,
            const LevelData<MFCellFAB>& a_phi,
            const LevelData<MFCellFAB>& a_rhs,
-           const bool                  a_homogeneousPhysBc);
+           const bool                  a_homogeneousPhysBc) override final;
 
   /*!
     @brief Precondition system before bottom solve
@@ -770,7 +770,7 @@ protected:
               const LevelData<MFCellFAB>&       a_phi,
               const LevelData<MFCellFAB>&       a_phiCoar,
               const bool                        a_homogeneousPhysBC,
-              AMRLevelOp<LevelData<MFCellFAB>>* a_finerOp);
+              AMRLevelOp<LevelData<MFCellFAB>>* a_finerOp) override;
 };
 
 #include <CD_NamespaceFooter.H>

--- a/Source/RadiativeTransfer/CD_McPhoto.H
+++ b/Source/RadiativeTransfer/CD_McPhoto.H
@@ -386,7 +386,7 @@ public:
     @return Returns number of plot variables that will be written to file in writePlotData
   */
   virtual int
-  getNumberOfPlotVariables() const;
+  getNumberOfPlotVariables() const override;
 
   /*!
     @brief Count number of photons in particle list
@@ -459,7 +459,7 @@ public:
     @details The default implementation returns the number of cells in the grid patch as a proxy for the load. 
   */
   virtual void
-  computeLoads(Vector<long long>& a_loads, const DisjointBoxLayout& a_dbl, const int a_level) const noexcept;
+  computeLoads(Vector<long long>& a_loads, const DisjointBoxLayout& a_dbl, const int a_level) const noexcept override;
 
 protected:
   /*!

--- a/Source/TracerParticles/CD_TracerParticle.H
+++ b/Source/TracerParticles/CD_TracerParticle.H
@@ -95,7 +95,7 @@ public:
     @param[in] a_buffer Pointer to memory block
   */
   inline virtual void
-  linearIn(void* a_buffer);
+  linearIn(void* a_buffer) override;
 
 protected:
   /*!

--- a/Source/Utilities/CD_Decorations.H
+++ b/Source/Utilities/CD_Decorations.H
@@ -21,6 +21,9 @@
 #elif defined(__INTEL_COMPILER)
 #define CD_PRAGMA_SIMD _Pragma("ivdep")
 
+#elif defined(__INTEL_LLVM_COMPILER)
+#define CD_PRAGMA_SIMD _Pragma("SIMD")
+
 #elif defined(__clang__)
 #define CD_PRAGMA_SIMD _Pragma("clang loop vectorize(enable)")
 
@@ -30,7 +33,7 @@
 #else
 #define CD_PRAGMA_SIMD
 
-#endif /* simd */
+#endif
 
 // Force inline.
 #if defined(__GNUC__)


### PR DESCRIPTION
## Summary

This fixes a bunch of compiler warnings which came through the Intel oneAPI compiler suite. 

This also adds #pragma SIMD to BoxLoops when the Intel LLVM compiler is defined so that the innermost loop is always vectorized. 

## Intent

- [ ] Fix a bug or incorrect behavior.
- [ ] Add new capabilities.

## Checklist

- [ ] If relevant, add Sphinx documentation in the rst files. 
- [ ] Add doxygen documentation. 
