### PR TITLE
Add particle initialization from a density distribution

### DIFF
--- a/Docs/Sphinx/source/Applications/ItoKMC.rst
+++ b/Docs/Sphinx/source/Applications/ItoKMC.rst
@@ -2202,9 +2202,9 @@ Simulations that fail to stabilize, i.e., where the field strength diverges, may
       }
    ]
 
-   This will limit the rate such that :math:`k \left[\text[N]_2\right]\Delta t = 2`.
-   I.e., all background species are first absorbed into the rate calculation before the rate is limited.
-   We point out that limiting is not possible if both species on the left hand side are solver variables.
+This will limit the rate such that :math:`k \left[\text[N]_2\right]\Delta t = 2`.
+I.e., all background species are first absorbed into the rate calculation before the rate is limited.
+We point out that limiting is not possible if both species on the left hand side are solver variables.
 
 
 .. important::

--- a/Docs/Sphinx/source/Applications/ItoKMC.rst
+++ b/Docs/Sphinx/source/Applications/ItoKMC.rst
@@ -172,7 +172,7 @@ Species are defined either as input species for CDR solvers (see :ref:`Chap:CdrS
 It is sufficient to populate the ``ItoKMCPhysics`` species vectors ``m_cdrSpecies`` and ``m_itoSpecies`` if one only wants to initialize the solvers.
 See :ref:`Chap:ItoKMCPhysics` for their C++ definition.
 In addition to actually populating the vectors, users will typically also include initial conditions for the species.
-The interfaces permit initial particles for the Îto solvers, while the CDR solvers permit particles *and* initial density functions.
+The interfaces permit initial particles and density functions for both both solver types.
 Additionally, one must define all species associated with radiative transfer solvers.
 
 .. _Chap:ItoKMCPlasmaReaction:
@@ -1236,7 +1236,7 @@ For example:
 Initial densities
 _________________
 
-If a species is defined by a convection-diffusion-reaction solver, one may include an initial density by setting the ``initial density``parameter.
+One may include an initial density by setting the ``initial density``parameter.
 For example:
 
 .. code-block:: json
@@ -1252,6 +1252,8 @@ For example:
 	  "initial density": 1E10
       }
     ]
+
+If the species is defined as a particle species, computational particles will be generated within each grid so that the density is approximately as specified.
 
 Photon species
 --------------

--- a/Docs/Sphinx/source/Solvers/Ito.rst
+++ b/Docs/Sphinx/source/Solvers/Ito.rst
@@ -140,6 +140,20 @@ Initial data for the ``ItoSolver`` is provided through ``ItoSpecies`` by providi
 When ``ItoSolver`` initializes the data in the solver, it transfers the particles from the species and into the solver.
 See :ref:`Chap:ParticleOps` for examples on how to draw initial particles and how to partition them when using MPI.
 
+Another way the initial particles can be generated is to set an initial density distribution for the species:
+
+.. code-block:: c++
+
+   class ItoSpecies {
+   public:
+
+   void setInitialDensityDistribution(const std::function<Real(const RealVect& x, const Real& t)>& phi);
+   
+   };
+
+When the user sets this function, the initialization routine in the solver will generate particles in the grid cell so that the specified density is reached.
+Note that this evaluation is stochastic, and there is currently a hard limit that restricts the number of initial computational particles per cell to 32. 
+
 Transport kernel
 ----------------
 

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.H
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.H
@@ -606,10 +606,10 @@ namespace Physics {
       initializeParticles();
 
       /*!
-	@brief Parse initial densities for CDR equations.
+	@brief Parse initial densities for CDR and Ito species. 
       */
       virtual void
-      initializeDensitiesCDR();
+      initializeDensities();
 
       /*!
 	@brief Initialize mobility functions

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -51,7 +51,7 @@ ItoKMCJSON::ItoKMCJSON()
   // Initialize the plasma species
   this->initializePlasmaSpecies();
   this->initializeParticles();
-  this->initializeDensitiesCDR();
+  this->initializeDensities();
   this->initializeMobilities();
   this->initializeDiffusionCoefficients();
   this->initializeTemperatures();
@@ -1307,14 +1307,14 @@ ItoKMCJSON::initializeParticles()
 }
 
 void
-ItoKMCJSON::initializeDensitiesCDR()
+ItoKMCJSON::initializeDensities()
 {
-  CH_TIME("ItoKMCJSON::initializeDensitiesCDR");
+  CH_TIME("ItoKMCJSON::initializeDensities");
   if (m_verbose) {
-    pout() << m_className + "::initializeDensitiesCDR" << endl;
+    pout() << m_className + "::initializeDensities" << endl;
   }
 
-  const std::string baseError = "ItoKMCJSON::initializeDensitiesCDR";
+  const std::string baseError = "ItoKMCJSON::initializeDensities";
 
   for (const auto& species : m_json["plasma species"]) {
     const std::string speciesID   = species["id"].get<std::string>();
@@ -1324,7 +1324,7 @@ ItoKMCJSON::initializeDensitiesCDR()
 
     // Put the particles in the solvers.
     const SpeciesType& speciesType = m_plasmaSpeciesTypes.at(speciesID);
-    if ((speciesType == SpeciesType::CDR) && species.contains("initial density")) {
+    if (species.contains("initial density")) {
       const Real density = species["initial density"].get<Real>();
 
       if (density < 0.0) {
@@ -1336,12 +1336,18 @@ ItoKMCJSON::initializeDensitiesCDR()
         return density;
       };
 
-      const int idx = m_cdrSpeciesMap.at(speciesID);
+      if (speciesType == SpeciesType::CDR) {
+        const int idx = m_cdrSpeciesMap.at(speciesID);
 
-      // Doing the ugly, but I happen to KNOW that we can cast here.
-      auto species = static_cast<ItoKMCCDRSpecies*>(&(*m_cdrSpecies[idx]));
+        auto species = static_cast<ItoKMCCDRSpecies*>(&(*m_cdrSpecies[idx]));
 
-      species->setInitialData(initFunc);
+        species->setInitialData(initFunc);
+      }
+      else if (speciesType == SpeciesType::Ito) {
+        const int idx = m_itoSpeciesMap.at(speciesID);
+
+        m_itoSpecies[idx]->setInitialDensity(initFunc);
+      }
     }
   }
 }

--- a/Source/ItoDiffusion/CD_ItoSolver.H
+++ b/Source/ItoDiffusion/CD_ItoSolver.H
@@ -119,6 +119,17 @@ public:
   initialData();
 
   /*!
+    @brief Fill a particle container randomly with particles such that we obtain the target uniform density.
+    @param[inout] a_particles Particle container to fill. Particles already in the container will be kept.
+    @param[in] a_densityFunc Density function.
+    @param[in] a_maxParticlesPerCell Maximum number of computational particles generated per cell. 
+  */
+  virtual void
+  generateParticlesFromDensity(ParticleContainer<ItoParticle>&              a_particles,
+                               const std::function<Real(const RealVect x)>& a_densityFunc,
+                               const int                                    a_maxParticlesPerCell) const noexcept;
+
+  /*!
     @brief Regrid this solver. 
     @param[in] a_lmin           Coarsest level where grids did not change. 
     @param[in] a_oldFinestLevel Finest AMR level before the regrid. 

--- a/Source/ItoDiffusion/CD_ItoSpecies.H
+++ b/Source/ItoDiffusion/CD_ItoSpecies.H
@@ -61,6 +61,13 @@ public:
   getChargeNumber() const;
 
   /*!
+    @brief Return the initial density
+    @return Returns m_initialDensity
+  */
+  const std::function<Real(const RealVect& x, const Real& t)>&
+  getInitialDensity() const;
+
+  /*!
     @brief Return diffusive or not
   */
   bool
@@ -91,6 +98,13 @@ public:
   diffusion(const Real a_energy) const;
 
   /*!
+    @brief Set the initial species density
+    @param[in] a_initialDensity Initial density.
+  */
+  virtual void
+  setInitialDensity(const std::function<Real(const RealVect& x, const Real& t)>& a_initialDensity);
+
+  /*!
     @brief Get initial particles -- this is called by ItoSolver when filling the solver with initial particles. 
     @return Returns m_initialParticles
   */
@@ -116,6 +130,11 @@ protected:
   int m_chargeNumber;
 
   /*!
+    @brief Maximum number of initial numerical particles per cell
+  */
+  int m_maxInitialParticlesPerCell;
+
+  /*!
     @brief Diffusive ItoSpecies or not
   */
   bool m_isDiffusive;
@@ -129,6 +148,11 @@ protected:
     @brief Initial particles
   */
   List<ItoParticle> m_initialParticles;
+
+  /*!
+    @brief Initial density, in case the user wants to generate particles from a density distribution
+  */
+  std::function<Real(const RealVect& x, const Real& t)> m_initialDensity;
 };
 
 #include <CD_NamespaceFooter.H>

--- a/Source/ItoDiffusion/CD_ItoSpecies.cpp
+++ b/Source/ItoDiffusion/CD_ItoSpecies.cpp
@@ -15,18 +15,24 @@
 
 ItoSpecies::ItoSpecies()
 {
-  m_name         = "ItoSpecies";
-  m_isMobile     = false;
-  m_isDiffusive  = false;
-  m_chargeNumber = 0;
+  m_name           = "ItoSpecies";
+  m_isMobile       = false;
+  m_isDiffusive    = false;
+  m_chargeNumber   = 0;
+  m_initialDensity = [](const RealVect& x, const Real& t) -> Real {
+    return 0.0;
+  };
 }
 
 ItoSpecies::ItoSpecies(const std::string a_name, const int a_chargeNumber, const bool a_mobile, const bool a_diffusive)
 {
-  m_name         = a_name;
-  m_chargeNumber = a_chargeNumber;
-  m_isMobile     = a_mobile;
-  m_isDiffusive  = a_diffusive;
+  m_name           = a_name;
+  m_chargeNumber   = a_chargeNumber;
+  m_isMobile       = a_mobile;
+  m_isDiffusive    = a_diffusive;
+  m_initialDensity = [](const RealVect& x, const Real& t) -> Real {
+    return 0.0;
+  };
 }
 
 ItoSpecies::~ItoSpecies()
@@ -44,6 +50,12 @@ ItoSpecies::getChargeNumber() const
   return m_chargeNumber;
 }
 
+const std::function<Real(const RealVect& x, const Real& t)>&
+ItoSpecies::getInitialDensity() const
+{
+  return m_initialDensity;
+}
+
 bool
 ItoSpecies::isDiffusive() const
 {
@@ -54,6 +66,12 @@ bool
 ItoSpecies::isMobile() const
 {
   return m_isMobile;
+}
+
+void
+ItoSpecies::setInitialDensity(const std::function<Real(const RealVect& x, const Real& t)>& a_initialDensity)
+{
+  m_initialDensity = a_initialDensity;
 }
 
 List<ItoParticle>&


### PR DESCRIPTION
# Summary

This PR adds a feature to ItoSolver where the solver can fill particles from a density distribution. This feature has been extended to ItoKMC so that we can generate uniform distributions over large domains, even when including AMR.

Closes #547 

### Background

ItoSolver would only read particles from files or functions, but this design does not respect the actual grids that are being generated. To get an approximately uniform distribution over an AMR hierarchy, one would have to virtually sample physical particles which would be coalesced later. In practice, we would always end up with superparticles with very high weights in the fine grids. 

### Solution

Add an initial density function to ItoSolver and let the class generate particles from this function when setting up the solver.

### Side-effects

We are currently limiting to 32 numerical particles per cell. This may be insufficient (or too much) for users, but I could not find a proper place to drop in this setting.

### Alternative solutions 

None considered.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
