### PR TITLE
Time step restriction bug fix

### DIFF
--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -1443,6 +1443,10 @@ ItoKMCStepper<I, C, R, F>::computeDt()
   m_relaxationTime = this->computeRelaxationTime();
   timer.stopEvent("Relaxation");
 
+  const bool hasParticleAdvectionDt          = m_particleAdvectionDt < std::numeric_limits<Real>::max();
+  const bool hasParticleDiffusionDt          = m_particleDiffusionDt < std::numeric_limits<Real>::max();
+  const bool hasParticleAdvectionDiffusionDt = m_particleAdvectionDiffusionDt < std::numeric_limits<Real>::max();
+
   if (m_maxParticleAdvectionCFL * m_particleAdvectionDt < dt) {
     dt         = m_maxParticleAdvectionCFL * m_particleAdvectionDt;
     m_timeCode = TimeCode::AdvectionIto;
@@ -1473,21 +1477,18 @@ ItoKMCStepper<I, C, R, F>::computeDt()
     m_timeCode = TimeCode::Physics;
   }
 
-  if (dt < m_minParticleAdvectionCFL * m_particleAdvectionDt) {
-    dt = m_minParticleAdvectionCFL * m_particleAdvectionDt;
-
+  if ((dt < m_minParticleAdvectionCFL * m_particleAdvectionDt) && hasParticleAdvectionDt) {
+    dt         = m_minParticleAdvectionCFL * m_particleAdvectionDt;
     m_timeCode = TimeCode::AdvectionIto;
   }
 
-  if (dt < m_minParticleDiffusionCFL * m_particleDiffusionDt) {
-    dt = m_minParticleDiffusionCFL * m_particleDiffusionDt;
-
+  if ((dt < m_minParticleDiffusionCFL * m_particleDiffusionDt) && hasParticleDiffusionDt) {
+    dt         = m_minParticleDiffusionCFL * m_particleDiffusionDt;
     m_timeCode = TimeCode::DiffusionIto;
   }
 
-  if (dt < m_minParticleAdvectionDiffusionCFL * m_particleAdvectionDiffusionDt) {
-    dt = m_minParticleAdvectionDiffusionCFL * m_particleAdvectionDiffusionDt;
-
+  if ((dt < m_minParticleAdvectionDiffusionCFL * m_particleAdvectionDiffusionDt) && hasParticleAdvectionDiffusionDt) {
+    dt         = m_minParticleAdvectionDiffusionCFL * m_particleAdvectionDiffusionDt;
     m_timeCode = TimeCode::AdvectionDiffusionIto;
   }
 


### PR DESCRIPTION
# Summary

Issue a fix for a time step restriction bug when there were no particle-based CFL time step restriction.

Closes #503 

### Background

ItoKMCStepper would not restrict by the fluid-based CFL when there were no particle species in the simulation. This simply had to do with an unfortunate limit when multiplying the CFL by a very large number, which triggered a hardcap restriction that facilitated the bug. 

### Solution

Guard against case when there are no particle-based time step restriction. 

### Side-effects

None.

### Alternative solutions 

None considered.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
