### PR TITLE
Update clang-format to v18

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run clang-format
         uses: jidicula/clang-format-action@v4.10.1
         with:
-          clang-format-version: '10'
+          clang-format-version: '18'
           check-path: ${{ matrix.directory }}
 
   Linux-GNU:

--- a/Exec/Convergence/AdvectionDiffusion/C2/program.cpp
+++ b/Exec/Convergence/AdvectionDiffusion/C2/program.cpp
@@ -80,7 +80,7 @@ main(int argc, char* argv[])
 #ifdef CH_MPI
   if (procID() == 0) {
 #endif
-    //clang-format off
+    // clang-format off
     std::cout << "# nref\t"
               << "Linf error\t"
               << "L1 error\t"
@@ -90,7 +90,7 @@ main(int argc, char* argv[])
       std::cout << std::pow(2, i + 1) << "\t" << std::get<0>(norms[i]) << "\t" << std::get<1>(norms[i]) << "\t"
                 << std::get<2>(norms[i]) << "\n";
     }
-    //    clang-format on
+    // clang-format on
 #ifdef CH_MPI
   }
   MPI_Finalize();

--- a/Exec/Convergence/RadiativeTransfer/C2/program.cpp
+++ b/Exec/Convergence/RadiativeTransfer/C2/program.cpp
@@ -81,7 +81,7 @@ main(int argc, char* argv[])
 #ifdef CH_MPI
   if (procID() == 0) {
 #endif
-    //clang-format off
+    // clang-format off
     std::cout << "# nref\t"
               << "Linf error\t"
               << "L1 error\t"
@@ -91,7 +91,7 @@ main(int argc, char* argv[])
       std::cout << std::pow(2, i + 1) << "\t" << std::get<0>(norms[i]) << "\t" << std::get<1>(norms[i]) << "\t"
                 << std::get<2>(norms[i]) << "\n";
     }
-    //    clang-format on
+    // clang-format on
 #ifdef CH_MPI
   }
   MPI_Finalize();

--- a/Physics/AdvectionDiffusion/CD_AdvectionDiffusion.H
+++ b/Physics/AdvectionDiffusion/CD_AdvectionDiffusion.H
@@ -16,8 +16,7 @@ namespace Physics {
   /*!
     @brief Namespace for encapsulating AdvectionDiffusion physics code.
   */
-  namespace AdvectionDiffusion {
-  };
+  namespace AdvectionDiffusion {};
 
 } // namespace Physics
 

--- a/Physics/BrownianWalker/CD_BrownianWalker.H
+++ b/Physics/BrownianWalker/CD_BrownianWalker.H
@@ -17,8 +17,7 @@ namespace Physics {
   /*!
     @brief Namespace for encapsulating physics code for describing Brownian walkers. 
   */
-  namespace BrownianWalker {
-  }
+  namespace BrownianWalker {}
 
 } // namespace Physics
 

--- a/Physics/CD_Physics.H
+++ b/Physics/CD_Physics.H
@@ -15,7 +15,6 @@
 /*!
   @brief Name containing various physics models for running chombo-discharge code
 */
-namespace Physics {
-};
+namespace Physics {};
 
 #endif

--- a/Physics/CdrPlasma/CD_CdrPlasma.H
+++ b/Physics/CdrPlasma/CD_CdrPlasma.H
@@ -16,8 +16,7 @@ namespace Physics {
   /*!
     @brief Namespace for encapsulating CDR plasma code.
   */
-  namespace CdrPlasma {
-  };
+  namespace CdrPlasma {};
 
 } // namespace Physics
 

--- a/Physics/CdrPlasma/CD_CdrPlasmaPhysics.H
+++ b/Physics/CdrPlasma/CD_CdrPlasmaPhysics.H
@@ -47,7 +47,7 @@ namespace Physics {
 	@brief Parse run-time options
       */
       virtual void
-      parseRuntimeOptions(){
+      parseRuntimeOptions() {
 
       };
 

--- a/Physics/CdrPlasma/Timesteppers/CdrPlasmaGodunovStepper/CD_CdrPlasmaGodunovStepper.cpp
+++ b/Physics/CdrPlasma/Timesteppers/CdrPlasmaGodunovStepper/CD_CdrPlasmaGodunovStepper.cpp
@@ -864,7 +864,7 @@ CdrPlasmaGodunovStepper::extrapolateCdrToEB()
   //       will later fetch these quantities and pass them into our boundary condition routines.
 
   Vector<EBAMRCellData*>
-                         cdrDensities; // Cell-centered densities used when extrapolating to EBs and domains when parsing boundary conditions.
+    cdrDensities; // Cell-centered densities used when extrapolating to EBs and domains when parsing boundary conditions.
   Vector<EBAMRCellData*> cdrGradients;   // Gradient of cell-centered densities
   Vector<EBAMRIVData*>   cdrDensitiesEB; // Extrapolation of cdrDensities to the EB
   Vector<EBAMRIVData*>   cdrGradientsEB; // Extrapolation of cdrGradients to the EB

--- a/Physics/CdrPlasma/Timesteppers/CdrPlasmaImExSdcStepper/CD_CdrPlasmaImExSdcStepper.cpp
+++ b/Physics/CdrPlasma/Timesteppers/CdrPlasmaImExSdcStepper/CD_CdrPlasmaImExSdcStepper.cpp
@@ -2036,15 +2036,11 @@ CdrPlasmaImExSdcStepper::writeStepProfile(const Real a_dt,
     const int width = 12;
 
     if (write_header) {
-      f << std::left << std::setw(width) << "# Step"
-        << "\t" << std::left << std::setw(width) << "Time"
-        << "\t" << std::left << std::setw(width) << "dt"
-        << "\t" << std::left << std::setw(width) << "Substeps"
-        << "\t" << std::left << std::setw(width) << "Corrections"
-        << "\t" << std::left << std::setw(width) << "Rejections"
-        << "\t" << std::left << std::setw(width) << "Error"
-        << "\t" << std::left << std::setw(width) << "CFL"
-        << "\t" << endl;
+      f << std::left << std::setw(width) << "# Step" << "\t" << std::left << std::setw(width) << "Time" << "\t"
+        << std::left << std::setw(width) << "dt" << "\t" << std::left << std::setw(width) << "Substeps" << "\t"
+        << std::left << std::setw(width) << "Corrections" << "\t" << std::left << std::setw(width) << "Rejections"
+        << "\t" << std::left << std::setw(width) << "Error" << "\t" << std::left << std::setw(width) << "CFL" << "\t"
+        << endl;
     }
 
     f << std::left << std::setw(width) << m_timeStep << "\t" << std::left << std::setw(width) << m_time << "\t"

--- a/Physics/Electrostatics/CD_Electrostatics.H
+++ b/Physics/Electrostatics/CD_Electrostatics.H
@@ -16,8 +16,7 @@ namespace Physics {
   /*!
     @brief Namespace for encapsulating physics code for electrostatic problems
   */
-  namespace Electrostatics {
-  }
+  namespace Electrostatics {}
 
 } // namespace Physics
 

--- a/Physics/Electrostatics/CD_FieldStepper.H
+++ b/Physics/Electrostatics/CD_FieldStepper.H
@@ -159,7 +159,7 @@ namespace Physics {
 	@brief Print step report -- this does nothing. 
       */
       void
-      printStepReport() override{};
+      printStepReport() override {};
 
       /*!
 	@brief Register simulation realms to be used for this simulation module. 

--- a/Physics/Electrostatics/CD_FieldStepper.cpp
+++ b/Physics/Electrostatics/CD_FieldStepper.cpp
@@ -15,8 +15,7 @@
 #include <CD_NamespaceHeader.H>
 
 namespace Physics {
-  namespace Electrostatics {
-  }
+  namespace Electrostatics {}
 } // namespace Physics
 
 #include <CD_NamespaceFooter.H>

--- a/Physics/TracerParticle/CD_TracerParticlePhysics.H
+++ b/Physics/TracerParticle/CD_TracerParticlePhysics.H
@@ -18,8 +18,7 @@ namespace Physics {
   /*!
     @brief Namespace for encapsulating physics code for tracer particles
   */
-  namespace TracerParticle {
-  }
+  namespace TracerParticle {}
 
 } // namespace Physics
 

--- a/Source/Particle/CD_ParticleContainer.H
+++ b/Source/Particle/CD_ParticleContainer.H
@@ -526,8 +526,8 @@ public:
 
 protected:
   // Reductions for performing catenation and join operations in a thread-safe manner.
-#pragma omp declare reduction(catenate : List <P> : ThreadSafeCatenation <P>(omp_out, omp_in))
-#pragma omp declare reduction(join : List <P> : ThreadSafeJoin <P>(omp_out, omp_in))
+#pragma omp declare reduction(catenate : List<P> : ThreadSafeCatenation<P>(omp_out, omp_in))
+#pragma omp declare reduction(join : List<P> : ThreadSafeJoin<P>(omp_out, omp_in))
 
   /*!
     @brief Realm on which the ParticleContainer is defined

--- a/Source/Utilities/CD_MemoryReport.cpp
+++ b/Source/Utilities/CD_MemoryReport.cpp
@@ -31,9 +31,9 @@ MemoryReport::getMaxMinMemoryUsage()
 
   MemoryReport::getMaxMinMemoryUsage(maxPeak, minPeak, maxUnfreed, minUnfreed);
 
-  pout() << "MemoryReport::getMaxMinMemoryUsage:"
-         << "\t Max peak = " << 1.0 * maxPeak << "\t Min peak = " << 1.0 * minPeak
-         << "\t Max unfreed = " << 1.0 * maxUnfreed << "\t Min unfreed = " << 1.0 * minUnfreed << endl;
+  pout() << "MemoryReport::getMaxMinMemoryUsage:" << "\t Max peak = " << 1.0 * maxPeak
+         << "\t Min peak = " << 1.0 * minPeak << "\t Max unfreed = " << 1.0 * maxUnfreed
+         << "\t Min unfreed = " << 1.0 * minUnfreed << endl;
 #endif
 }
 

--- a/Source/Utilities/CD_OpenMP.H
+++ b/Source/Utilities/CD_OpenMP.H
@@ -51,7 +51,8 @@ ThreadSafePairMin(std::pair<Real, RealVect>& ompOut, const std::pair<Real, RealV
 {
   ompOut = (ompIn.first < ompOut.first) ? ompIn : ompOut;
 }
-#pragma omp declare reduction(pairmin : std::pair<Real, RealVect> : ThreadSafePairMin(omp_out, omp_in)) initializer(omp_priv=omp_orig)
+#pragma omp declare reduction(pairmin : std::pair<Real, RealVect> : ThreadSafePairMin(omp_out, omp_in)) \
+  initializer(omp_priv = omp_orig)
 
 #endif
 

--- a/Source/Utilities/CD_TimerImplem.H
+++ b/Source/Utilities/CD_TimerImplem.H
@@ -119,21 +119,15 @@ Timer::printReportHeader(std::ostream& a_outputStream) const noexcept
     header
       << "| ---------------------------------------------------------------------------------------------------------|"
       << "\n"
-      << "| " + m_processName + " kernel report: "
-      << "\n"
+      << "| " + m_processName + " kernel report: " << "\n"
       << "| ---------------------------------------------------------------------------------------------------------|"
       << "\n"
-      << "| " << std::left << std::setw(25) << "Event"
-      << "| " << std::right << std::setw(8) << "Loc. (s)"
-      << "| " << std::right << std::setw(8) << "Loc. (%)"
+      << "| " << std::left << std::setw(25) << "Event" << "| " << std::right << std::setw(8) << "Loc. (s)" << "| "
+      << std::right << std::setw(8) << "Loc. (%)"
 #ifdef CH_MPI
-      << "| " << std::right << std::setw(8) << "Min. (s)"
-      << "| " << std::right << std::setw(8) << "Max. (s)"
-      << "| " << std::right << std::setw(8) << "Avg. (s)"
-      << "| " << std::right << std::setw(8) << "Dev. (s)"
-      << "| " << std::right << std::setw(8) << "Min rank"
-      << "| " << std::right << std::setw(8) << "Max rank"
-      << "| "
+      << "| " << std::right << std::setw(8) << "Min. (s)" << "| " << std::right << std::setw(8) << "Max. (s)" << "| "
+      << std::right << std::setw(8) << "Avg. (s)" << "| " << std::right << std::setw(8) << "Dev. (s)" << "| "
+      << std::right << std::setw(8) << "Min rank" << "| " << std::right << std::setw(8) << "Max rank" << "| "
 #endif
       << "\n"
       << "| ---------------------------------------------------------------------------------------------------------|"
@@ -156,10 +150,8 @@ Timer::printReportTail(std::ostream& a_outputStream, const std::pair<Real, Real>
     tail
       << "| ---------------------------------------------------------------------------------------------------------|"
       << "\n"
-      << "| Local elapsed time  = " << std::fixed << std::setprecision(4) << a_elapsedTime.first << " seconds"
-      << "\n"
-      << "| Global elapsed time = " << std::fixed << std::setprecision(4) << a_elapsedTime.second << " seconds"
-      << "\n"
+      << "| Local elapsed time  = " << std::fixed << std::setprecision(4) << a_elapsedTime.first << " seconds" << "\n"
+      << "| Global elapsed time = " << std::fixed << std::setprecision(4) << a_elapsedTime.second << " seconds" << "\n"
       << "| ---------------------------------------------------------------------------------------------------------|"
       << "\n";
 
@@ -293,8 +285,7 @@ Timer::eventReport(std::ostream& a_outputStream, const bool a_localReportOnly) c
                    << std::right << std::setw(8) << ssDevDuration.str() << "| " << std::right << std::setw(8)
                    << ssMinRank.str() << "| " << std::right << std::setw(8) << ssMaxRank.str()
 #endif
-                   << "| "
-                   << "\n";
+                   << "| " << "\n";
 
       a_outputStream << outputString.str();
     }
@@ -332,7 +323,7 @@ Timer::computeTotalElapsedTime(const bool a_localReportOnly) const noexcept
     elapsedTimeGlobal = elapsedTimeLocal;
   }
 #else
-  elapsedTimeGlobal  = elapsedTimeLocal;
+  elapsedTimeGlobal = elapsedTimeLocal;
 #endif
 
   return std::make_pair(elapsedTimeLocal, elapsedTimeGlobal);


### PR DESCRIPTION
# Summary

This PR updates clang-format to version 18.

Closes #550 

### Background

We were running an old version of clang-format that was not available on newer systems. 

### Solution

Update the github CI file to use version 18 rather than 10. 

### Side-effects

Formatted files, so some older print messages that used to look good are potentially unreadable now.

### Alternative solutions 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
