### PR TITLE
Add support for mobility and diffusion specification for ItoKMCJSON

### DIFF
--- a/Docs/Sphinx/source/Applications/ItoKMC.rst
+++ b/Docs/Sphinx/source/Applications/ItoKMC.rst
@@ -723,6 +723,34 @@ For example,
 	}
     ]
 
+Constant
+^^^^^^^^
+
+To set a coefficient that is constant vs :math:`N`, set the ``type`` specifier to ``mu*N`` or ``D*N`` and then assign the value.
+For example,
+
+.. code-block:: json
+   :emphasize-lines: 12-19
+
+    "plasma species" :
+    [
+	{
+            "id": "e",             // Species ID
+	    "Z" : -1,              // Charge number
+	    "solver" : "ito",      // Solver type. Either 'ito' or 'cdr'
+	    "mobile" : true,       // Mobile or not
+	    "diffusive" : true     // Diffusive or not,
+	    "mobility": {
+	       "type": "mu*N",     // Set mu*N to a constant
+	       "value": 1E24
+	    },
+	    "diffusion": {
+	       "type": "D*N",      // Set D*N to a constant
+	       "value": 5E24
+	    }
+	}
+    ]    
+
 Table vs :math:`E/N`
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/Docs/Sphinx/source/Applications/ItoKMC.rst
+++ b/Docs/Sphinx/source/Applications/ItoKMC.rst
@@ -726,7 +726,7 @@ For example,
 Constant
 ^^^^^^^^
 
-To set a coefficient that is constant vs :math:`N`, set the ``type`` specifier to ``mu*N`` or ``D*N`` and then assign the value.
+To set a coefficient that is constant vs :math:`N`, set the ``type`` specifier to ``constant mu*N`` or ``constant D*N`` and then assign the value.
 For example,
 
 .. code-block:: json
@@ -735,17 +735,17 @@ For example,
     "plasma species" :
     [
 	{
-            "id": "e",             // Species ID
-	    "Z" : -1,              // Charge number
-	    "solver" : "ito",      // Solver type. Either 'ito' or 'cdr'
-	    "mobile" : true,       // Mobile or not
-	    "diffusive" : true     // Diffusive or not,
+            "id": "e",			// Species ID
+	    "Z" : -1,			// Charge number
+	    "solver" : "ito",		// Solver type. Either 'ito' or 'cdr'
+	    "mobile" : true,		// Mobile or not
+	    "diffusive" : true		// Diffusive or not,
 	    "mobility": {
-	       "type": "mu*N",     // Set mu*N to a constant
+	       "type": "constant mu*N", // Set mu*N to a constant
 	       "value": 1E24
 	    },
 	    "diffusion": {
-	       "type": "D*N",      // Set D*N to a constant
+	       "type": "constant D*N",  // Set D*N to a constant
 	       "value": 5E24
 	    }
 	}

--- a/Docs/Sphinx/source/Applications/ItoKMC.rst
+++ b/Docs/Sphinx/source/Applications/ItoKMC.rst
@@ -723,8 +723,8 @@ For example,
 	}
     ]
 
-Constant
-^^^^^^^^
+Constant :math:`*N`
+^^^^^^^^^^^^^^^^^^^^^^
 
 To set a coefficient that is constant vs :math:`N`, set the ``type`` specifier to ``constant mu*N`` or ``constant D*N`` and then assign the value.
 For example,

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -1293,15 +1293,15 @@ ItoKMCJSON::initializeMobilities()
           return mu;
         };
       }
-      else if (type == "mu*N") {
+      else if (type == "constant mu*N") {
         if (!(mobilityJSON.contains("value"))) {
-          this->throwParserError(baseErrorID + " and got 'mu*N' but 'value' field is not specified");
+          this->throwParserError(baseErrorID + " and got 'constant mu*N' but 'value' field is not specified");
         }
 
         const Real mu = mobilityJSON["value"].get<Real>();
 
         if (mu < 0.0) {
-          this->throwParserError(baseErrorID + " and got 'mu*N' but 'value' can't be negative");
+          this->throwParserError(baseErrorID + " and got 'constant mu*N' but 'value' can't be negative");
         }
 
         mobilityFunction = [this, mu](const Real E, const RealVect x) -> Real {
@@ -1388,15 +1388,15 @@ ItoKMCJSON::initializeDiffusionCoefficients()
           return D;
         };
       }
-      else if (type == "D*N") {
+      else if (type == "constant D*N") {
         if (!(diffusionJSON.contains("value"))) {
-          this->throwParserError(baseErrorID + " and got 'D*N' but 'value' field is not specified");
+          this->throwParserError(baseErrorID + " and got 'constant D*N' but 'value' field is not specified");
         }
 
         const Real D = diffusionJSON["value"].get<Real>();
 
         if (D < 0.0) {
-          this->throwParserError(baseErrorID + " and got 'D*N' but 'value' can't be negative");
+          this->throwParserError(baseErrorID + " and got 'constant D*N' but 'value' can't be negative");
         }
 
         diffusionCoefficient = [this, D](const Real E, const RealVect x) -> Real {

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -1293,6 +1293,23 @@ ItoKMCJSON::initializeMobilities()
           return mu;
         };
       }
+      else if (type == "mu*N") {
+        if (!(mobilityJSON.contains("value"))) {
+          this->throwParserError(baseErrorID + " and got 'mu*N' but 'value' field is not specified");
+        }
+
+        const Real mu = mobilityJSON["value"].get<Real>();
+
+        if (mu < 0.0) {
+          this->throwParserError(baseErrorID + " and got 'mu*N' but 'value' can't be negative");
+        }
+
+        mobilityFunction = [this, mu](const Real E, const RealVect x) -> Real {
+          const Real N = m_gasNumberDensity(x);
+
+          return mu / (std::numeric_limits<Real>::epsilon() + N);
+        };
+      }
       else if (type == "table vs E/N") {
         const std::string baseErrorTable = baseErrorID + " and also got table vs E/N";
 
@@ -1369,6 +1386,23 @@ ItoKMCJSON::initializeDiffusionCoefficients()
 
         diffusionCoefficient = [D](const Real E, const RealVect x) -> Real {
           return D;
+        };
+      }
+      else if (type == "D*N") {
+        if (!(diffusionJSON.contains("value"))) {
+          this->throwParserError(baseErrorID + " and got 'D*N' but 'value' field is not specified");
+        }
+
+        const Real D = diffusionJSON["value"].get<Real>();
+
+        if (D < 0.0) {
+          this->throwParserError(baseErrorID + " and got 'D*N' but 'value' can't be negative");
+        }
+
+        diffusionCoefficient = [this, D](const Real E, const RealVect x) -> Real {
+          const Real N = m_gasNumberDensity(x);
+
+          return D / (std::numeric_limits<Real>::epsilon() + N);
         };
       }
       else if (type == "table vs E/N") {


### PR DESCRIPTION
# Summary

Add support for specifying that mu*N and D*N should be constants. 

### Background

Current, ItoKMCJSON only supports constant mobilities or tabulated mobilities. If users wanted to use a mobility where mu*N was a constant, they had to create a table with two entries where mu*N was the same for both. 

### Solution

ItoKMCJSON can now parse mobility and diffusion specifiers as 'constant mu*N' and 'constant D*N' such that users can simply specify whatever mu*N = constant that they want.

### Side-effects

None.

### Alternative solutions 

None.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
