### PR TITLE
Add field emission from electrodes and dielectrics in ItoKMC

### DIFF
--- a/Docs/Sphinx/source/Applications/ItoKMC.rst
+++ b/Docs/Sphinx/source/Applications/ItoKMC.rst
@@ -2010,14 +2010,76 @@ The above example can be compressed by using a wildcard and an ``efficiencies`` 
    "dielectric emission":
    [
       {
-         "reaction": "Y -> @",
+      "reaction": "Y -> @",
 	 "@": ["e", "(null)"],
 	 "efficiencies": [1,9]
       }
    ]
 
 where for the sake of demonstration the efficiencies are set to 1 and 9 (rather than 0.1 and 0.9).
-This has no effect on the probabilities :math:`p(i)` given above. 
+This has no effect on the probabilities :math:`p(i)` given above.
+
+Field emission
+--------------
+
+Field emission for a specified species is supported by including a ``field emission`` specifier.
+Currently supported expressions are:
+
+#. Fowler-Nordheim emission:
+
+   .. math::
+
+      J(E) &= \frac{a F^2}{\phi}\exp\left(-v(f) b \phi^{3/2} F\right),\\
+      F &= \left(\beta E\right)\times 10^9,\\
+      a &= 1.541434\times 10^{-6}\,\text{AeV}/\text{V}^2, \\
+      b &= 6.830890\,\text{eV}^{-3/2}\text{V}\text{nm}^{-1},\\
+      v(f) &= 1 - f + \left(1/6\right)f\log(f),\\
+      f &\approx 1.439964\,\text{eV}^2\text{V}^{-1}\text{nm}\times \frac{F}{\phi^2}.
+
+   Here, :math:`\phi` is the work function (in electron volts) and :math:`\beta` is an empirical factor that describes local field amplifications.
+      
+
+#. Schottky emission:
+
+   .. math::
+
+      J(E) &= \lambda A_0 T^2\exp\left(-\frac{\left(\phi-\Delta\phi\right)q_\text{e}}{k_{\text{B}}T}\right), \\
+      F &= \beta E, \\
+      A_0 &\approx 1.201736\times 10^6\,\text{A}\text{m}^{-2}\text{K}^{-2}, \\
+      \Delta \phi &= \sqrt{\frac{q_\text{e} F}{4\pi\epsilon_0}}.
+
+   Here, :math:`T` is the cathode temperature and :math:`\phi` is the work function (in electron volts).
+   The value :math:`\lambda` is typically around :math:`0.5`.
+   As for the Fowler-Nordheim equation, a factor that describes local field amplifications is given in :math:`\beta`. 
+
+.. warning::
+      
+   The expressions above both use a correction factor :math:`\beta` that describes local field amplifications.
+   Note, however, that the number of emitted electrons is proportional to the area of the emitter, and there are no current models in ``chombo-discharge`` that can compute this effective area.
+
+Below, we show an example that includes both Schottky and Fowler-Nordheim emission
+
+.. code-block:: json
+
+    "field emission":
+    [
+	{
+	    "species": "e",
+	    "surface": "electrode",
+	    "type": "fowler-nordheim",
+	    "work": 5.0,
+	    "beta": 1
+	},
+	{
+	    "species": "e",
+	    "surface": "electrode",
+	    "type": "schottky",
+	    "lambda": 0.5	    
+	    "temperature": 300,
+	    "work": 5.0,
+	    "beta": 1,
+	}
+    ]		
 
 
 .. _Chap:ItoKMCWarnings:

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.H
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.H
@@ -407,6 +407,16 @@ namespace Physics {
       std::pair<bool, std::string> m_autoEta;
 
       /*!
+	@brief List of dielectric field emission reactions.
+      */
+      std::vector<std::pair<int, FunctionEN>> m_dielectricFieldEmission;
+
+      /*!
+	@brief List of electrode field emission reactions.
+      */
+      std::vector<std::pair<int, FunctionEN>> m_electrodeFieldEmission;
+
+      /*!
 	@brief Townsend ionization coefficient. Defined during parseAlpha
       */
       FunctionEX m_alpha;
@@ -636,6 +646,12 @@ namespace Physics {
       */
       virtual void
       initializeSurfaceEmission(const std::string a_surface);
+
+      /*!
+	@brief Initialize field emission reactions
+      */
+      virtual void
+      initializeFieldEmission();
 
       /*!
 	@brief Initialize the particle placement algorithm

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -3154,7 +3154,14 @@ ItoKMCJSON::updateReactionRates(std::vector<std::shared_ptr<const KMCReaction>>&
 
       a_kmcReactions[i]->rate() *= fcorr;
     }
+
+
   }
+
+    if(a_phi[2] + a_phi[3] > 1.E24) {
+      a_kmcReactions[1]->rate() = 0.0;
+      a_kmcReactions[2]->rate() = 0.0;      
+    }  
 }
 
 void


### PR DESCRIPTION
# Summary

Add support for Schottky and Fowler-Nordheim emission in the Ito-KMC model.

Closes #427 

### Background

Field emission might be important (we don't know yet) in, e.g., cathode sheaths. This PR adds support for this by parsing field emission specifications from the JSON file.

### Solution

Add new data members to ItoKMCJSON, and add the field-emitted particles directly into the function that resolves secondary emission at EBs.

### Side-effects

There are no safeguards around e.g. NaNs when evaluating the resulting expressions. Bad user input will result in bad code.

### Alternative solutions

None considered. 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
