### PR TITLE
Bug fix for photoionization efficiency in reaction specifier

### DIFF
--- a/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
@@ -614,15 +614,20 @@ ItoKMCPhysics::reconcilePhotoionization(Vector<List<ItoParticle>*>&   a_itoParti
       const std::map<int, int>&       localToGlobalMap = m_photoPathways.at(i).second;
 
       for (ListIterator<Photon> lit(*a_absorbedPhotons[i]); lit.ok(); ++lit) {
-        const RealVect x = lit().position();
-        const Real     w = lit().weight();
+        const RealVect x            = lit().position();
+        const Real     photonWeight = lit().weight();
 
         // Determine the photo-reaction type.
         const int localReaction  = Random::get(d);
         const int globalReaction = localToGlobalMap.at(localReaction);
 
-        const ItoKMCPhotoReaction& photoReaction = m_photoReactions[globalReaction];
-        const std::list<size_t>&   plasmaTargets = photoReaction.getTargetSpecies();
+        const ItoKMCPhotoReaction& photoReaction      = m_photoReactions[globalReaction];
+        const std::list<size_t>&   plasmaTargets      = photoReaction.getTargetSpecies();
+        const Real&                reactionEfficiency = photoReaction.getEfficiency();
+
+        std::binomial_distribution<long long> d(static_cast<long long>(llround(photonWeight)), reactionEfficiency);
+
+        const Real numReactions = 1.0 * Random::get(d);
 
         for (const auto& t : plasmaTargets) {
           const SpeciesType& type       = m_speciesMap.at(t).first;


### PR DESCRIPTION
# Summary

Fix a bug where ItoKMCPhysics would not use the reaction efficiency when stochastically sampling ionizing reactions.

### Background

ItoKMCJSON would read in a reaction specifier from the JSON file, but when actually reconciling the photoionizing reactions the parent class (ItoKMCPhysics) never used this efficiency. 

### Solution

Added binomial sampling in ItoKMCPhysics where each absorbed photon is subjected to a binomial sampling using the input efficiency and the superphoton weight (which becomes the number of trials).

### Side-effects

There is no safeguard around the binomial sampling. For reaction efficiencies that are either 0 or  1 we could get rid of the sampling entirely.

### Alternative solutions 

Could potentially just use the mean value and/or the variance. 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
