### PR TITLE
Improved accuracy for capacitance calculation

### DIFF
--- a/Source/Electrostatics/CD_FieldSolver.H
+++ b/Source/Electrostatics/CD_FieldSolver.H
@@ -437,7 +437,8 @@ public:
   /*!
     @brief Compute the capacitance. 
     @details This will first obtain a solution without any sources, and then compute the energy density. The capacitance is then C = 2*EnergyDensity/(V*V)
-    @return Capacitance for system. 
+    @return Capacitance for system.
+    @note This will set up a new solve and change the underlying solver coefficients. Use with caution!
   */
   Real
   computeCapacitance();


### PR DESCRIPTION
# Summary

Upgrade the capacitance calculation so it integrates over valid cells on the finest level.

### Background

The old capacitance calculation in FieldSolver would restrict onto the coarsest AMR level and then perform the integration when computing the capacitance as 0.5CV^2 = \int E*D dV. 

### Solution

Replace the integration by an integration on the valid cells -- this avoids summing contributions from cells that are covered by a finer level.

### Side-effects

None.

### Alternative solutions 

None.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
