### PR TITLE
Bug fix for Driver::m_startTime

### DIFF
--- a/Source/Driver/CD_Driver.cpp
+++ b/Source/Driver/CD_Driver.cpp
@@ -73,12 +73,15 @@ Driver::Driver(const RefCountedPtr<ComputationalGeometry>& a_computationalGeomet
   this->parseOptions();
 
   // Always register this Realm and these operators.
+
   m_realm = Realm::Primal;
   m_amr->registerRealm(m_realm);
   m_amr->registerOperator(s_eb_fill_patch, m_realm, phase::gas);
 
   // Seed the RNG.
   Random::seed();
+
+  m_time = m_startTime;
 }
 
 Driver::~Driver()
@@ -1993,10 +1996,8 @@ Driver::writeMemoryUsage()
     const int width = 12;
 
     // Write header
-    f << std::left << std::setw(width) << "# MPI rank"
-      << "\t" << std::left << std::setw(width) << "Peak memory"
-      << "\t" << std::left << std::setw(width) << "Unfreed memory"
-      << "\t" << endl;
+    f << std::left << std::setw(width) << "# MPI rank" << "\t" << std::left << std::setw(width) << "Peak memory" << "\t"
+      << std::left << std::setw(width) << "Unfreed memory" << "\t" << endl;
 
     // Write memory
     for (int i = 0; i < numProc(); i++) {

--- a/Source/Driver/CD_Driver.cpp
+++ b/Source/Driver/CD_Driver.cpp
@@ -73,7 +73,6 @@ Driver::Driver(const RefCountedPtr<ComputationalGeometry>& a_computationalGeomet
   this->parseOptions();
 
   // Always register this Realm and these operators.
-
   m_realm = Realm::Primal;
   m_amr->registerRealm(m_realm);
   m_amr->registerOperator(s_eb_fill_patch, m_realm, phase::gas);


### PR DESCRIPTION
# Summary

This PR fixes a bug where Driver would not set the correct start time on the first time step (subsequent steps were fine).

Closes #548 

### Background

Driver would read the start time but not set it on the first time step. 

### Solution

Set m_time in the constructor just after parsing the start time.

### Side-effects

I have not scoured the entire class -- hopefully the way the time was set does not conflict with other functions that also set it (e.g., restarting).

### Alternative solutions 

None considered.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
