### PR TITLE
Remove accidental preprocessor warning

### DIFF
--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -2755,8 +2755,6 @@ ItoKMCJSON::parsePlasmaReactionRate(const nlohmann::json&    a_reactionJSON,
     }
   }
 
-#warning "ItoKMCJSON -- need to inverse rate to turn fluid into particles! So, must be an above/below threshold"
-
   // This is the KMC rate -- note that it absorbs the background species.
   FunctionEVXP kmcRate = [fluidRate,
                           volumeFactor,


### PR DESCRIPTION
# Summary

Remove preprocessor warning.

### Background

The previous commit had a preprocessor warning that should have been removed prior to the pull request. 

### Solution

### Side-effects

### Alternative solutions 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [x] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
