### PR TITLE
Bug fix in ItoKMCJSON temperature calculation

### DIFF
--- a/Docs/Sphinx/source/Applications/ItoKMC.rst
+++ b/Docs/Sphinx/source/Applications/ItoKMC.rst
@@ -1515,7 +1515,7 @@ An example specification is
       }
    ]
 
-**function TT A**
+**function T1T2 A**
 
 This specification is equivalent to a fluid rate
 
@@ -1531,12 +1531,12 @@ An example specification is
 		
    "plasma reactions": [
       {
-         "reaction": "A + B -> "  // Example reaction string. 
-	 "type": "function TT A", // Function based rate.
-	 "c1": 1.0,               // c1-coefficient
-	 "c2": 1.0,               // c2-coefficient
-	 "T1": "A",               // Which species temperature for T1
-	 "T2": "B"                // Which species temperature for T2	 
+         "reaction": "A + B -> "    // Example reaction string. 
+	 "type": "function T1T2 A", // Function based rate.
+	 "c1": 1.0,                 // c1-coefficient
+	 "c2": 1.0,                 // c2-coefficient
+	 "T1": "A",                 // Which species temperature for T1
+	 "T2": "B"                  // Which species temperature for T2	 
       }
    ]   
 

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -2665,7 +2665,7 @@ ItoKMCJSON::parsePlasmaReactionRate(const nlohmann::json&    a_reactionJSON,
       return c1 * std::pow(T(E, x), c2);
     };
   }
-  else if (type == "function TT A") {
+  else if (type == "function T1T2 A") {
     if (!(a_reactionJSON.contains("T1"))) {
       this->throwParserError(baseError + " and got 'functionT1T2 A' but field 'T1' was not found");
     }
@@ -2708,6 +2708,7 @@ ItoKMCJSON::parsePlasmaReactionRate(const nlohmann::json&    a_reactionJSON,
     else {
       speciesTemperature1 = m_plasmaTemperatures[m_plasmaIndexMap.at(speciesT1)];
     }
+
     if (isBackgroundT2) {
       speciesTemperature2 = [&backgroundTemperature = this->m_gasTemperature](const Real E, const RealVect x) -> Real {
         return backgroundTemperature(x);
@@ -2718,7 +2719,7 @@ ItoKMCJSON::parsePlasmaReactionRate(const nlohmann::json&    a_reactionJSON,
     }
 
     const Real c1 = a_reactionJSON["c1"].get<Real>();
-    const Real c2 = a_reactionJSON["c1"].get<Real>();
+    const Real c2 = a_reactionJSON["c2"].get<Real>();
 
     fluidRate = [c1, c2, T1 = speciesTemperature1, T2 = speciesTemperature2](const Real E, const RealVect x) -> Real {
       return c1 * std::pow(T1(E, x) / T2(E, x), c2);

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -1555,7 +1555,7 @@ ItoKMCJSON::initializeTemperatures()
           const Real N   = m_gasNumberDensity(x);
           const Real Etd = E / (N * Units::Td);
 
-          return eVToKelvin * tabulatedCoeff.interpolate<1>(Etd) / (std::numeric_limits<Real>::epsilon() + N);
+          return eVToKelvin * tabulatedCoeff.interpolate<1>(Etd);
         };
       }
       else {
@@ -2647,7 +2647,7 @@ ItoKMCJSON::parsePlasmaReactionRate(const nlohmann::json&    a_reactionJSON,
     const bool isBackground = this->isBackgroundSpecies(species);
     const bool isPlasma     = this->isPlasmaSpecies(species);
 
-    if (!isBackground || !isPlasma) {
+    if (!isBackground && !isPlasma) {
       this->throwParserError(baseError + " but species '" + species + "' is not a background or plasma species");
     }
 


### PR DESCRIPTION
# Summary

Fix a bug where the input temperature with tabulated input was accidentally divided by N.

### Background

Users may input the species temperature by reading this from a tabulated file. This functionality was probably copied over from where the mobility and diffusion coefficients were parsed, which included a division by the neutral density N.
This is obviously a bug that should not have been present.

### Solution

Remove division.

### Side-effects

None.

### Alternative solutions 

None.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
