### PR TITLE
User-specified secondary emission

### DIFF
--- a/Exec/Examples/ItoKMC/AirBasic/dev.inputs
+++ b/Exec/Examples/ItoKMC/AirBasic/dev.inputs
@@ -237,6 +237,7 @@ RodNeedleDisk.disk_extra_thickness = 0.0        # Extra disk thickness
 # ====================================================================================================
 ItoKMCGodunovStepper.checkpoint_particles                  = true           # If true, regrid on restart is supported (otherwise it's not)
 ItoKMCGodunovStepper.verbosity                             = -1             # Verbosity
+ItoKMCGodunovStepper.secondary_emission                    = after_reactions # When to emit secondary particles. Either 'before_reactions' or 'after_reactions
 ItoKMCGodunovStepper.abort_on_failure                      = true           # Abort on Poisson solver failure or not
 ItoKMCGodunovStepper.redistribute_cdr                      = true           # Turn on/off reactive redistribution
 ItoKMCGodunovStepper.profile                               = true           # Turn on/off run-time profiling

--- a/Exec/Examples/ItoKMC/AirBasic/example.inputs
+++ b/Exec/Examples/ItoKMC/AirBasic/example.inputs
@@ -237,6 +237,7 @@ RodNeedleDisk.disk_extra_thickness = 0.0        # Extra disk thickness
 # ====================================================================================================
 ItoKMCGodunovStepper.checkpoint_particles                  = true           # If true, regrid on restart is supported (otherwise it's not)
 ItoKMCGodunovStepper.verbosity                             = -1             # Verbosity
+ItoKMCGodunovStepper.secondary_emission                    = after_reactions # When to emit secondary particles. Either 'before_reactions' or 'after_reactions
 ItoKMCGodunovStepper.abort_on_failure                      = true           # Abort on Poisson solver failure or not
 ItoKMCGodunovStepper.redistribute_cdr                      = true           # Turn on/off reactive redistribution
 ItoKMCGodunovStepper.profile                               = true           # Turn on/off run-time profiling

--- a/Exec/Examples/ItoKMC/AirDBD/example.inputs
+++ b/Exec/Examples/ItoKMC/AirDBD/example.inputs
@@ -237,6 +237,7 @@ DiskProfiledPlane.cylinder_radius       = 1E-3                    # Radius for c
 # ====================================================================================================
 ItoKMCGodunovStepper.checkpoint_particles                  = true           # If true, regrid on restart is supported (otherwise it's not)
 ItoKMCGodunovStepper.verbosity                             = -1             # Verbosity
+ItoKMCGodunovStepper.secondary_emission                    = after_reactions # When to emit secondary particles. Either 'before_reactions' or 'after_reactions
 ItoKMCGodunovStepper.abort_on_failure                      = true           # Abort on Poisson solver failure or not
 ItoKMCGodunovStepper.redistribute_cdr                      = true           # Turn on/off reactive redistribution
 ItoKMCGodunovStepper.profile                               = true           # Turn on/off run-time profiling

--- a/Exec/Examples/ItoKMC/PartialDischarge/example.inputs
+++ b/Exec/Examples/ItoKMC/PartialDischarge/example.inputs
@@ -223,6 +223,7 @@ Aerosol.sphere1.center    = 0.0 0.0 0.0    # Sphere position
 # ====================================================================================================
 ItoKMCGodunovStepper.checkpoint_particles                  = true           # If true, regrid on restart is supported (otherwise it's not)
 ItoKMCGodunovStepper.verbosity                             = -1             # Verbosity
+ItoKMCGodunovStepper.secondary_emission                    = after_reactions # When to emit secondary particles. Either 'before_reactions' or 'after_reactions
 ItoKMCGodunovStepper.abort_on_failure                      = true           # Abort on Poisson solver failure or not
 ItoKMCGodunovStepper.redistribute_cdr                      = true           # Turn on/off reactive redistribution
 ItoKMCGodunovStepper.profile                               = true          # Turn on/off run-time profiling

--- a/Exec/Examples/ItoKMC/WireWire/example.inputs
+++ b/Exec/Examples/ItoKMC/WireWire/example.inputs
@@ -226,6 +226,7 @@ WireWire.second.center            = 0 -600E-6 ## Wire center
 # ====================================================================================================
 ItoKMCGodunovStepper.checkpoint_particles                  = true           # If true, regrid on restart is supported (otherwise it's not)
 ItoKMCGodunovStepper.verbosity                             = -1             # Verbosity
+ItoKMCGodunovStepper.secondary_emission                    = after_reactions # When to emit secondary particles. Either 'before_reactions' or 'after_reactions
 ItoKMCGodunovStepper.abort_on_failure                      = true           # Abort on Poisson solver failure or not
 ItoKMCGodunovStepper.redistribute_cdr                      = true           # Turn on/off reactive redistribution
 ItoKMCGodunovStepper.profile                               = false          # Turn on/off run-time profiling

--- a/Exec/Tests/ItoKMC/JSON/development.inputs
+++ b/Exec/Tests/ItoKMC/JSON/development.inputs
@@ -237,6 +237,7 @@ DiskProfiledPlane.cylinder_radius       = 1E-3                    # Radius for c
 # ====================================================================================================
 ItoKMCGodunovStepper.checkpoint_particles                  = true           # If true, regrid on restart is supported (otherwise it's not)
 ItoKMCGodunovStepper.verbosity                             = -1             # Verbosity
+ItoKMCGodunovStepper.secondary_emission                    = after_reactions # When to emit secondary particles. Either 'before_reactions' or 'after_reactions
 ItoKMCGodunovStepper.abort_on_failure                      = true           # Abort on Poisson solver failure or not
 ItoKMCGodunovStepper.redistribute_cdr                      = true           # Turn on/off reactive redistribution
 ItoKMCGodunovStepper.profile                               = true           # Turn on/off run-time profiling

--- a/Exec/Tests/ItoKMC/JSON/regression2d.inputs
+++ b/Exec/Tests/ItoKMC/JSON/regression2d.inputs
@@ -237,6 +237,7 @@ RodNeedleDisk.disk_extra_thickness = 0.0        # Extra disk thickness
 # ====================================================================================================
 ItoKMCGodunovStepper.checkpoint_particles                  = true           # If true, regrid on restart is supported (otherwise it's not)
 ItoKMCGodunovStepper.verbosity                             = -1             # Verbosity
+ItoKMCGodunovStepper.secondary_emission                    = after_reactions # When to emit secondary particles. Either 'before_reactions' or 'after_reactions
 ItoKMCGodunovStepper.abort_on_failure                      = true           # Abort on Poisson solver failure or not
 ItoKMCGodunovStepper.redistribute_cdr                      = true           # Turn on/off reactive redistribution
 ItoKMCGodunovStepper.profile                               = false          # Turn on/off run-time profiling

--- a/Exec/Tests/ItoKMC/JSON/regression3d.inputs
+++ b/Exec/Tests/ItoKMC/JSON/regression3d.inputs
@@ -237,6 +237,7 @@ RodNeedleDisk.disk_extra_thickness = 0.0        # Extra disk thickness
 # ====================================================================================================
 ItoKMCGodunovStepper.checkpoint_particles                  = true           # If true, regrid on restart is supported (otherwise it's not)
 ItoKMCGodunovStepper.verbosity                             = -1             # Verbosity
+ItoKMCGodunovStepper.secondary_emission                    = after_reactions # When to emit secondary particles. Either 'before_reactions' or 'after_reactions
 ItoKMCGodunovStepper.abort_on_failure                      = true           # Abort on Poisson solver failure or not
 ItoKMCGodunovStepper.redistribute_cdr                      = true           # Turn on/off reactive redistribution
 ItoKMCGodunovStepper.profile                               = false          # Turn on/off run-time profiling

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepper.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepper.H
@@ -168,6 +168,11 @@ namespace Physics {
       bool m_smoothConductivity;
 
       /*!
+	@brief If true, particles will be emitted before the reactive step
+      */
+      bool m_emitSecondaryParticlesBeforeReactions;
+
+      /*!
 	@brief Which advancement algorithm to use.
       */
       WhichAlgorithm m_algorithm;
@@ -263,6 +268,12 @@ namespace Physics {
       */
       virtual void
       parseCheckpointParticles() noexcept;
+
+      /*!
+	@brief Parse when secondary particles are emitted
+      */
+      virtual void
+      parseSecondaryEmissionSpecification() noexcept;
 
       /*!
 	@brief Set the starting positions for the ItoSolver particles

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepper.options
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepper.options
@@ -1,37 +1,38 @@
-# ==================================================================================================== 
-# ItoKMCGodunovStepper class options
-# ====================================================================================================
-ItoKMCGodunovStepper.checkpoint_particles                  = true           # If true, regrid on restart is supported (otherwise it's not)
-ItoKMCGodunovStepper.verbosity                             = -1             # Verbosity
-ItoKMCGodunovStepper.abort_on_failure                      = true           # Abort on Poisson solver failure or not
-ItoKMCGodunovStepper.redistribute_cdr                      = true           # Turn on/off reactive redistribution
-ItoKMCGodunovStepper.profile                               = false          # Turn on/off run-time profiling
-ItoKMCGodunovStepper.plt_vars                              = none           # 'conductivity', 'current_density', 'particles_per_patch'
-ItoKMCGodunovStepper.dual_grid                             = true           # Turn on/off dual-grid functionality
-ItoKMCGodunovStepper.load_balance_fluid                    = false          # Turn on/off fluid realm load balancing. 
-ItoKMCGodunovStepper.load_balance_particles                = true           # Turn on/off particle load balancing
-ItoKMCGodunovStepper.load_indices                          = -1             # Which particle containers to use for load balancing (-1 => all)
-ItoKMCGodunovStepper.load_per_cell                         = 1.0            # Default load per grid cell.
-ItoKMCGodunovStepper.box_sorting                           = morton         # Box sorting when load balancing
-ItoKMCGodunovStepper.particles_per_cell                    = 64             # Max computational particles per cell
-ItoKMCGodunovStepper.merge_interval                        = 1              # Time steps between superparticle merging
-ItoKMCGodunovStepper.regrid_superparticles                 = false          # Make superparticles during regrids
-ItoKMCGodunovStepper.min_particle_advection_cfl            = 0.0            # Advective time step CFL restriction
-ItoKMCGodunovStepper.max_particle_advection_cfl            = 1.0            # Advective time step CFL restriction
-ItoKMCGodunovStepper.min_particle_diffusion_cfl            = 0.0            # Diffusive time step CFL restriction
-ItoKMCGodunovStepper.max_particle_diffusion_cfl            = 1.E99          # Diffusive time step CFL restriction
-ItoKMCGodunovStepper.min_particle_advection_diffusion_cfl  = 0.0            # Advection-diffusion time step CFL restriction
-ItoKMCGodunovStepper.max_particle_advection_diffusion_cfl  = 1.E99          # Advection-diffusion time step CFL restriction
-ItoKMCGodunovStepper.fluid_advection_diffusion_cfl         = 0.5            # Advection-diffusion time step CFL restriction
-ItoKMCGodunovStepper.relax_dt_factor                       = 100.0          # Relaxation time step restriction. 
-ItoKMCGodunovStepper.min_dt                                = 0.0            # Minimum permitted time step
-ItoKMCGodunovStepper.max_dt                                = 1.E99          # Maximum permitted time step
-ItoKMCGodunovStepper.max_growth_dt                         = 1.E99          # Maximum permitted time step increase (dt * factor)
-ItoKMCGodunovStepper.max_shrink_dt                         = 1.E99          # Maximum permissible time step reduction (dt/factor)
-ItoKMCGodunovStepper.extend_conductivity                   = true           # Permit particles to live outside the EB to avoid bad gradients near EB
-ItoKMCGodunovStepper.smooth_conductivity                   = false          # Use bilinear smoothing on the conductivity.
-ItoKMCGodunovStepper.filter_num                            = 0              # Number of filterings for the space-density
-ItoKMCGodunovStepper.filter_max_stride                     = 1              # Maximum stride for filter
-ItoKMCGodunovStepper.filter_alpha                          = 0.5            # Filtering factor (0.5 is a bilinear filter)
-ItoKMCGodunovStepper.eb_tolerance                          = 0.0            # EB intersection test tolerance
-ItoKMCGodunovStepper.algorithm                             = euler_maruyama # Integration algorithm. 'euler_maruyama' or 'trapezoidal'
+ ====================================================================================================
+ ItoKMCGodunovStepper class options
+ ====================================================================================================
+ItoKMCGodunovStepper.checkpoint_particles                  = true                 ## If true, regrid on restart is supported (otherwise it's not)
+ItoKMCGodunovStepper.verbosity                             = -1                   ## Verbosity
+ItoKMCGodunovStepper.secondary_emission                    = after_reactions      ## When to emit secondary particles. Either 'before_reactions' or 'after_reactions'
+ItoKMCGodunovStepper.abort_on_failure                      = true                 ## Abort on Poisson solver failure or not
+ItoKMCGodunovStepper.redistribute_cdr                      = true                 ## Turn on/off reactive redistribution
+ItoKMCGodunovStepper.profile                               = false                ## Turn on/off run-time profiling
+ItoKMCGodunovStepper.plt_vars                              = current_density      ## 'conductivity', 'current_density', 'particles_per_patch'
+ItoKMCGodunovStepper.dual_grid                             = true                 ## Turn on/off dual-grid functionality
+ItoKMCGodunovStepper.load_balance_fluid                    = false                ## Turn on/off fluid realm load balancing.
+ItoKMCGodunovStepper.load_balance_particles                = true                 ## Turn on/off particle load balancing
+ItoKMCGodunovStepper.load_indices                          = -1                   ## Which particle containers to use for load balancing (-1 => all)
+ItoKMCGodunovStepper.load_per_cell                         = 1.0                  ## Default load per grid cell.
+ItoKMCGodunovStepper.box_sorting                           = morton               ## Box sorting when load balancing
+ItoKMCGodunovStepper.particles_per_cell                    = 64                   ## Max computational particles per cell
+ItoKMCGodunovStepper.merge_interval                        = 1                    ## Time steps between superparticle merging
+ItoKMCGodunovStepper.regrid_superparticles                 = false                ## Make superparticles during regrids
+ItoKMCGodunovStepper.min_particle_advection_cfl            = 0.0                  ## Advective time step CFL restriction
+ItoKMCGodunovStepper.max_particle_advection_cfl            = 1.0                  ## Advective time step CFL restriction
+ItoKMCGodunovStepper.min_particle_diffusion_cfl            = 0.0                  ## Diffusive time step CFL restriction
+ItoKMCGodunovStepper.max_particle_diffusion_cfl            = 1.E99                ## Diffusive time step CFL restriction
+ItoKMCGodunovStepper.min_particle_advection_diffusion_cfl  = 0.0                  ## Advection-diffusion time step CFL restriction
+ItoKMCGodunovStepper.max_particle_advection_diffusion_cfl  = 1.E99                ## Advection-diffusion time step CFL restriction
+ItoKMCGodunovStepper.fluid_advection_diffusion_cfl         = 0.5                  ## Advection-diffusion time step CFL restriction
+ItoKMCGodunovStepper.relax_dt_factor                       = 100.0                ## Relaxation time step restriction.
+ItoKMCGodunovStepper.min_dt                                = 0.0                  ## Minimum permitted time step
+ItoKMCGodunovStepper.max_dt                                = 1.E99                ## Maximum permitted time step
+ItoKMCGodunovStepper.max_growth_dt                         = 1.E99                ## Maximum permitted time step increase (dt * factor)
+ItoKMCGodunovStepper.max_shrink_dt                         = 1.E99                ## Maximum permissible time step reduction (dt/factor)
+ItoKMCGodunovStepper.extend_conductivity                   = true                 ## Permit particles to live outside the EB to avoid bad gradients near EB
+ItoKMCGodunovStepper.smooth_conductivity                   = false                ## Use bilinear smoothing on the conductivity.
+ItoKMCGodunovStepper.filter_num                            = 0                    ## Number of filterings for the space-density
+ItoKMCGodunovStepper.filter_max_stride                     = 1                    ## Maximum stride for filter
+ItoKMCGodunovStepper.filter_alpha                          = 0.5                  ## Filtering factor (0.5 is a bilinear filter)
+ItoKMCGodunovStepper.eb_tolerance                          = 0.0                  ## EB intersection test tolerance
+ItoKMCGodunovStepper.algorithm                             = euler_maruyama       ## Integration algorithm. 'euler_maruyama' or 'trapezoidal'

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
@@ -138,6 +138,7 @@ ItoKMCGodunovStepper<I, C, R, F>::parseOptions() noexcept
   this->parseAlgorithm();
   this->parseFiltering();
   this->parseCheckpointParticles();
+  this->parseSecondaryEmissionSpecification();
 }
 
 template <typename I, typename C, typename R, typename F>
@@ -154,6 +155,7 @@ ItoKMCGodunovStepper<I, C, R, F>::parseRuntimeOptions() noexcept
   this->parseAlgorithm();
   this->parseFiltering();
   this->parseCheckpointParticles();
+  this->parseSecondaryEmissionSpecification();
 }
 
 template <typename I, typename C, typename R, typename F>
@@ -218,6 +220,37 @@ ItoKMCGodunovStepper<I, C, R, F>::parseCheckpointParticles() noexcept
   ParmParse pp(this->m_name.c_str());
 
   pp.query("checkpoint_particles", m_writeCheckpointParticles);
+}
+
+template <typename I, typename C, typename R, typename F>
+void
+ItoKMCGodunovStepper<I, C, R, F>::parseSecondaryEmissionSpecification() noexcept
+{
+  CH_TIME("ItoKMCGodunovStepper::parseSecondaryEmissionSpecifiation");
+  if (this->m_verbosity > 5) {
+    pout() << this->m_name + "::parseSecondaryEmissionSpecification" << endl;
+  }
+
+  ParmParse pp(this->m_name.c_str());
+
+  std::string str;
+
+  pp.query("secondary_emission", str);
+
+  if (str == "before_reactions") {
+    m_emitSecondaryParticlesBeforeReactions = true;
+  }
+  else if (str == "after_reactions") {
+    m_emitSecondaryParticlesBeforeReactions = false;
+  }
+  else {
+    std::string err;
+
+    err = "ItoKMCGodunovStepper::parseSecondaryEmissionSpecification - expected 'before_reactions' or 'after_reactions'";
+    err += "but got" + str;
+
+    MayDay::Abort(err.c_str());
+  }
 }
 
 template <typename I, typename C, typename R, typename F>
@@ -390,6 +423,16 @@ ItoKMCGodunovStepper<I, C, R, F>::advance(const Real a_dt)
     m_timer.stopEvent("Gradient calculation");
   }
 
+  // Resolve secondary emission. We have filled the relevant particles in the transport step -- this can be done
+  // either before or after the reactions.
+  if (m_emitSecondaryParticlesBeforeReactions) {
+    this->barrier();
+    m_timer.startEvent("EB particle injection");
+    this->fillSecondaryEmissionEB(a_dt);
+    this->resolveSecondaryEmissionEB(a_dt);
+    m_timer.stopEvent("EB particle injection");
+  }
+
   // Sort the particles and photons per cell so we can call reaction algorithms
   this->barrier();
   m_timer.startEvent("Sort by cell");
@@ -412,13 +455,15 @@ ItoKMCGodunovStepper<I, C, R, F>::advance(const Real a_dt)
   this->sortPhotonsByPatch(McPhoto::WhichContainer::Source);
   m_timer.stopEvent("Sort by patch");
 
-  // Resolve secondary emission. We have filled the relevant particles in the transport step. This is done
-  // AFTER the reaction step to improve stability behavior in cathode sheaths.
-  this->barrier();
-  m_timer.startEvent("EB particle injection");
-  this->fillSecondaryEmissionEB(a_dt);
-  this->resolveSecondaryEmissionEB(a_dt);
-  m_timer.stopEvent("EB particle injection");
+  // Resolve secondary emission. We have filled the relevant particles in the transport step -- this can be done
+  // either before or after the reactions.
+  if (!m_emitSecondaryParticlesBeforeReactions) {
+    this->barrier();
+    m_timer.startEvent("EB particle injection");
+    this->fillSecondaryEmissionEB(a_dt);
+    this->resolveSecondaryEmissionEB(a_dt);
+    m_timer.stopEvent("EB particle injection");
+  }
 
   // Remove particles that are inside the EB -- this is not a part of the algorithm, just a safety measure to make sure
   // we don't do things with particles that lie inside the EB.


### PR DESCRIPTION
# Summary

This PR adds a user-specified secondary emission step in the Ito-KMC algorithm. The secondary emitted particles can now be injected either before or after the reactions.

Closes #497 

### Background

The Ito-KMC algorithm uses a split step method where the transport step is performed first, which is followed by a radiative transfer step. In these two steps we compute the particle/photon intersection with a boundary and store all particles that left the domain. After the transport steps we called the reaction algorithm, and we emitted the secondary particles after the reaction step. While this can improve stability, it also means that for large time steps the secondary particles dont react properly in e.g. cathode sheaths. This PR adds another hook where the secondary emitted particles can be added before the reactive step, permitting the secondary particles to react within the same time step.

### Solution

Simple if-loop that checks when to inject the particles. A new option flag has been added to ItoKMCGodunovStepper, which is called 'ItoKMCGodunovStepper.seconadry_emission'. Valid input options are 'after_reactions' and 'before_reactions'.

### Side-effects

Because this PR adds another option, all input files must be updated to include the new flag (ItoKMCGodunov

### Alternative solutions 

We could perform even more advanced methods where the secondary particles are additionally transported within the same time step (at the cost of significantly increased code complexities).

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
