### PR TITLE
Resolve bug in output report after DischargeInception refactor

### DIFF
--- a/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
+++ b/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
@@ -4959,13 +4959,12 @@ DischargeInceptionStepper<P, F, C>::writeReportStationary() const noexcept
       output << left << setw(15) << setfill(' ') << m_voltageSweeps[i];
       output << left << setw(15) << setfill(' ') << std::get<1>(m_KPlusValues[i]);
       output << left << setw(15) << setfill(' ') << std::get<1>(m_KMinuValues[i]);
-      
       output << left << setw(ww) << setfill(' ') << RealVectToString(std::get<2>(m_KPlusValues[i]));
-      output << left << setw(ww) << setfill(' ') << RealVectToString(std::get<2>(m_KPlusValues[i]));
+      output << left << setw(ww) << setfill(' ') << RealVectToString(std::get<2>(m_KMinuValues[i]));
       output << left << setw(20) << setfill(' ') << std::get<1>(m_TPlusValues[i]);
       output << left << setw(20) << setfill(' ') << std::get<1>(m_TMinuValues[i]);
       output << left << setw(ww) << setfill(' ') << RealVectToString(std::get<2>(m_TPlusValues[i]));
-      output << left << setw(ww) << setfill(' ') << RealVectToString(std::get<2>(m_TPlusValues[i]));
+      output << left << setw(ww) << setfill(' ') << RealVectToString(std::get<2>(m_TMinuValues[i]));
       output << left << setw(20) << setfill(' ') << m_criticalVolumePlus[i];
       output << left << setw(20) << setfill(' ') << m_criticalVolumeMinu[i];
       output << left << setw(20) << setfill(' ') << m_criticalAreaPlus[i];


### PR DESCRIPTION
# Summary

This PR fixes a bug where the DischargeInception report file would output the wrong position for the max-K value for one of the polarities. 

### Background

In #563 we refactored DischargeInceptionStepper, and unfortunately a bug snuck in where the report file would output the wrong location for the max-K values. 

### Solution

Print correct location.

### Side-effects

### Alternative solutions 

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
