### PR TITLE
Various ItoKMC upgrades

### DIFF
--- a/Physics/ItoKMC/CD_ItoKMCPhysics.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysics.H
@@ -201,6 +201,12 @@ namespace Physics {
       getNumPhotonSpecies() const;
 
       /*!
+	@brief Return true/false if physics model needs species gradients.
+      */
+      virtual bool
+      needGradients() const noexcept;
+
+      /*!
 	@brief Get the internal mapping between plasma species and Ito solvers
       */
       inline const std::map<int, std::pair<SpeciesType, int>>&

--- a/Physics/ItoKMC/CD_ItoKMCPhysics.cpp
+++ b/Physics/ItoKMC/CD_ItoKMCPhysics.cpp
@@ -52,4 +52,12 @@ ItoKMCPhysics::getNumberOfPlotVariables() const noexcept
   return 0;
 }
 
+bool
+ItoKMCPhysics::needGradients() const noexcept
+{
+  CH_TIME("ItoKMCPhysics::needGradients");
+
+  return false;
+}
+
 #include <CD_NamespaceFooter.H>

--- a/Physics/ItoKMC/CD_ItoKMCStepper.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepper.H
@@ -673,18 +673,6 @@ namespace Physics {
       EBAMRIVData m_conductivityEB;
 
       /*!
-	@brief For holding the number of physical particles per cell
-	@note Defined over the particle realm. 
-      */
-      EBAMRCellData m_oldPPC;
-
-      /*!
-	@brief For holding the number of physical particles per cell
-	@note Defined over the particle realm. 
-      */
-      EBAMRCellData m_newPPC;
-
-      /*!
 	@brief For holding the number of physical particles per cell for all Ito species.
 	@note Defined on the particle realm with components = number of Ito species
       */

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -597,8 +597,6 @@ ItoKMCStepper<I, C, R, F>::allocateInternals() noexcept
   m_amr->allocate(m_currentDensity, m_fluidRealm, m_plasmaPhase, SpaceDim);
 
   // Storage required for the reaction network.
-  m_amr->allocate(m_oldPPC, m_particleRealm, m_plasmaPhase, numPlasmaSpecies);
-  m_amr->allocate(m_newPPC, m_particleRealm, m_plasmaPhase, numPlasmaSpecies);
   m_amr->allocate(m_fluidPPC, m_fluidRealm, m_plasmaPhase, numPlasmaSpecies);
 
   if (numItoSpecies > 0) {
@@ -1528,6 +1526,8 @@ ItoKMCStepper<I, C, R, F>::prePlot() noexcept
   }
 
   this->computePhysicsPlotVariables(m_physicsPlotVariables);
+  this->computeCurrentDensity(this->m_currentDensity);
+  m_ito->depositParticles();
 }
 
 template <typename I, typename C, typename R, typename F>
@@ -1619,8 +1619,6 @@ ItoKMCStepper<I, C, R, F>::preRegrid(const int a_lmin, const int a_oldFinestLeve
   }
 
   m_currentDensity.clear();
-  m_oldPPC.clear();
-  m_newPPC.clear();
   m_fluidPPC.clear();
 
   m_particleItoPPC.clear();
@@ -4781,8 +4779,6 @@ ItoKMCStepper<I, C, R, F>::fillSecondaryEmissionEB(Vector<ParticleContainer<ItoP
 
       const EBISBox&       ebisbox       = ebisl[din];
       const EBCellFAB&     electricField = (*a_electricField[lvl])[din];
-      const EBCellFAB&     oldPPC        = (*m_oldPPC[lvl])[din];
-      const EBCellFAB&     newPPC        = (*m_newPPC[lvl])[din];
       const BaseFab<bool>& validCells    = (*m_amr->getValidCells(m_particleRealm)[lvl])[din];
 
       bool isDielectric = false;

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.H
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.H
@@ -159,6 +159,12 @@ namespace Physics {
       getNumberOfPlotVariables() const noexcept override;
 
       /*!
+	@brief Return true/false if physics model needs species gradients.
+      */
+      virtual bool
+      needGradients() const noexcept override;
+
+      /*!
 	@brief Compute the Ito solver mobilities.
 	@param[in] a_time Time
 	@param[in] a_pos  Position

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -3108,6 +3108,25 @@ ItoKMCJSON::secondaryEmissionEB(Vector<List<ItoParticle>>&       a_secondaryPart
   }
 }
 
+bool
+ItoKMCJSON::needGradients() const noexcept
+{
+  CH_TIME("ItoKMCJSON::needGradients");
+  if (m_verbose) {
+    pout() << m_className + "::needGradients" << endl;
+  }
+
+  bool needGradient = false;
+
+  for (const auto& gradCorr : m_kmcReactionGradientCorrections) {
+    if (gradCorr.first) {
+      needGradient = true;
+    }
+  }
+
+  return needGradient;
+}
+
 int
 ItoKMCJSON::getNumberOfPlotVariables() const noexcept
 {

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
@@ -234,9 +234,6 @@ ItoKMCGodunovStepper<I, C, R, F>::advance(const Real a_dt)
   }
   m_timer.stopEvent("Deposit photons");
 
-  // Compute the number of particles per cell.
-  this->getPhysicalParticlesPerCell(this->m_oldPPC);
-
   // ====== BEGIN TRANSPORT STEP ======
   // Semi-implicitly advance the particles and the field.
   switch (m_algorithm) {
@@ -347,7 +344,6 @@ ItoKMCGodunovStepper<I, C, R, F>::advance(const Real a_dt)
     this->m_amr->transferIrregularParticles(ebParticles, bulkParticles, this->m_plasmaPhase);
   }
 
-  this->getPhysicalParticlesPerCell(this->m_newPPC);
   m_timer.stopEvent("EB/Particle intersection");
 
   // Remove the run-time configurable particle storage. It is no longer needed.
@@ -359,18 +355,13 @@ ItoKMCGodunovStepper<I, C, R, F>::advance(const Real a_dt)
   this->advancePhotons(a_dt);
   m_timer.stopEvent("Photon transport");
 
-  // Resolve injection at the EB.
-  this->barrier();
-  m_timer.startEvent("EB particle injection");
-  this->fillSecondaryEmissionEB(a_dt);
-  this->resolveSecondaryEmissionEB(a_dt);
-  m_timer.stopEvent("EB particle injection");
-
   // Compute the gradients of the various species densities - this is used in the KMC kernels.
-  m_timer.startEvent("Gradient calculation");
-  (this->m_ito)->depositParticles();
-  this->computeDensityGradients();
-  m_timer.stopEvent("Gradient calculation");
+  if ((this->m_physics)->needGradients()) {
+    m_timer.startEvent("Gradient calculation");
+    (this->m_ito)->depositParticles();
+    this->computeDensityGradients();
+    m_timer.stopEvent("Gradient calculation");
+  }
 
   // Sort the particles and photons per cell so we can call reaction algorithms
   this->barrier();
@@ -394,13 +385,22 @@ ItoKMCGodunovStepper<I, C, R, F>::advance(const Real a_dt)
   this->sortPhotonsByPatch(McPhoto::WhichContainer::Source);
   m_timer.stopEvent("Sort by patch");
 
-  // Remove particles that are inside the EB.
+  // Resolve secondary emission. We have filled the relevant particles in the transport step. This is done
+  // AFTER the reaction step to improve stability behavior in cathode sheaths.
+  this->barrier();
+  m_timer.startEvent("EB particle injection");
+  this->fillSecondaryEmissionEB(a_dt);
+  this->resolveSecondaryEmissionEB(a_dt);
+  m_timer.stopEvent("EB particle injection");
+
+  // Remove particles that are inside the EB -- this is not a part of the algorithm, just a safety measure to make sure
+  // we don't do things with particles that lie inside the EB.
   this->barrier();
   m_timer.startEvent("Remove covered");
   this->removeCoveredParticles(SpeciesSubset::AllMobileOrDiffusive, EBRepresentation::Discrete, this->m_toleranceEB);
   m_timer.stopEvent("Remove covered");
 
-  // Clear BC data holders for now.
+  // Clear BC data holders.
   for (auto solverIt = (this->m_ito)->iterator(); solverIt.ok(); ++solverIt) {
     solverIt()->clear(ItoSolver::WhichContainer::EB);
     solverIt()->clear(ItoSolver::WhichContainer::Domain);
@@ -416,11 +416,6 @@ ItoKMCGodunovStepper<I, C, R, F>::advance(const Real a_dt)
   m_timer.startEvent("Post-compute D");
   this->computeDiffusionCoefficients();
   m_timer.stopEvent("Post-compute D");
-
-  this->barrier();
-  m_timer.startEvent("Compute J");
-  this->computeCurrentDensity(this->m_currentDensity);
-  m_timer.stopEvent("Compute J");
 
   if ((this->m_profile)) {
     m_timer.eventReport(pout(), false);


### PR DESCRIPTION
# Summary

Add various ItoKMC upgrades which increase the efficiency and stability of the advance method. 

Closes #463 

### Background

Some calculations in the advance method for the ItoKMC functionality was unecessary (e.g., current calculation). Moreover, adding particles from secondary emission _after_ the reaction step also favors stability since injected particles are advected away from the sheath before they react. 
 
### Solution

Changed the order of the algorithm to transport-reaction-inject rather than transport-inject-react. Other redundant functionality is moved to the prePlot function (e.g., calculating the currect). 

### Side-effects

None.

### Alternative solutions 

None.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [x] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
