### PR TITLE
Add another constructor to CdrPlasmaJSON

### DIFF
--- a/Physics/CdrPlasma/PlasmaModels/CdrPlasmaJSON/CD_CdrPlasmaJSON.H
+++ b/Physics/CdrPlasma/PlasmaModels/CdrPlasmaJSON/CD_CdrPlasmaJSON.H
@@ -90,9 +90,17 @@ namespace Physics {
       using FunctionTT = std::function<Real(const Real a_T1, const Real a_T2)>;
 
       /*!
-	@brief Default constructor.
+	@brief Default constructor. Puts object in usable state. 
       */
       CdrPlasmaJSON();
+
+      /*!
+	@brief Dummy constructor. Leaves object in undefined state.
+	@details This constructor is present in order to allow new derived class of CdrPlasmaJSON that instantiate
+	without calling the all-defining base constructor. 
+	@param[in] a_dummy Dummy argument. 
+      */
+      CdrPlasmaJSON(const int a_dummy);
 
       /*!
 	@brief Destructor

--- a/Physics/CdrPlasma/PlasmaModels/CdrPlasmaJSON/CD_CdrPlasmaJSON.cpp
+++ b/Physics/CdrPlasma/PlasmaModels/CdrPlasmaJSON/CD_CdrPlasmaJSON.cpp
@@ -70,6 +70,11 @@ CdrPlasmaJSON::CdrPlasmaJSON()
   m_numRtSpecies  = m_rtSpecies.size();
 }
 
+CdrPlasmaJSON::CdrPlasmaJSON(const int a_dummy)
+{
+  CH_TIME("CdrPlasmaJSON::CdrPlasmaJSON(int)");
+}
+
 CdrPlasmaJSON::~CdrPlasmaJSON()
 {
   CH_TIME("CdrPlasmaJSON::~CdrPlasmaJSON()");
@@ -730,8 +735,7 @@ CdrPlasmaJSON::initializePlasmaSpecies()
 
     // Print out a message if we're verbose.
     if (m_verbose) {
-      pout() << "CdrPlasmaJSON::initializePlasmaSpecies: instantiating species"
-             << "\n"
+      pout() << "CdrPlasmaJSON::initializePlasmaSpecies: instantiating species" << "\n"
              << "\tName             = " << name << "\n"
              << "\tZ                = " << Z << "\n"
              << "\tMobile           = " << mobile << "\n"


### PR DESCRIPTION
# Summary

Add an empty constructor to CdrPlasmaJSON.

### Background

CdrPlasmaJSON has a base constructor that calls quite a few virtual functions. However, this prevents inherited classes from actually overriding them since the parent version is always called in the base constructor. 

### Solution

To circumvent this, I am simply adding an empty constructor with a dummy argument so that people can instantiate their derived classes using an empty constructor rather than an all-defining one. 

### Side-effects

None.

### Alternative solutions 

Redesign how CdrPlasmaJSON is built, i.e., using a define function outside of the base constructor. 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [x] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
