### PR TITLE
Use local copy of Copier in interpToNewGrids 

### DIFF
--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -2135,7 +2135,8 @@ AmrMesh::interpToNewGrids(EBAMRCellData&                   a_newData,
   // for performance at large scales (> 1M boxes and 10k ranks).
   for (int lvl = 0; lvl <= std::max(0, a_lmin - 1); lvl++) {
     if (m_hasRegridCopiers && a_newData[lvl]->ghostVect() == ghost) {
-      const Copier& copier = m_oldToNewCellCopiers.at(a_newData.getRealm())[lvl];
+      //      const Copier& copier = m_oldToNewCellCopiers.at(a_newData.getRealm())[lvl];
+      Copier copier(m_oldToNewCellCopiers.at(a_newData.getRealm())[lvl]);
 
       CH_assert(copier.isDefined());
 
@@ -2162,7 +2163,8 @@ AmrMesh::interpToNewGrids(EBAMRCellData&                   a_newData,
     // to pollute the solution with interpolation there since we already have valid data.
     if (lvl <= std::min(a_oldFinestLevel, a_newFinestLevel)) {
       if (m_hasRegridCopiers && a_newData[lvl]->ghostVect() == ghost) {
-        const Copier& copier = m_oldToNewCellCopiers.at(a_newData.getRealm())[lvl];
+        //        const Copier& copier = m_oldToNewCellCopiers.at(a_newData.getRealm())[lvl];
+        Copier copier(m_oldToNewCellCopiers.at(a_newData.getRealm())[lvl]);
 
         CH_assert(copier.isDefined());
 
@@ -2204,7 +2206,8 @@ AmrMesh::interpToNewGrids(EBAMRIVData&                     a_newData,
   // These levels have not changed but ownership might have changed so we still need to copy.
   for (int lvl = 0; lvl <= std::max(0, a_lmin - 1); lvl++) {
     if (m_hasRegridCopiers && a_newData[lvl]->ghostVect() == ghost) {
-      const Copier& copier = m_oldToNewEBCopiers.at(a_newData.getRealm())[lvl];
+      //      const Copier& copier = m_oldToNewEBCopiers.at(a_newData.getRealm())[lvl];
+      Copier copier(m_oldToNewEBCopiers.at(a_newData.getRealm())[lvl]);
 
       CH_assert(copier.isDefined());
 
@@ -2229,7 +2232,8 @@ AmrMesh::interpToNewGrids(EBAMRIVData&                     a_newData,
     // to pollute the solution with interpolation errors there since we already have valid data.
     if (lvl <= std::min(a_oldFinestLevel, a_newFinestLevel)) {
       if (m_hasRegridCopiers && a_newData[lvl]->ghostVect() == ghost) {
-        const Copier& copier = m_oldToNewEBCopiers.at(a_newData.getRealm())[lvl];
+        //        const Copier& copier = m_oldToNewEBCopiers.at(a_newData.getRealm())[lvl];
+        Copier copier(m_oldToNewEBCopiers.at(a_newData.getRealm())[lvl]);
 
         CH_assert(copier.isDefined());
 


### PR DESCRIPTION
# Summary

Perform a local copy of the Copier object which performs the old-to-new grid copy during regrids.

Closes #479 

### Background

Reported crashes during mesh regrids have been tracked down to memory corruption in Copier. I don't know what causes this but a local redefine of the Copier object fixes this. This is probably a Chombo bug. 

### Solution

Change to local redefine of the relevant Copier. 

### Side-effects

This can potentially lead to a slight performance degradation. However, I also believe that the most expensive part of the Copier define method is the grid iteration loops, so the extra loop iterations are (hopefully) not that bad. 

### Alternative solutions 

Can track down the memory corruption error in Chombo. 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [x] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
