### PR TITLE
Bug fix after #565

### DIFF
--- a/Source/Particle/CD_EBParticleMesh.H
+++ b/Source/Particle/CD_EBParticleMesh.H
@@ -194,7 +194,7 @@ protected:
   /*!
     @brief Function for depositing a single particle with a TSC scheme.
     @details The user can input a differerent particle width than the standard width byu adjusting a_particleWidth. The input
-    box (a_cicBox) must be large enough to contain a particle. E.g., if a_particleWidth = 2, then the box must be at least
+    box (a_particleBox) must be large enough to contain a particle. E.g., if a_particleWidth = 2, then the box must be at least
     Box(-2*IntVect::Unit, 2*IntVect::Unit).
     @param[inout] a_rho            Mesh data
     @param[in]    a_position       Particle position
@@ -233,7 +233,7 @@ protected:
     @param[out] a_particleField  Particle quantity to interpolate into.
     @param[in]  a_meshData       Mesh data
     @param[in]  a_validRegion    Region where particle can live without kernels reaching outside the domain.
-    @param[in]  a_particleBox    Box that is sufficiently large to contain the particle, computed from the clouds lower-left corner
+    @param[in]  a_gatherBox      Box from which we gather the field.
     @param[in]  a_position       Particle position
     @param[in]  a_numComp        Number of components to interpolate.
     @param[in]  a_forceIrregNGP  Force NGP in cut-cells
@@ -242,7 +242,7 @@ protected:
   interpolateParticleCIC(Real*            a_particleField,
                          const EBCellFAB& a_meshData,
                          const Box&       a_validBox,
-                         const Box&       a_particleBox,
+                         const Box&       a_gatherBox,
                          const RealVect&  a_position,
                          const int&       a_numComp,
                          const bool       a_forceIrregNGP) const noexcept;
@@ -252,7 +252,7 @@ protected:
     @param[out] a_particleField  Particle quantity to interpolate into.
     @param[in]  a_meshData       Mesh data
     @param[in]  a_validRegion    Region where particle can live without kernels reaching outside the domain.
-    @param[in]  a_particleBox    Box that is sufficiently large to contain the particle, computed from the clouds lower-left corner
+    @param[in]  a_gatherBox      Box from which we gather the field.
     @param[in]  a_position       Particle position
     @param[in]  a_numComp        Number of components to interpolate.
     @param[in]  a_forceIrregNGP  Force NGP in cut-cells
@@ -261,7 +261,7 @@ protected:
   interpolateParticleTSC(Real*            a_particleField,
                          const EBCellFAB& a_meshData,
                          const Box&       a_validBox,
-                         const Box&       a_particleBox,
+                         const Box&       a_gatherBox,
                          const RealVect&  a_position,
                          const int&       a_numComp,
                          const bool       a_forceIrregNGP) const noexcept;

--- a/Source/Particle/CD_EBParticleMeshImplem.H
+++ b/Source/Particle/CD_EBParticleMeshImplem.H
@@ -113,26 +113,30 @@ EBParticleMesh::interpolate(List<P>&             a_particleList,
 
   const Interval variables = Interval(0, numComp - 1);
 
+  // validBox is the domain in which we can use the specified interpolation scheme. E.g., TSC fails nears the domain boundaries
+  // since we don't have enough ghost cells to interpolate from.
+  //
+  // gatherBox is the box from which we gather the field.
+  //
   Box validBox;
-  Box particleBox;
+  Box gatherBox;
 
   switch (a_interpType) {
   case DepositionType::NGP: {
-    validBox    = m_domain.domainBox();
-    particleBox = Box(IntVect::Zero, IntVect::Zero);
+    validBox  = m_domain.domainBox();
+    gatherBox = Box(IntVect::Zero, IntVect::Zero);
 
     break;
   }
-
   case DepositionType::CIC: {
-    validBox    = grow(validBox, -1);
-    particleBox = Box(IntVect::Zero, IntVect::Unit);
+    validBox  = grow(m_domain.domainBox(), -1);
+    gatherBox = Box(IntVect::Zero, IntVect::Unit);
 
     break;
   }
   case DepositionType::TSC: {
-    validBox    = grow(validBox, -2);
-    particleBox = Box(IntVect::Zero, 2 * IntVect::Unit);
+    validBox  = grow(m_domain.domainBox(), -2);
+    gatherBox = Box(IntVect::Zero, 2 * IntVect::Unit);
 
     break;
   }
@@ -184,7 +188,7 @@ EBParticleMesh::interpolate(List<P>&             a_particleList,
       auto&&      w = (p.*MemberFunc)();
       const auto& x = p.position();
 
-      this->interpolateParticleCIC(GetPointer{}(w), a_meshData, validBox, particleBox, x, numComp, a_forceIrregNGP);
+      this->interpolateParticleCIC(GetPointer{}(w), a_meshData, validBox, gatherBox, x, numComp, a_forceIrregNGP);
     }
 
     break;
@@ -195,7 +199,7 @@ EBParticleMesh::interpolate(List<P>&             a_particleList,
       auto&&      w = (p.*MemberFunc)();
       const auto& x = p.position();
 
-      this->interpolateParticleTSC(GetPointer{}(w), a_meshData, validBox, particleBox, x, numComp, a_forceIrregNGP);
+      this->interpolateParticleTSC(GetPointer{}(w), a_meshData, validBox, gatherBox, x, numComp, a_forceIrregNGP);
     }
 
     break;
@@ -352,13 +356,15 @@ inline void
 EBParticleMesh::interpolateParticleCIC(Real*            a_particleField,
                                        const EBCellFAB& a_meshData,
                                        const Box&       a_validBox,
-                                       const Box&       a_cicBox,
+                                       const Box&       a_gatherBox,
                                        const RealVect&  a_position,
                                        const int&       a_numComp,
                                        const bool       a_forceIrregNGP) const noexcept
 {
   CH_TIME("EBParticleMesh::interpolateParticleCIC");
 
+  // particleIV is the cell index where the particle center lies.
+  // loIndex is the cell index of the lower-left corner of the particle.
   const IntVect particleIV = ParticleOps::getParticleCellIndex(a_position, m_probLo, m_dx);
   const IntVect loIndex    = ParticleOps::getParticleCellIndex(a_position - 0.5 * m_dx, m_probLo, m_dx);
 
@@ -378,7 +384,7 @@ EBParticleMesh::interpolateParticleCIC(Real*            a_particleField,
       a_particleField[comp] = meshData(particleIV, comp);
     }
   }
-  else if (m_ebisbox.isRegular(particleIV)) {
+  else if (!(m_ebisbox.isCovered(particleIV))) {
     auto cicKernel = [&](const IntVect& iv) -> void {
       Real weight = 1.0;
 
@@ -393,9 +399,9 @@ EBParticleMesh::interpolateParticleCIC(Real*            a_particleField,
       }
     };
 
-    const Box particleBox = a_cicBox + particleIV;
+    const Box gatherBox = a_gatherBox + loIndex;
 
-    BoxLoops::loop(particleBox, cicKernel);
+    BoxLoops::loop(gatherBox, cicKernel);
   }
 }
 
@@ -403,13 +409,15 @@ inline void
 EBParticleMesh::interpolateParticleTSC(Real*            a_particleField,
                                        const EBCellFAB& a_meshData,
                                        const Box&       a_validBox,
-                                       const Box&       a_particleBox,
+                                       const Box&       a_gatherBox,
                                        const RealVect&  a_position,
                                        const int&       a_numComp,
                                        const bool       a_forceIrregNGP) const noexcept
 {
   CH_TIME("EBParticleMesh::interpolateParticleTSC");
 
+  // particleIV is the cell index where the particle center lies.
+  // loIndex is the cell index of the lower-left corner of the particle.
   const IntVect particleIV = ParticleOps::getParticleCellIndex(a_position, m_probLo, m_dx);
   const IntVect loIndex    = ParticleOps::getParticleCellIndex(a_position - m_dx, m_probLo, m_dx);
 
@@ -429,7 +437,7 @@ EBParticleMesh::interpolateParticleTSC(Real*            a_particleField,
       a_particleField[comp] = meshData(particleIV, comp);
     }
   }
-  else if (m_ebisbox.isRegular(particleIV)) {
+  else if (!(m_ebisbox.isCovered(particleIV))) {
     auto tscKernel = [&](const IntVect& iv) -> void {
       Real weight = 1.0;
 
@@ -451,9 +459,9 @@ EBParticleMesh::interpolateParticleTSC(Real*            a_particleField,
       }
     };
 
-    const Box particleBox = a_particleBox + particleIV;
+    const Box gatherBox = a_gatherBox + loIndex;
 
-    BoxLoops::loop(particleBox, tscKernel);
+    BoxLoops::loop(gatherBox, tscKernel);
   }
 }
 


### PR DESCRIPTION
# Summary

Fix a bug where the interpolation scheme would always default to NGP.

### Background

PR #565 was a major refactor of the particle-mesh functionality. When I rewrote the interpolation kernels I did not pass in an initialized box for the valid interpolation region for the particle. This caused all interpolations to occur with an NGP scheme.

### Solution

Initialized the box. During a code review I also noticed that the particle would gather the field from the incorrect region, potentially reaching outside of the domain, even. 

### Side-effects

None that I can think of. Hopefully this will improve things.

### Alternative solutions 

None considered.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
