### PR TITLE
Bug fix after #491

### DIFF
--- a/Exec/Examples/DischargeInception/Vessel/example2d.inputs
+++ b/Exec/Examples/DischargeInception/Vessel/example2d.inputs
@@ -185,7 +185,7 @@ DischargeInceptionStepper.townsend_grid_dx = 2.0		## Space step to use for Towns
 # Static mode
 DischargeInceptionStepper.voltage_lo       = 20E3                     # Low voltage multiplier
 DischargeInceptionStepper.voltage_hi       = 60E3                     # Highest voltage multiplier
-DischargeInceptionStepper.voltage_steps    = 20			                            # Number of voltage steps
+DischargeInceptionStepper.voltage_steps    = 19			                            # Number of voltage steps
 
 # Dynamic mode
 DischargeInceptionStepper.ion_transport = true                    # Turn on/off ion transport
@@ -201,8 +201,8 @@ DischargeInceptionStepper.max_dt_growth = 0.05                    # Maximum rela
 # DischargeInceptionTagger class options
 # ====================================================================================================
 DischargeInceptionTagger.verbosity   = -1    # Tagger chattiness. 
-DischargeInceptionTagger.buffer      = 0     # Grown buffer around flagged cells
-DischargeInceptionTagger.max_voltage = 40E3 # Maximum applied voltage 
+DischargeInceptionTagger.buffer      = 4     # Grown buffer around flagged cells
+DischargeInceptionTagger.max_voltage = 60E3 # Maximum applied voltage 
 DischargeInceptionTagger.ref_alpha   = 1.0   # Refinement curvature criterion. Lower => more mesh
 DischargeInceptionTagger.plot        = false # Plot tagging field or not.
 

--- a/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
+++ b/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
@@ -2630,6 +2630,7 @@ DischargeInceptionStepper<P, F, C>::inceptionIntegrateEuler(const Real& a_voltag
   EBAMRCellData scratch;
   m_amr->allocate(scratch, m_realm, m_phase, SpaceDim);
   this->superposition(scratch, a_voltage);
+  DataOps::scale(scratch, -1.0);
 
   m_tracerParticleSolver->setVelocity(scratch);
   m_tracerParticleSolver->interpolateVelocities();

--- a/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
+++ b/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
@@ -2670,7 +2670,7 @@ DischargeInceptionStepper<P, F, C>::inceptionIntegrateEuler(const Real& a_voltag
 
           // Select a step size equal to the avalance length, but never exceed the physical and grid hardcaps
           Real deltaX;
-          deltaX = std::min(m_alphaDx / (tol + std::abs(alphaEff)), std::abs(alphaEff / gradAlpha));
+          deltaX = std::min(m_alphaDx / (tol + std::abs(alphaEff)), m_gradAlphaDx * std::abs(alphaEff / gradAlpha));
           deltaX = std::max(deltaX, m_minGridDx * dx);
           deltaX = std::min(deltaX, m_maxGridDx * dx);
           deltaX = std::min(deltaX, m_maxPhysDx);
@@ -2854,7 +2854,7 @@ DischargeInceptionStepper<P, F, C>::inceptionIntegrateTrapezoidal(const Real& a_
 
           // Select a step size equal to the avalance length, but never exceed the physical and grid hardcaps
           Real deltaX;
-          deltaX = std::min(m_alphaDx / (tol + std::abs(alphaEff)), std::abs(alphaEff / gradAlpha));
+          deltaX = std::min(m_alphaDx / (tol + std::abs(alphaEff)), m_gradAlphaDx * std::abs(alphaEff / gradAlpha));
           deltaX = std::max(deltaX, m_minGridDx * dx);
           deltaX = std::min(deltaX, m_maxGridDx * dx);
           deltaX = std::min(deltaX, m_maxPhysDx);


### PR DESCRIPTION
# Summary

Correct  two bugs:

1. Incorrect behavior of Euler integration of seed particles in DischargeInceptionStepper. 
2. Incorrect behavior of adaptive integration based on grad(alpha).

### Background

PR #491 added new controls for particle integration. A bug crept in where the electron velocity was set parallel to the field direction instead of opposite to it. This is obviously a bug and causes accidental polarity swapping. Moreover, the particle integration flag that restricted the time step according to alpha/grad(alpha) was not multiplied by the input parameter, so we permitted 100% changes in this value, and the restriction therefore had no effect. 

### Solution

This PR rectifies the two bugs by scaling the electron velocity and multiplying by the correct input parameter.

### Side-effects

### Alternative solutions 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
