### PR TITLE
Update Betzy makefiles for new software stack

### DIFF
--- a/Lib/Local/betzy/Make.defs.MPI.HDF5.GNU
+++ b/Lib/Local/betzy/Make.defs.MPI.HDF5.GNU
@@ -128,11 +128,11 @@ CXXSTD         = 14
 USE_EB         = TRUE
 #USE_CCSE      =
 USE_HDF        = TRUE
-HDFINCFLAGS    = -I/cluster/software/HDF5/1.10.7-gompi-2021a/include
-HDFLIBFLAGS    = -L/cluster/software/HDF5/1.10.7-gompi-2021a/lib -lhdf5 -lz
+HDFINCFLAGS	= -I/cluster/software/HDF5/1.14.0-gompi-2023a/include  -DH5_USE_110_API
+HDFLIBFLAGS	= -L/cluster/software/HDF5/1.14.0-gompi-2023a/lib -lhdf5 -lz  -DH5_USE_110_API
 ## Note: don't set the HDFMPI* variables if you don't have parallel HDF installed
-HDFMPIINCFLAGS = -I/cluster/software/HDF5/1.10.7-gompi-2021a/include
-HDFMPILIBFLAGS = -L/cluster/software/HDF5/1.10.7-gompi-2021a/lib -lhdf5 -lz
+HDFMPIINCFLAGS	= -I/cluster/software/HDF5/1.14.0-gompi-2023a/include -DH5_USE_110_API
+HDFMPILIBFLAGS	= -L/cluster/software/HDF5/1.14.0-gompi-2023a/lib -lhdf5 -lz -DH5_USE_110_API 
 USE_MF         = TRUE
 #USE_MT        =
 #USE_SETVAL    =

--- a/Lib/Local/betzy/template.GNU.slurm
+++ b/Lib/Local/betzy/template.GNU.slurm
@@ -12,8 +12,8 @@ set -o nounset
 
 ## Software modules
 module restore system
-module load foss/2020a
-module load HDF5/1.10.6-gompi-2020a
+module load foss/2023a
+module load HDF5/1.14.0-foss-2023a
 
 # Program to run and input script
 executable=main3d.Linux.64.mpicxx.gfortran.OPTHIGH.MPI.ex


### PR DESCRIPTION
# Summary

Update makefiles for building and running chombo-discharge on Betzy. 

### Background

Betzy was updated in July 2024 and the old makefiles were outdated. This PR adds new makefiles.

### Solution

Update the old makefiles to use the new software stack.

### Side-effects

None.

### Alternative solutions 

# Checklist

- [ ] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [ ] I have added all relevant user documentation to Sphinx.
- [ ] I have added all relevant APIs to the doxygen documentation.
- [ ] I have added appropriate labels to this PR
