### PR TITLE
Remove profiling code

### DIFF
--- a/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
+++ b/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
@@ -2485,8 +2485,6 @@ DischargeInceptionStepper<P, F, C>::computeInceptionIntegralStationary() noexcep
   m_amr->allocate(Kminu, m_realm, m_phase, 1);
 
   // Integrate for each voltage
-  Timer timer("discharge_inception");
-  timer.startEvent("integration");
   for (int i = 0; i < m_voltageSweeps.size(); ++i) {
 
     DataOps::setValue(Kplus, 0.0);
@@ -2563,8 +2561,6 @@ DischargeInceptionStepper<P, F, C>::computeInceptionIntegralStationary() noexcep
       }
     }
   }
-  timer.stopEvent("integration");
-  timer.eventReport(pout(), false);
 }
 
 template <typename P, typename F, typename C>


### PR DESCRIPTION
# Summary

Remove timer profiling of DischargeInceptionStepper kernels. 

### Background

PR #491 had profiling kernels that should not have been present in the final PR. This PR removes the relevant code. 

### Solution

Deleted code. 

### Side-effects

None.

### Alternative solutions 

None. 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
