### PR TITLE
Bugfix for column selection in tabulated data inputs

### DIFF
--- a/Docs/Sphinx/source/Applications/ItoKMC.rst
+++ b/Docs/Sphinx/source/Applications/ItoKMC.rst
@@ -767,8 +767,8 @@ To set the transport coefficients as functions :math:`f = f\left(E/N\right)`, se
 
 * ``header`` For specifying where in the file one starts reading data.
   This is an optional argument intended for use with BOLSIG+ output data where the user specifies that the data is contained in the lines below the specified header.
-* ``E/N`` For setting which column in the data file contains the values of :math:`E/N` (optional, defaults to 0).
-* ``mu*N`` For setting which column in the data file contains the values of :math:`\mu N` (or alternatively :math:`DN` for the diffusion coefficient).
+* ``E/N column`` For setting which column in the data file contains the values of :math:`E/N` (optional, defaults to 0).
+* ``mu*N column`` For setting which column in the data file contains the values of :math:`\mu N` (or alternatively :math:`DN` for the diffusion coefficient).
   This is an optional argument that defaults to 1.
 * ``E/N scale`` Optional scaling of the column containing the :math:`E/N` data.
 * ``mu*N scale`` Optional scaling of the column containing the :math:`\mu N` data (or alternatively :math:`DN` for the diffusion coefficient).
@@ -797,8 +797,8 @@ An example JSON specification that uses a BOLSIG+ output file for parsing the da
 	     "file" : "bolsig_air.dat",                    // File containg the mobility data
 	     "dump" : "debug_mobility.dat",                // Optional argument for dumping table to disk (useful for debugging)		
 	     "header" : "E/N (Td)\tMobility *N (1/m/V/s)", // Line immediately preceding the colum data
-	     "E/N" : 0,                                    // Column containing E/N
-	     "mu*N" : 1,                                   // Column containing mu*N
+	     "E/N column" : 0,                             // Column containing E/N
+	     "mu*N column" : 1,                            // Column containing mu*N
 	     "min E/N" : 1,                                // Minimum E/N kept when resampling table
 	     "max E/N" : 2E6,                              // Maximum E/N kept when resampling table
 	     "points" : 1000,                              // Number of grid points kept when resampling the table
@@ -884,8 +884,8 @@ To set the species temperature as a function :math:`T = T\left(E/N\right)`, set 
 
 * ``header`` For specifying where in the file one starts reading data.
   This is an optional argument intended for use with BOLSIG+ output data where the user specifies that the data is contained in the lines below the specified header.
-* ``E/N`` For setting which column in the data file contains the values of :math:`E/N` (optional, defaults to 0).
-* ``eV`` For setting which column in the data file contains the energy vs :math:`E/N`.
+* ``E/N column`` For setting which column in the data file contains the values of :math:`E/N` (optional, defaults to 0).
+* ``eV column`` For setting which column in the data file contains the energy vs :math:`E/N`.
   This is an optional argument that defaults to 1.
 * ``E/N scale`` Optional scaling of the column containing the :math:`E/N` data.
 * ``eV scale`` Optional scaling of the column containing the energy (in eV).
@@ -914,8 +914,8 @@ An example JSON specification that uses a BOLSIG+ output file for parsing the da
 	     "file": "bolsig_air.dat",                // File name
 	     "dump": "debug_temperature.dat",         // Dump to file
 	     "header" : "E/N (Td)\tMean energy (eV)", // Header preceding data
-	     "E/N" : 0,                               // Column containing E/N
-	     "eV" : 1,                                // Column containing the energy
+	     "E/N column" : 0,                        // Column containing E/N
+	     "eV column" : 1,                         // Column containing the energy
 	     "min E/N" : 10,                          // Truncation of table
 	     "max E/N" : 2E6,                         // Truncation of table
 	     "E/N scale": 1.0,                        // Scaling of input data

--- a/Exec/Examples/ItoKMC/AirBasic/simple_air_chemistry.json
+++ b/Exec/Examples/ItoKMC/AirBasic/simple_air_chemistry.json
@@ -87,8 +87,8 @@
 		"file" : "bolsig_air.dat",                    // File containg the mobility data
 		//"dump" : "debug_mobility.dat",              // Optional argument for dumping table to disk (useful for debugging)		
 		"header" : "E/N (Td)\tMobility *N (1/m/V/s)", // Line immediately preceding the colum data
-		"E/N" : 0,                                    // Column containing E/N
-		"mu*N" : 1,                                   // Column containing mu*N
+		"E/N column" : 0,                             // Column containing E/N
+		"mu*N column" : 1,                            // Column containing mu*N
 		"min E/N" : 1,                                // Minimum E/N kept when resampling table
 		"max E/N" : 2E6,                              // Maximum E/N kept when resampling table
 		"points" : 1000,                              // Number of grid points kept when resampling the table
@@ -102,8 +102,8 @@
 		"file" : "bolsig_air.dat",
 		//"dump": "debug_diffusion.dat",		
 		"header" : "E/N (Td)\tDiffusion coefficient *N (1/m/s)",
-		"E/N" : 0,
-		"D*N" : 1,
+		"E/N column" : 0,
+		"D*N column" : 1,
 		"min E/N" : 10,
 		"max E/N" : 2E6,
 		"spacing" : "exponential",
@@ -115,8 +115,8 @@
 		"file": "bolsig_air.dat",
 		//"dump": "debug_temperature.dat",				
 		"header" : "E/N (Td)\tMean energy (eV)",
-		"E/N" : 0,
-		"eV" : 1,
+		"E/N column" : 0,
+		"eV column" : 1,
 		"min E/N" : 10,
 		"max E/N" : 2E6,
 		"E/N scale": 1.0,

--- a/Exec/Examples/ItoKMC/AirDBD/simple_air_chemistry.json
+++ b/Exec/Examples/ItoKMC/AirDBD/simple_air_chemistry.json
@@ -114,8 +114,8 @@
 		"file" : "bolsig_air.dat",                    // File containg the mobility data
 		//"dump" : "debug_mobility.dat",              // Optional argument for dumping table to disk (useful for debugging)		
 		"header" : "E/N (Td)\tMobility *N (1/m/V/s)", // Line immediately preceding the colum data
-		"E/N" : 0,                                    // Column containing E/N
-		"mu*N" : 1,                                   // Column containing mu*N
+		"E/N column" : 0,                                    // Column containing E/N
+		"mu*N column" : 1,                                   // Column containing mu*N
 		"min E/N" : 1,                                // Minimum E/N kept when resampling table
 		"max E/N" : 2E6,                              // Maximum E/N kept when resampling table
 		"points" : 1000,                              // Number of grid points kept when resampling the table
@@ -129,8 +129,8 @@
 		"file" : "bolsig_air.dat",
 		//"dump": "debug_diffusion.dat",		
 		"header" : "E/N (Td)\tDiffusion coefficient *N (1/m/s)",
-		"E/N" : 0,
-		"D*N" : 1,
+		"E/N column" : 0,
+		"D*N column" : 1,
 		"min E/N" : 10,
 		"max E/N" : 2E6,
 		"spacing" : "exponential",
@@ -142,8 +142,8 @@
 		"file": "bolsig_air.dat",
 		//"dump": "debug_temperature.dat",				
 		"header" : "E/N (Td)\tMean energy (eV)",
-		"E/N" : 0,
-		"eV" : 1,
+		"E/N column" : 0,
+		"eV column" : 1,
 		"min E/N" : 10,
 		"max E/N" : 2E6,
 		"E/N scale": 1.0,

--- a/Exec/Examples/ItoKMC/PartialDischarge/simple_air_chemistry.json
+++ b/Exec/Examples/ItoKMC/PartialDischarge/simple_air_chemistry.json
@@ -124,8 +124,8 @@
 		"file" : "bolsig_air.dat",                    // File containg the mobility data
 		//"dump" : "debug_mobility.dat",              // Optional argument for dumping table to disk (useful for debugging)		
 		"header" : "E/N (Td)\tMobility *N (1/m/V/s)", // Line immediately preceding the colum data
-		"E/N" : 0,                                    // Column containing E/N
-		"mu*N" : 1,                                   // Column containing mu*N
+		"E/N column" : 0,                                    // Column containing E/N
+		"mu*N column" : 1,                                   // Column containing mu*N
 		"min E/N" : 1,                                // Minimum E/N kept when resampling table
 		"max E/N" : 2E6,                              // Maximum E/N kept when resampling table
 		"points" : 1000,                              // Number of grid points kept when resampling the table
@@ -139,8 +139,8 @@
 		"file" : "bolsig_air.dat",
 		//"dump": "debug_diffusion.dat",		
 		"header" : "E/N (Td)\tDiffusion coefficient *N (1/m/s)",
-		"E/N" : 0,
-		"D*N" : 1,
+		"E/N column" : 0,
+		"D*N column" : 1,
 		"min E/N" : 10,
 		"max E/N" : 2E6,
 		"spacing" : "exponential",
@@ -152,8 +152,8 @@
 		"file": "bolsig_air.dat",
 		//"dump": "debug_temperature.dat",				
 		"header" : "E/N (Td)\tMean energy (eV)",
-		"E/N" : 0,
-		"eV" : 1,
+		"E/N column" : 0,
+		"eV column" : 1,
 		"min E/N" : 10,
 		"max E/N" : 2E6,
 		"E/N scale": 1.0,

--- a/Exec/Examples/ItoKMC/WireWire/chemistry.json
+++ b/Exec/Examples/ItoKMC/WireWire/chemistry.json
@@ -62,8 +62,8 @@
 		"file" : "bolsig_air.dat",                    // File containg the mobility data
 		//"dump" : "debug_mobility.dat",              // Optional argument for dumping table to disk (useful for debugging)		
 		"header" : "E/N (Td)\tMobility *N (1/m/V/s)", // Line immediately preceding the colum data
-		"E/N" : 0,                                    // Column containing E/N
-		"mu*N" : 1,                                   // Column containing mu*N
+		"E/N column" : 0,                                    // Column containing E/N
+		"mu*N column" : 1,                                   // Column containing mu*N
 		"min E/N" : 1,                                // Minimum E/N kept when resampling table
 		"max E/N" : 2E6,                              // Maximum E/N kept when resampling table
 		"points" : 1000,                              // Number of grid points kept when resampling the table
@@ -77,8 +77,8 @@
 		"file" : "bolsig_air.dat",
 		//"dump": "debug_diffusion.dat",		
 		"header" : "E/N (Td)\tDiffusion coefficient *N (1/m/s)",
-		"E/N" : 0,
-		"D*N" : 1,
+		"E/N column" : 0,
+		"D*N column" : 1,
 		"min E/N" : 10,
 		"max E/N" : 2E6,
 		"spacing" : "exponential",
@@ -90,8 +90,8 @@
 		"file": "bolsig_air.dat",
 		//"dump": "debug_temperature.dat",				
 		"header" : "E/N (Td)\tMean energy (eV)",
-		"E/N" : 0,
-		"eV" : 1,
+		"E/N column" : 0,
+		"eV column" : 1,
 		"min E/N" : 10,
 		"max E/N" : 2E6,
 		"E/N scale": 1.0,

--- a/Exec/Tests/ItoKMC/JSON/simple_air_chemistry.json
+++ b/Exec/Tests/ItoKMC/JSON/simple_air_chemistry.json
@@ -114,8 +114,8 @@
 		"file" : "bolsig_air.dat",                    // File containg the mobility data
 		//"dump" : "debug_mobility.dat",              // Optional argument for dumping table to disk (useful for debugging)		
 		"header" : "E/N (Td)\tMobility *N (1/m/V/s)", // Line immediately preceding the colum data
-		"E/N" : 0,                                    // Column containing E/N
-		"mu*N" : 1,                                   // Column containing mu*N
+		"E/N column" : 0,                                    // Column containing E/N
+		"mu*N column" : 1,                                   // Column containing mu*N
 		"min E/N" : 1,                                // Minimum E/N kept when resampling table
 		"max E/N" : 2E6,                              // Maximum E/N kept when resampling table
 		"points" : 1000,                              // Number of grid points kept when resampling the table
@@ -129,8 +129,8 @@
 		"file" : "bolsig_air.dat",
 		//"dump": "debug_diffusion.dat",		
 		"header" : "E/N (Td)\tDiffusion coefficient *N (1/m/s)",
-		"E/N" : 0,
-		"D*N" : 1,
+		"E/N column" : 0,
+		"D*N column" : 1,
 		"min E/N" : 10,
 		"max E/N" : 2E6,
 		"spacing" : "exponential",
@@ -142,8 +142,8 @@
 		"file": "bolsig_air.dat",
 		//"dump": "debug_temperature.dat",				
 		"header" : "E/N (Td)\tMean energy (eV)",
-		"E/N" : 0,
-		"eV" : 1,
+		"E/N column" : 0,
+		"eV column" : 1,
 		"min E/N" : 10,
 		"max E/N" : 2E6,
 		"E/N scale": 1.0,

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -2771,8 +2771,8 @@ ItoKMCJSON::parseTableEByN(const nlohmann::json& a_tableEntry, const std::string
 
   LookupTable::Spacing spacing = LookupTable::Spacing::Exponential;
 
-  if (a_tableEntry.contains("EbyN column")) {
-    columnEbyN = a_tableEntry["EbyN column"].get<int>();
+  if (a_tableEntry.contains("E/N column")) {
+    columnEbyN = a_tableEntry["E/N column"].get<int>();
   }
   if (a_tableEntry.contains(a_dataID + " column")) {
     columnCoeff = a_tableEntry[a_dataID + " column"].get<int>();


### PR DESCRIPTION
# Summary

Fix for column selection in tabulated data inputs. 

### Background

ItoKMCJSON would parse lookup tables based on column specifiers "EbyN column" and "data column", whereas the documention indicated that the JSON specifiers would simply be "E/N" and "data". 

This PR sets this to the correct format. 

### Solution

Update column specifiers as "E/N column" and "data column", and update documentation. 

### Side-effects

None

### Alternative solutions 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [x] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
