### PR TITLE
Reset ostream flags in Timer

### DIFF
--- a/Source/Utilities/CD_TimerImplem.H
+++ b/Source/Utilities/CD_TimerImplem.H
@@ -112,6 +112,7 @@ Timer::stopEvent(const std::string a_event) noexcept
 inline void
 Timer::printReportHeader(std::ostream& a_outputStream) const noexcept
 {
+  std::ios::fmtflags oldFlags = a_outputStream.flags();
 #ifdef _OPENMP
   if (omp_get_thread_num() == 0) {
 #endif
@@ -137,11 +138,13 @@ Timer::printReportHeader(std::ostream& a_outputStream) const noexcept
 #ifdef _OPENMP
   }
 #endif
+  a_outputStream.flags(oldFlags);
 }
 
 inline void
 Timer::printReportTail(std::ostream& a_outputStream, const std::pair<Real, Real> a_elapsedTime) const noexcept
 {
+  std::ios::fmtflags oldFlags = a_outputStream.flags();
 #ifdef _OPENMP
   if (omp_get_thread_num() == 0) {
 #endif
@@ -159,6 +162,7 @@ Timer::printReportTail(std::ostream& a_outputStream, const std::pair<Real, Real>
 #ifdef _OPENMP
   }
 #endif
+  a_outputStream.flags(oldFlags);
 }
 
 inline void
@@ -166,6 +170,7 @@ Timer::eventReport(std::ostream& a_outputStream, const bool a_localReportOnly) c
 {
   // This routine prints a header, the timing report for the various event, and a tail. All events are included
   // but unfinished ones are not counted towards the elapsed time.
+  std::ios::fmtflags oldFlags = a_outputStream.flags();
 #ifdef _OPENMP
   if (omp_get_thread_num() == 0) {
 #endif
@@ -295,6 +300,7 @@ Timer::eventReport(std::ostream& a_outputStream, const bool a_localReportOnly) c
 #ifdef _OPENMP
   }
 #endif
+  a_outputStream.flags(oldFlags);
 }
 
 inline std::pair<Real, Real>


### PR DESCRIPTION
# Summary

Reset formatting flags in the ostreams used by Timer.

Closes #576 

### Background

Timer would change the format flags, which could unintentionally change pout/cout calls elsewhere. 

### Solution

Reset flags when Timer exits its report routines.

### Side-effects

None

### Alternative solutions 

None

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
