### PR TITLE
Update Ito-KMC step report

### DIFF
--- a/Physics/ItoKMC/CD_ItoKMCPhysics.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysics.H
@@ -109,6 +109,14 @@ namespace Physics {
       computeDt(const RealVect a_E, const RealVect a_pos, const Vector<FPR> a_numParticles) const noexcept;
 
       /*!
+	@brief Get the neutral density at a position in space
+	@param[in] a_pos Physical position
+	@return Neutral density
+      */
+      virtual Real
+      getNeutralDensity(const RealVect a_pos) const noexcept = 0;
+
+      /*!
 	@brief Compute Townsend ionization coefficient
 	@param[in] a_E Electric field magnitude
 	@param[in] a_x Physical coordinate

--- a/Physics/ItoKMC/CD_ItoKMCStepper.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepper.H
@@ -655,6 +655,11 @@ namespace Physics {
       EBAMRCellData m_physicsPlotVariables;
 
       /*!
+	@brief Storage for the neutral density.
+      */
+      EBAMRCellData m_neutralDensity;
+
+      /*!
 	@brief Cell-centered conductivity.
 	@note Defined on the fluid realm with 1 component
       */
@@ -932,30 +937,30 @@ namespace Physics {
                                      const int             a_level) const noexcept;
 
       /*!
-	@brief Get maximum density of the Ito species
+	@brief Get maximum density of the Ito species (only for charged species)
 	@param[inout] a_maxDensity Maximum mesh density
 	@param[inout] a_minDensity Minium mesh density
 	@param[inout] a_maxSolver  Solver with highest density
 	@param[inout] a_minSolver  Solver with lowest density
       */
       virtual void
-      getMaxMinItoDensity(Real&        a_maxDensity,
-                          Real&        a_minDensity,
-                          std::string& a_maxSolver,
-                          std::string& a_minSolver) const noexcept;
+      getMaxMinRelativeItoDensity(Real&        a_maxDensity,
+                                  Real&        a_minDensity,
+                                  std::string& a_maxSolver,
+                                  std::string& a_minSolver) const noexcept;
 
       /*!
-	@brief Get maximum density of the CDr species
+	@brief Get maximum density of the CDR species (only for charged species)
 	@param[inout] a_maxDensity Maximum mesh density
 	@param[inout] a_minDensity Minium mesh density
 	@param[inout] a_maxSolver  Solver with highest density
 	@param[inout] a_minSolver  Solver with lowest density
       */
       virtual void
-      getMaxMinCDRDensity(Real&        a_maxDensity,
-                          Real&        a_minDensity,
-                          std::string& a_maxSolver,
-                          std::string& a_minSolver) const noexcept;
+      getMaxMinRelativeCDRDensity(Real&        a_maxDensity,
+                                  Real&        a_minDensity,
+                                  std::string& a_maxSolver,
+                                  std::string& a_minSolver) const noexcept;
 
       /*!
 	@brief Compute some particle statistics
@@ -1016,11 +1021,18 @@ namespace Physics {
       getLoadBalanceSolvers() const noexcept;
 
       /*!
+	@brief Compute the neutral density on the mesh.
+	@details This will populate m_neutralDensity with a density given by the physics interface
+      */
+      virtual void
+      fillNeutralDensity() noexcept;
+
+      /*!
 	@brief Compute the maximum electric field (norm)
 	@param[in] a_phase Phase where we compute the field. 
       */
       virtual Real
-      computeMaxElectricField(const phase::which_phase a_phase) const noexcept;
+      computeMaxReducedElectricField(const phase::which_phase a_phase) const noexcept;
 
       /*!
 	@brief Compute the space charge. Calls the other version. 

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -1766,6 +1766,7 @@ ItoKMCStepper<I, C, R, F>::fillNeutralDensity() noexcept
     const int nbox = dit.size();
 
     CH_assert(!(m_neutralDensity[lvl].isNull()));
+    CH_assert(m_neutralDensity[lvl]->nComp() == 1);
 
 #pragma omp parallel for schedule(runtime)
     for (int mybox = 0; mybox < nbox; mybox++) {
@@ -1775,8 +1776,6 @@ ItoKMCStepper<I, C, R, F>::fillNeutralDensity() noexcept
 
       EBCellFAB& neutralDensity    = (*m_neutralDensity[lvl])[din];
       FArrayBox& neutralDensityReg = neutralDensity.getFArrayBox();
-
-      CH_assert(neutralDensity.nComp() == 1);
 
       auto regularKernel = [&](const IntVect& iv) -> void {
         const RealVect pos = probLo + (0.5 * RealVect::Unit + iv) * dx;
@@ -1815,7 +1814,7 @@ ItoKMCStepper<I, C, R, F>::computeMaxReducedElectricField(const phase::which_pha
 
   // Interpolate to centroids
   EBAMRCellData tmp;
-  m_amr->allocate(tmp, m_fluidRealm, a_phase, SpaceDim);
+  m_amr->allocate(tmp, m_fluidRealm, a_phase, 1);
 
   DataOps::vectorLength(tmp, cellCenteredE);
   m_amr->interpToCentroids(tmp, m_fluidRealm, m_plasmaPhase);
@@ -1825,7 +1824,7 @@ ItoKMCStepper<I, C, R, F>::computeMaxReducedElectricField(const phase::which_pha
   Real max = 0.0;
   Real min = 0.0;
 
-  DataOps::getMaxMinNorm(max, min, tmp);
+  DataOps::getMaxMin(max, min, tmp, 0);
 
   return max * 1E21;
 }

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -1292,29 +1292,33 @@ ItoKMCStepper<I, C, R, F>::getMaxMinRelativeItoDensity(Real&        a_maxDensity
 
   // Go through each solver and find the max/min values.
   for (auto solverIt = m_ito->iterator(); solverIt.ok(); ++solverIt) {
-    const RefCountedPtr<ItoSolver>& solver = solverIt();
+    const RefCountedPtr<ItoSolver>&  solver  = solverIt();
+    const RefCountedPtr<ItoSpecies>& species = solver->getSpecies();
+    const int                        Z       = species->getChargeNumber();
 
-    Real curMin = std::numeric_limits<Real>::max();
-    Real curMax = -std::numeric_limits<Real>::max();
+    if (Z != 0) {
+      Real curMin = std::numeric_limits<Real>::max();
+      Real curMax = -std::numeric_limits<Real>::max();
 
-    // Ito solvers might be defined on a separate realm, so we have to copy the data over
-    // before dividing by the neutral density
-    const Interval dstInterv = Interval(0, 0);
-    const Interval srcInterv = Interval(0, 0);
+      // Ito solvers might be defined on a separate realm, so we have to copy the data over
+      // before dividing by the neutral density
+      const Interval dstInterv = Interval(0, 0);
+      const Interval srcInterv = Interval(0, 0);
 
-    m_amr->copyData(tmp, solverIt()->getPhi(), dstInterv, srcInterv);
+      m_amr->copyData(tmp, solverIt()->getPhi(), dstInterv, srcInterv);
 
-    DataOps::divideFallback(tmp, m_neutralDensity, 0.0);
-    DataOps::getMaxMin(curMax, curMin, tmp, 0);
+      DataOps::divideFallback(tmp, m_neutralDensity, 0.0);
+      DataOps::getMaxMin(curMax, curMin, tmp, 0);
 
-    if (curMax > a_maxDensity) {
-      a_maxDensity = curMax;
-      a_maxSolver  = solver->getName();
-    }
+      if (curMax > a_maxDensity) {
+        a_maxDensity = curMax;
+        a_maxSolver  = solver->getName();
+      }
 
-    if (curMin < a_minDensity) {
-      a_minDensity = curMin;
-      a_minSolver  = solver->getName();
+      if (curMin < a_minDensity) {
+        a_minDensity = curMin;
+        a_minSolver  = solver->getName();
+      }
     }
   }
 }
@@ -1336,28 +1340,32 @@ ItoKMCStepper<I, C, R, F>::getMaxMinRelativeCDRDensity(Real&        a_maxDensity
 
   // Go through each solver and find the max/min values.
   for (auto solverIt = m_cdr->iterator(); solverIt.ok(); ++solverIt) {
-    const RefCountedPtr<CdrSolver>& solver = solverIt();
+    const RefCountedPtr<CdrSolver>&  solver  = solverIt();
+    const RefCountedPtr<CdrSpecies>& species = solver->getSpecies();
+    const int                        Z       = species->getChargeNumber();
 
-    Real curMin = std::numeric_limits<Real>::max();
-    Real curMax = -std::numeric_limits<Real>::max();
+    if (Z != 0) {
+      Real curMin = std::numeric_limits<Real>::max();
+      Real curMax = -std::numeric_limits<Real>::max();      
 
-    // Copy the data over to a temporary holder before dividing by the neutral density
-    const Interval dstInterv = Interval(0, 0);
-    const Interval srcInterv = Interval(0, 0);
+      // Copy the data over to a temporary holder before dividing by the neutral density
+      const Interval dstInterv = Interval(0, 0);
+      const Interval srcInterv = Interval(0, 0);
 
-    m_amr->copyData(tmp, solverIt()->getPhi(), dstInterv, srcInterv);
+      m_amr->copyData(tmp, solverIt()->getPhi(), dstInterv, srcInterv);
 
-    DataOps::divideFallback(tmp, m_neutralDensity, 0.0);
-    DataOps::getMaxMin(curMax, curMin, tmp, 0);
+      DataOps::divideFallback(tmp, m_neutralDensity, 0.0);
+      DataOps::getMaxMin(curMax, curMin, tmp, 0);
 
-    if (curMax > a_maxDensity) {
-      a_maxDensity = curMax;
-      a_maxSolver  = solver->getName();
-    }
+      if (curMax > a_maxDensity) {
+        a_maxDensity = curMax;
+        a_maxSolver  = solver->getName();
+      }
 
-    if (curMin < a_minDensity) {
-      a_minDensity = curMin;
-      a_minSolver  = solver->getName();
+      if (curMin < a_minDensity) {
+        a_minDensity = curMin;
+        a_minSolver  = solver->getName();
+      }
     }
   }
 }

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -1346,7 +1346,7 @@ ItoKMCStepper<I, C, R, F>::getMaxMinRelativeCDRDensity(Real&        a_maxDensity
 
     if (Z != 0) {
       Real curMin = std::numeric_limits<Real>::max();
-      Real curMax = -std::numeric_limits<Real>::max();      
+      Real curMax = -std::numeric_limits<Real>::max();
 
       // Copy the data over to a temporary holder before dividing by the neutral density
       const Interval dstInterv = Interval(0, 0);

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -544,7 +544,10 @@ ItoKMCStepper<I, C, R, F>::allocateInternals() noexcept
   m_amr->allocate(m_particleScratchD, m_particleRealm, m_plasmaPhase, SpaceDim);
   m_amr->allocate(m_particleScratchEB, m_particleRealm, m_plasmaPhase, 1);
 
-  // Storage for conductiviies on cell, cell faces, and EB faces.
+  // Storage for neutral density
+  m_amr->allocate(m_neutralDensity, m_fluidRealm, m_plasmaPhase, 1);
+
+  // Storage for conductivities on cell, cell faces, and EB faces.
   m_amr->allocate(m_conductivityCell, m_fluidRealm, m_plasmaPhase, 1);
   m_amr->allocate(m_conductivityFace, m_fluidRealm, m_plasmaPhase, 1);
   m_amr->allocate(m_conductivityEB, m_fluidRealm, m_plasmaPhase, 1);
@@ -672,6 +675,9 @@ ItoKMCStepper<I, C, R, F>::initialData() noexcept
   // Fill solvers with velocities and diffusion coefficients
   this->computeDriftVelocities();
   this->computeDiffusionCoefficients();
+
+  // Fill the internal neutral density
+  this->fillNeutralDensity();
 }
 
 template <typename I, typename C, typename R, typename F>
@@ -1158,7 +1164,7 @@ ItoKMCStepper<I, C, R, F>::printStepReport() noexcept
     pout() << m_name + "::printStepReport" << endl;
   }
 
-  const Real Emax = this->computeMaxElectricField(m_plasmaPhase);
+  const Real Emax = this->computeMaxReducedElectricField(m_plasmaPhase);
 
   const unsigned long long localParticlesBulk    = m_ito->getNumParticles(ItoSolver::WhichContainer::Bulk, true);
   const unsigned long long globalParticlesBulk   = m_ito->getNumParticles(ItoSolver::WhichContainer::Bulk, false);
@@ -1186,8 +1192,8 @@ ItoKMCStepper<I, C, R, F>::printStepReport() noexcept
   std::string maxSolver = "invalid solver";
   std::string minSolver = "invalid solver";
 
-  this->getMaxMinItoDensity(maxDensity, minDensity, maxSolver, minSolver);
-  this->getMaxMinCDRDensity(maxDensity, minDensity, maxSolver, minSolver);
+  this->getMaxMinRelativeItoDensity(maxDensity, minDensity, maxSolver, minSolver);
+  this->getMaxMinRelativeCDRDensity(maxDensity, minDensity, maxSolver, minSolver);
 
   std::string str;
   switch (m_timeCode) {
@@ -1244,8 +1250,8 @@ ItoKMCStepper<I, C, R, F>::printStepReport() noexcept
   //clang-format off
   const std::string whitespace = "                                   ";
   pout() << "                                   " + str << endl;
-  pout() << whitespace + "Emax        = " << Emax << endl
-         << whitespace + "Max density = " << maxDensity << " (" << maxSolver << ")" << endl
+  pout() << whitespace + "Emax        = " << Emax << " (Td)" << endl
+         << whitespace + "Max n/N     = " << maxDensity << " (" << maxSolver << ")" << endl
          << whitespace + "Qplus       = " << Qplus << endl
          << whitespace + "Qminu       = " << Qminu << endl
          << whitespace + "Qsurf       = " << Qsurf << endl
@@ -1270,15 +1276,19 @@ ItoKMCStepper<I, C, R, F>::printStepReport() noexcept
 
 template <typename I, typename C, typename R, typename F>
 void
-ItoKMCStepper<I, C, R, F>::getMaxMinItoDensity(Real&        a_maxDensity,
-                                               Real&        a_minDensity,
-                                               std::string& a_maxSolver,
-                                               std::string& a_minSolver) const noexcept
+ItoKMCStepper<I, C, R, F>::getMaxMinRelativeItoDensity(Real&        a_maxDensity,
+                                                       Real&        a_minDensity,
+                                                       std::string& a_maxSolver,
+                                                       std::string& a_minSolver) const noexcept
 {
   CH_TIME("ItoKMCStepper::getMaxMinDensity(Realx2, std::string2x)");
   if (m_verbosity > 5) {
     pout() << m_name + "::getMaxMinDensity(Realx2, std::string2x)" << endl;
   }
+
+  // Allocate some temporary storage.
+  EBAMRCellData tmp;
+  m_amr->allocate(tmp, m_fluidRealm, m_plasmaPhase, 1);
 
   // Go through each solver and find the max/min values.
   for (auto solverIt = m_ito->iterator(); solverIt.ok(); ++solverIt) {
@@ -1287,7 +1297,15 @@ ItoKMCStepper<I, C, R, F>::getMaxMinItoDensity(Real&        a_maxDensity,
     Real curMin = std::numeric_limits<Real>::max();
     Real curMax = -std::numeric_limits<Real>::max();
 
-    DataOps::getMaxMin(curMax, curMin, solverIt()->getPhi(), 0);
+    // Ito solvers might be defined on a separate realm, so we have to copy the data over
+    // before dividing by the neutral density
+    const Interval dstInterv = Interval(0, 0);
+    const Interval srcInterv = Interval(0, 0);
+
+    m_amr->copyData(tmp, solverIt()->getPhi(), dstInterv, srcInterv);
+
+    DataOps::divideFallback(tmp, m_neutralDensity, 0.0);
+    DataOps::getMaxMin(curMax, curMin, tmp, 0);
 
     if (curMax > a_maxDensity) {
       a_maxDensity = curMax;
@@ -1303,15 +1321,18 @@ ItoKMCStepper<I, C, R, F>::getMaxMinItoDensity(Real&        a_maxDensity,
 
 template <typename I, typename C, typename R, typename F>
 void
-ItoKMCStepper<I, C, R, F>::getMaxMinCDRDensity(Real&        a_maxDensity,
-                                               Real&        a_minDensity,
-                                               std::string& a_maxSolver,
-                                               std::string& a_minSolver) const noexcept
+ItoKMCStepper<I, C, R, F>::getMaxMinRelativeCDRDensity(Real&        a_maxDensity,
+                                                       Real&        a_minDensity,
+                                                       std::string& a_maxSolver,
+                                                       std::string& a_minSolver) const noexcept
 {
-  CH_TIME("ItoKMCStepper::getMaxMinCDRDensity(Realx2, std::string2x)");
+  CH_TIME("ItoKMCStepper::getMaxMinRelativeCDRDensity(Realx2, std::string2x)");
   if (m_verbosity > 5) {
-    pout() << m_name + "::getMaxMinCDRDensity(Realx2, std::string2x)" << endl;
+    pout() << m_name + "::getMaxMinRelativeCDRDensity(Realx2, std::string2x)" << endl;
   }
+
+  EBAMRCellData tmp;
+  m_amr->allocate(tmp, m_fluidRealm, m_plasmaPhase, 1);
 
   // Go through each solver and find the max/min values.
   for (auto solverIt = m_cdr->iterator(); solverIt.ok(); ++solverIt) {
@@ -1320,7 +1341,14 @@ ItoKMCStepper<I, C, R, F>::getMaxMinCDRDensity(Real&        a_maxDensity,
     Real curMin = std::numeric_limits<Real>::max();
     Real curMax = -std::numeric_limits<Real>::max();
 
-    DataOps::getMaxMin(curMax, curMin, solverIt()->getPhi(), 0);
+    // Copy the data over to a temporary holder before dividing by the neutral density
+    const Interval dstInterv = Interval(0, 0);
+    const Interval srcInterv = Interval(0, 0);
+
+    m_amr->copyData(tmp, solverIt()->getPhi(), dstInterv, srcInterv);
+
+    DataOps::divideFallback(tmp, m_neutralDensity, 0.0);
+    DataOps::getMaxMin(curMax, curMin, tmp, 0);
 
     if (curMax > a_maxDensity) {
       a_maxDensity = curMax;
@@ -1680,6 +1708,8 @@ ItoKMCStepper<I, C, R, F>::regrid(const int a_lmin, const int a_oldFinestLevel, 
 
   this->computeDriftVelocities();
   this->computeDiffusionCoefficients();
+
+  this->fillNeutralDensity();
 }
 
 template <typename I, typename C, typename R, typename F>
@@ -1708,31 +1738,88 @@ ItoKMCStepper<I, C, R, F>::setVoltage(const std::function<Real(const Real a_time
 }
 
 template <typename I, typename C, typename R, typename F>
-Real
-ItoKMCStepper<I, C, R, F>::computeMaxElectricField(const phase::which_phase a_phase) const noexcept
+void
+ItoKMCStepper<I, C, R, F>::fillNeutralDensity() noexcept
 {
-  CH_TIME("ItoKMCStepper::computeMaxElectricField");
+  CH_TIME("ItoKMCStepper::fillNeutralDensity");
   if (m_verbosity > 5) {
-    pout() << m_name + "::computeMaxElectricField" << endl;
+    pout() << m_name + "::fillNeutralDensity" << endl;
+  }
+
+  DataOps::setValue(m_neutralDensity, 0.0);
+
+  for (int lvl = 0; lvl <= m_amr->getFinestLevel(); lvl++) {
+    const DisjointBoxLayout& dbl    = m_amr->getGrids(m_fluidRealm)[lvl];
+    const EBISLayout&        ebisl  = m_amr->getEBISLayout(m_fluidRealm, m_plasmaPhase)[lvl];
+    const DataIterator&      dit    = dbl.dataIterator();
+    const Real               dx     = m_amr->getDx()[lvl];
+    const RealVect           probLo = m_amr->getProbLo();
+
+    const int nbox = dit.size();
+
+    CH_assert(!(m_neutralDensity[lvl].isNull()));
+
+#pragma omp parallel for schedule(runtime)
+    for (int mybox = 0; mybox < nbox; mybox++) {
+      const DataIndex& din     = dit[mybox];
+      const Box        cellBox = dbl[din];
+      const EBISBox&   ebisbox = ebisl[din];
+
+      EBCellFAB& neutralDensity    = (*m_neutralDensity[lvl])[din];
+      FArrayBox& neutralDensityReg = neutralDensity.getFArrayBox();
+
+      CH_assert(neutralDensity.nComp() == 1);
+
+      auto regularKernel = [&](const IntVect& iv) -> void {
+        const RealVect pos = probLo + (0.5 * RealVect::Unit + iv) * dx;
+
+        neutralDensityReg(iv, 0) = m_physics->getNeutralDensity(pos);
+      };
+
+      auto irregularKernel = [&](const VolIndex& vof) -> void {
+        const RealVect pos = probLo + Location::position(Location::Cell::Centroid, vof, ebisbox, dx);
+
+        neutralDensity(vof, 0) = m_physics->getNeutralDensity(pos);
+      };
+
+      VoFIterator& vofit = (*m_amr->getVofIterator(m_fluidRealm, m_plasmaPhase)[lvl])[din];
+
+      BoxLoops::loop(cellBox, regularKernel);
+      BoxLoops::loop(vofit, irregularKernel);
+    }
+  }
+
+  m_amr->conservativeAverage(m_neutralDensity, m_fluidRealm, m_plasmaPhase);
+  m_amr->interpGhostPwl(m_neutralDensity, m_fluidRealm, m_plasmaPhase);
+}
+
+template <typename I, typename C, typename R, typename F>
+Real
+ItoKMCStepper<I, C, R, F>::computeMaxReducedElectricField(const phase::which_phase a_phase) const noexcept
+{
+  CH_TIME("ItoKMCStepper::computeMaxReducedElectricField");
+  if (m_verbosity > 5) {
+    pout() << m_name + "::computeMaxReducedElectricField" << endl;
   }
 
   // Get a handle to the E-field. Note that this is the cell-centered field!
   const EBAMRCellData cellCenteredE = m_amr->alias(a_phase, m_fieldSolver->getElectricField());
 
   // Interpolate to centroids
-  EBAMRCellData centroidCenteredE;
-  m_amr->allocate(centroidCenteredE, m_fluidRealm, a_phase, SpaceDim);
+  EBAMRCellData tmp;
+  m_amr->allocate(tmp, m_fluidRealm, a_phase, SpaceDim);
 
-  DataOps::copy(centroidCenteredE, cellCenteredE);
+  DataOps::vectorLength(tmp, cellCenteredE);
+  m_amr->interpToCentroids(tmp, m_fluidRealm, m_plasmaPhase);
 
-  m_amr->interpToCentroids(centroidCenteredE, m_fluidRealm, m_plasmaPhase);
+  DataOps::divideFallback(tmp, m_neutralDensity, 0.0);
 
   Real max = 0.0;
   Real min = 0.0;
 
-  DataOps::getMaxMinNorm(max, min, centroidCenteredE);
+  DataOps::getMaxMinNorm(max, min, tmp);
 
-  return max;
+  return max * 1E21;
 }
 
 template <typename I, typename C, typename R, typename F>

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.H
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.H
@@ -114,6 +114,14 @@ namespace Physics {
       computeDt(const RealVect a_E, const RealVect a_pos, const Vector<Real> a_densities) const noexcept override;
 
       /*!
+	@brief Get the neutral density at a position in space
+	@param[in] a_pos Physical position
+	@return Neutral density
+      */
+      virtual Real
+      getNeutralDensity(const RealVect a_pos) const noexcept override;
+
+      /*!
 	@brief Compute Townsend ionization coefficient
 	@param[in] a_E   Electric field. 
 	@param[in] a_pos Physical coordinates

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -613,6 +613,7 @@ ItoKMCJSON::initializePlasmaSpecies()
     m_allSpecies.emplace(speciesID);
 
     if (m_verbose) {
+      // clang-format off
       pout() << "ItoKMCJSON::initializePlasmaSpecies, instantiating species:" << "\n"
              << "\tName             = " << speciesID << "\n"
              << "\tZ                = " << Z << "\n"
@@ -620,6 +621,7 @@ ItoKMCJSON::initializePlasmaSpecies()
              << "\tDiffusive        = " << diffusive << "\n"
              << "\tSolver type      = " << solver << "\n"
              << "\n";
+      // clang-format on
     }
   }
 

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -2920,6 +2920,16 @@ ItoKMCJSON::computeDt(const RealVect a_E, const RealVect a_pos, const Vector<Rea
 }
 
 Real
+ItoKMCJSON::getNeutralDensity(const RealVect a_pos) const noexcept {
+  CH_TIME("ItoKMCJSON::getNeutralDensity");
+  if (m_verbose) {
+    pout() << m_className + "::getNeutralDensity" << endl;
+  }
+
+  return m_gasNumberDensity(a_pos);
+}
+
+Real
 ItoKMCJSON::computeAlpha(const Real a_E, const RealVect a_pos) const noexcept
 {
   CH_TIME("ItoKMCJSON::computeAlpha");

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -613,8 +613,7 @@ ItoKMCJSON::initializePlasmaSpecies()
     m_allSpecies.emplace(speciesID);
 
     if (m_verbose) {
-      pout() << "ItoKMCJSON::initializePlasmaSpecies, instantiating species:"
-             << "\n"
+      pout() << "ItoKMCJSON::initializePlasmaSpecies, instantiating species:" << "\n"
              << "\tName             = " << speciesID << "\n"
              << "\tZ                = " << Z << "\n"
              << "\tMobile           = " << mobile << "\n"
@@ -2920,7 +2919,8 @@ ItoKMCJSON::computeDt(const RealVect a_E, const RealVect a_pos, const Vector<Rea
 }
 
 Real
-ItoKMCJSON::getNeutralDensity(const RealVect a_pos) const noexcept {
+ItoKMCJSON::getNeutralDensity(const RealVect a_pos) const noexcept
+{
   CH_TIME("ItoKMCJSON::getNeutralDensity");
   if (m_verbose) {
     pout() << m_className + "::getNeutralDensity" << endl;

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
@@ -675,6 +675,9 @@ ItoKMCGodunovStepper<I, C, R, F>::regrid(const int a_lmin,
 
   // No reason to have this lying around.
   this->m_amr->deallocate(m_scratchSemiImplicitRhoCDR);
+
+  // Fill the neutral density on the mesh
+  this->fillNeutralDensity();
 }
 
 template <typename I, typename C, typename R, typename F>


### PR DESCRIPTION
# Summary

This PR updates the step-reports for the Ito-KMC module to used reduced electric fields and densities.

Closes #498 

### Background

The ItoKMC step report would print max fields/densities in SI units. Most users will have a different pressure range in mind, so we're changing this print the field in Townsend and the densities in terms of the ionization degree.

### Solution

Store the neutral density on the mesh and divide appropriately when printing the step report. 

### Side-effects

### Alternative solutions 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
