### PR TITLE
Bug fix in depositParticle4

### DIFF
--- a/Source/Particle/CD_EBParticleMeshImplem.H
+++ b/Source/Particle/CD_EBParticleMeshImplem.H
@@ -767,14 +767,14 @@ EBParticleMesh::depositParticle4(EBCellFAB&           a_rho,
 
   // Force NGP in cut-cells if we want.
   if (m_ebisbox.isIrregular(particleIndex) && a_forceIrregNGP) {
-    for (int comp = startComp; comp >= endComp; comp++) {
+    for (int comp = startComp; comp <= endComp; comp++) {
       rho(particleIndex, comp) += a_strength[comp] * invVol;
     }
   }
   else {
     switch (a_depositionType) {
     case DepositionType::NGP: {
-      for (int comp = startComp; comp >= endComp; comp++) {
+      for (int comp = startComp; comp <= endComp; comp++) {
         rho(particleIndex, comp) += a_strength[comp] * invVol;
       }
       break;
@@ -802,7 +802,7 @@ EBParticleMesh::depositParticle4(EBCellFAB&           a_rho,
           }
         }
 
-        for (int comp = startComp; comp >= endComp; comp++) {
+        for (int comp = startComp; comp <= endComp; comp++) {
           rho(iv, comp) += a_strength[comp] * weight;
         }
       };


### PR DESCRIPTION
# Summary

Fix an incorrect index loop in EBParticleMesh.

### Background

The loop in the factor 4 refinement deposition routines ran over more components than it should have. This is unlikely to have caused any subtle errors because it would have reached into invalid memory and immediately caused segfaults.

### Solution

Now looping correctly over components 'comp <= endComp' rather than 'comp >= endComp'.

### Side-effects

### Alternative solutions 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [x] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
