### PR TITLE
Improve time step controls

### DIFF
--- a/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
@@ -476,6 +476,12 @@ ItoKMCPhysics::advanceKMC(Vector<FPR>&            a_numParticles,
     auto       S = m_kmcState;
     const auto N = reaction->computeCriticalNumberOfReactions(m_kmcState);
 
+    // Trigger on both the reactions and the reactions with completely consumed reactants
+    const auto propensities = m_kmcSolver.propensities(S, m_kmcReactionsThreadLocal);
+    const Real physicsDt    = m_kmcSolver.computeDt(S, m_kmcReactionsThreadLocal, propensities, 1.0);
+
+    a_physicsDt = std::min(a_physicsDt, physicsDt);
+
     if (N < std::numeric_limits<FPR>::max()) {
       reaction->advanceState(S, N);
 


### PR DESCRIPTION
# Summary

Fix a bug introduced by #568 

### Background

PR #568 would exhaust reactions and trigger the time step controls. This led to reactions like e -> 2e not triggering because this reaction will never exhaust its reactants. I.e., when detachment was turned off it led to a bad time step restriction.

### Solution

Trigger on both the normal state and the exhausted state.

### Side-effects

Unknown.

### Alternative solutions 

None considered.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
