### PR TITLE
Impose KMC dt restriction on mean value only

### DIFF
--- a/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
@@ -465,7 +465,8 @@ ItoKMCPhysics::advanceKMC(Vector<FPR>&            a_numParticles,
     MayDay::Warning("ItoKMCPhysics::advanceKMC -- charge not conserved!");
   }
 
-  // Compute the critical and non-critical time steps
+  // Compute a time step using the non-critical reactions. We could have done this using ALL reactions, but I take for granted
+  // that the user will segregate the critical reactions anyways.
   const auto partitionedReactions = m_kmcSolver.partitionReactions(m_kmcState);
 
   const auto& criticalReactions    = partitionedReactions.first;
@@ -474,12 +475,7 @@ ItoKMCPhysics::advanceKMC(Vector<FPR>&            a_numParticles,
   const auto criticalPropensities    = m_kmcSolver.propensities(m_kmcState, criticalReactions);
   const auto nonCriticalPropensities = m_kmcSolver.propensities(m_kmcState, nonCriticalReactions);
 
-  // After doing this so we can simply reset the solver to use the appropriate eps.
-  m_kmcSolver.setSolverParameters(m_Ncrit, m_NSSA, m_maxIter, 1.0, m_SSAlim, m_exitTol);
-
-  a_physicsDt = m_kmcSolver.getNonCriticalTimeStep(m_kmcState, nonCriticalReactions, nonCriticalPropensities);
-
-  m_kmcSolver.setSolverParameters(m_Ncrit, m_NSSA, m_maxIter, m_eps, m_SSAlim, m_exitTol);
+  a_physicsDt = m_kmcSolver.computeDt(m_kmcState, nonCriticalReactions, nonCriticalPropensities, 1.0);
 }
 
 inline void

--- a/Physics/ItoKMC/CD_ItoKMCStepper.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepper.H
@@ -745,7 +745,7 @@ namespace Physics {
 	@details This is computed using the non-critical reactions assuming eps=1
 	@note Defined on the fluid realm. 	
       */
-      EBAMRCellData m_nonCriticalPhysicsDt;
+      EBAMRCellData m_kmcDt;
 
       /*!
 	@brief Storage for holding the energy sources for each species.

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -607,7 +607,7 @@ ItoKMCStepper<I, C, R, F>::allocateInternals() noexcept
   m_amr->allocate(m_currentDensity, m_fluidRealm, m_plasmaPhase, SpaceDim);
 
   // Storage for the physics time step
-  m_amr->allocate(m_nonCriticalPhysicsDt, m_fluidRealm, m_plasmaPhase, 1);
+  m_amr->allocate(m_kmcDt, m_fluidRealm, m_plasmaPhase, 1);
 
   // Storage required for the reaction network.
   m_amr->allocate(m_fluidPPC, m_fluidRealm, m_plasmaPhase, numPlasmaSpecies);
@@ -641,7 +641,7 @@ ItoKMCStepper<I, C, R, F>::allocateInternals() noexcept
     m_amr->allocate(m_fluidYPC, m_fluidRealm, m_plasmaPhase, 1);
   }
 
-  DataOps::setValue(m_nonCriticalPhysicsDt, std::numeric_limits<Real>::max());
+  DataOps::setValue(m_kmcDt, std::numeric_limits<Real>::max());
 }
 
 template <typename I, typename C, typename R, typename F>
@@ -4069,7 +4069,7 @@ ItoKMCStepper<I, C, R, F>::advanceReactionNetwork(EBCellFAB&       a_particlesPe
   Vector<const FArrayBox*> densityGradientsCDRReg(numCdrSpecies);
 
   // Handle to critical and non-critical time step containers.
-  EBCellFAB& physicsDt = (*m_nonCriticalPhysicsDt[a_level])[a_din];
+  EBCellFAB& physicsDt = (*m_kmcDt[a_level])[a_din];
 
   FArrayBox& physicsDtReg = physicsDt.getFArrayBox();
 
@@ -5219,7 +5219,7 @@ ItoKMCStepper<I, C, R, F>::computePhysicsDt() noexcept
   Real maxDt = std::numeric_limits<Real>::max();
   Real minDt = std::numeric_limits<Real>::max();
 
-  DataOps::getMaxMin(maxDt, minDt, m_nonCriticalPhysicsDt, 0);
+  DataOps::getMaxMin(maxDt, minDt, m_kmcDt, 0);
 
   m_physicsDt = minDt;
 }

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
@@ -1771,7 +1771,7 @@ ItoKMCGodunovStepper<I, C, R, F>::readCheckpointHeader(HDF5HeaderData& a_header)
   }
 
   this->m_prevDt    = a_header.m_real["prev_dt"];
-  this->m_physicsDt = a_header.m_real["physicsDt_dt"];
+  this->m_physicsDt = a_header.m_real["physics_dt"];
 
   m_readCheckpointParticles = (a_header.m_int["checkpoint_particles"] != 0) ? true : false;
   m_canRegridOnRestart      = m_readCheckpointParticles;

--- a/Source/KineticMonteCarlo/CD_KMCSolver.H
+++ b/Source/KineticMonteCarlo/CD_KMCSolver.H
@@ -237,6 +237,20 @@ public:
                          const std::vector<Real>& a_nonCriticalPropensities) const noexcept;
 
   /*!
+    @brief Compute a time step, using the leap condition on the mean value with eps = 1.
+    @details This is just like getNonCriticalTimeStep EXCEPT that the leap condition is not applied for the deviation
+    @param[in] a_state                   State vector
+    @param[in] a_nonCriticalReactions    Non-critical reactions
+    @param[in] a_nonCriticalPropensities Non-critical propensities
+    @param[in] a_epsilon                 Epsilon value for maximum change in propensities
+  */
+  inline Real
+  computeDt(const State&             a_state,
+            const ReactionList&      a_nonCriticalReactions,
+            const std::vector<Real>& a_nonCriticalPropensities,
+            const Real               a_epsilon) const noexcept;
+
+  /*!
     @brief Perform a single SSA step.
     @param[inout] a_state State vector to advance
     @note Calls the other version with m_reactions

--- a/Source/KineticMonteCarlo/CD_KMCSolverImplem.H
+++ b/Source/KineticMonteCarlo/CD_KMCSolverImplem.H
@@ -354,6 +354,73 @@ KMCSolver<R, State, T>::getNonCriticalTimeStep(const State&             a_state,
 }
 
 template <typename R, typename State, typename T>
+inline Real
+KMCSolver<R, State, T>::computeDt(const State&             a_state,
+                                  const ReactionList&      a_nonCriticalReactions,
+                                  const std::vector<Real>& a_nonCriticalPropensities,
+                                  const Real               a_epsilon) const noexcept
+{
+  CH_TIME("KMCSolver::getNonCriticalTimeStep(State, ReactionList, std::vector<Real>, Real");
+
+  CH_assert(a_nonCriticalReactions.size() == a_nonCriticalPropensities.size());
+
+  constexpr Real one = 1.0;
+
+  Real dt = std::numeric_limits<Real>::max();
+
+  const size_t numReactions = a_nonCriticalReactions.size();
+
+  if (numReactions > 0) {
+
+    // 1. Gather a list of all reactants involved in the non-critical reactions.
+    auto allReactants = a_nonCriticalReactions[0]->getReactants();
+    for (size_t i = 1; i < numReactions; i++) {
+      const auto& curReactants = a_nonCriticalReactions[i]->getReactants();
+
+      allReactants.insert(allReactants.end(), curReactants.begin(), curReactants.end());
+    }
+
+    // Only do unique reactants.
+    const auto ip = std::unique(allReactants.begin(), allReactants.end());
+    allReactants.resize(std::distance(allReactants.begin(), ip));
+
+    // 2. Iterate through all reactants and compute deviations.
+    for (const auto& reactant : allReactants) {
+
+      // Xi is the population of the current reactant. It might seem weird that we are indexing this
+      // through the reactions rather then through the state. Which it is, but the reason for that is
+      // that it is the REACTION that determines how we index the state population. This is simply a
+      // design choice that permits the user to apply different type of reactions without changing
+      // the underlying state.
+      const T Xi = a_nonCriticalReactions[0]->population(reactant, a_state);
+
+      if (Xi > (T)0) {
+        Real mu = 0.0;
+
+        // Set gi to 1 for now. A more complex version would parse this through an input parameter
+        // where the user has inspected the highest-order-reaction.
+        constexpr Real gi = 1.0;
+
+        for (size_t i = 0; i < numReactions; i++) {
+          const Real& p    = a_nonCriticalPropensities[i];
+          const auto& muIJ = a_nonCriticalReactions[i]->getStateChange(reactant);
+
+          mu += std::abs(muIJ * p);
+        }
+
+        const Real f = std::max(a_epsilon * Xi / gi, one);
+
+        if (mu > std::numeric_limits<Real>::min()) {
+          dt = std::min(dt, f / mu);
+        }
+      }
+    }
+  }
+
+  return dt;
+}
+
+template <typename R, typename State, typename T>
 inline void
 KMCSolver<R, State, T>::stepSSA(State& a_state) const noexcept
 {


### PR DESCRIPTION
# Summary

Impose KMC dt calculation using a leap condition on the mean value only.

Closes #560 

### Background

PR #559 imposed a time step restriction on the physics, but it used both the mean value and the standard deviation on the leap condition. This PR removes the restriction on the standard deviation, which is not required for accuracy. 

### Solution

Add a new function to KMCSolver which computes a dt, and use this function in ItoKMCPhysics.

### Side-effects

None.

### Alternative solutions 

None considered. 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
