### PR TITLE
Bug fix for ionization volume in DischargeInceptionStepper

### DIFF
--- a/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
+++ b/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
@@ -4762,7 +4762,7 @@ DischargeInceptionStepper<P, F, C>::computeIonizationVolumeTransient(const Real&
           const Real alpha = m_alpha(E, x);
           const Real eta   = m_eta(E, x);
           if (alpha >= eta) {
-            Vion = ebisbox.volFrac(vof) * vol;
+            Vion += ebisbox.volFrac(vof) * vol;
           }
         }
       };


### PR DESCRIPTION
# Summary

This PR fixes a bug where the ionization volume was incorrectly calculated in DischargeInceptionStepper for transient calculations.

Closes #513 

### Background

The ionization volume for the transient calculation in DischargeInceptionStepper was incorrectly calculated (note: this bug did not affect the critical volume). See issue #513.

### Solution

Properly increment rather than assign.

### Side-effects

None.

### Alternative solutions 

None.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
