### PR TITLE
Switch to collective MPI scatter for particle remapping

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,4 +15,5 @@
 - [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
 - [ ] I have added all relevant user documentation to Sphinx.
 - [ ] I have added all relevant APIs to the doxygen documentation.
+- [ ] I have run CheckDocs.py and fixed potentially broken literalincludes
 - [ ] I have added appropriate labels to this PR

--- a/Exec/Examples/ItoKMC/AirBasic/example.inputs
+++ b/Exec/Examples/ItoKMC/AirBasic/example.inputs
@@ -44,7 +44,7 @@ Driver.checkpoint_interval          = 50                  ## Checkpoint interval
 Driver.regrid_interval              = 2                   ## Regrid interval
 Driver.write_regrid_files           = false               ## Write regrid files or not.
 Driver.write_restart_files          = false               ## Write restart files or not
-Driver.initial_regrids              = 3                   ## Number of initial regrids
+Driver.initial_regrids              = 6                   ## Number of initial regrids
 Driver.do_init_load_balance         = false               ## If true, load balance the first step in a fresh simulation.
 Driver.start_time                   = 0                   ## Start time (fresh simulations only)
 Driver.stop_time                    = 100E-9              ## Stop time
@@ -293,6 +293,6 @@ ItoKMCStreamerTagger.buffer            = 4              ## Grow tagged cells
 
 ItoKMCStreamerTagger.refine_curvature      = 1.E99    ## Curvature refinement
 ItoKMCStreamerTagger.coarsen_curvature     = 1.E99    ## Curvature coarsening
-ItoKMCStreamerTagger.refine_alpha          = 1.0      ## Set alpha refinement. Lower  => More mesh
+ItoKMCStreamerTagger.refine_alpha          = 0.8      ## Set alpha refinement. Lower  => More mesh
 ItoKMCStreamerTagger.coarsen_alpha         = 0.1      ## Set alpha coarsening. Higher => Less mesh
 ItoKMCStreamerTagger.max_coarsen_lvl       = 4        ## Set max coarsening depth

--- a/Source/Particle/CD_ParticleContainer.H
+++ b/Source/Particle/CD_ParticleContainer.H
@@ -686,8 +686,8 @@ protected:
     @param[inout] a_unmappedParticles Particles that are not mapped (yet)
   */
   inline void
-  mapParticlesToAMRGrid(std::vector<std::map<std::pair<unsigned int, unsigned int>, List<P>>>& a_mappedParticles,
-                        List<P>& a_unmappedParticles) const noexcept;
+  mapParticlesToAMRGrid(std::vector<ParticleMap<List<P>>>& a_mappedParticles,
+                        List<P>&                           a_unmappedParticles) const noexcept;
 
   /*!
     @brief Catenate the particles. This is usually called within OpenMP parallel regions.
@@ -695,9 +695,8 @@ protected:
     @param[inout] a_localParticles Local particle map
    */
   inline void
-  catenateParticleMaps(
-    std::vector<std::map<std::pair<unsigned int, unsigned int>, List<P>>>& a_globalParticles,
-    std::vector<std::map<std::pair<unsigned int, unsigned int>, List<P>>>& a_localParticles) const noexcept;
+  catenateParticleMaps(std::vector<ParticleMap<List<P>>>& a_globalParticles,
+                       std::vector<ParticleMap<List<P>>>& a_localParticles) const noexcept;
 
   /*!
     @brief Gather particles locally
@@ -705,8 +704,7 @@ protected:
     @param[inout] a_particleData Where to assign the mapped particles
   */
   inline void
-  assignLocalParticles(std::map<std::pair<unsigned int, unsigned int>, List<P>>& a_mappedParticles,
-                       AMRParticles<P>&                                          a_particleData) const noexcept;
+  assignLocalParticles(ParticleMap<List<P>>& a_mappedParticles, AMRParticles<P>& a_particleData) const noexcept;
 };
 
 #include <CD_NamespaceFooter.H>

--- a/Source/Particle/CD_ParticleContainer.H
+++ b/Source/Particle/CD_ParticleContainer.H
@@ -25,6 +25,7 @@
 // Our includes
 #include <CD_OpenMP.H>
 #include <CD_LevelTiles.H>
+#include <CD_ParticleMap.H>
 #include <CD_NamespaceHeader.H>
 
 /*!

--- a/Source/Particle/CD_ParticleContainerImplem.H
+++ b/Source/Particle/CD_ParticleContainerImplem.H
@@ -12,6 +12,8 @@
 #ifndef CD_ParticleContainerImplem_H
 #define CD_ParticleContainerImplem_H
 
+#warning "The particle map we send should probably be ParticleMap<std::vector<P>> rather than List<P>"
+
 // Std includes
 #include <bitset>
 
@@ -564,12 +566,12 @@ ParticleContainer<P>::addParticles(const List<P>& a_particles)
   // TLDR: This routine is almost a precise copy of the remap routine, with the exception that the particles to be remapped
   //       are only the input particles rather than everything inside m_particles
 
-  const unsigned int numRanks = numProc();
-  const unsigned int myRank   = procID();
+  const uint32_t numRanks = numProc();
+  const uint32_t myRank   = procID();
 
-  using LevelAndIndex = std::pair<unsigned int, unsigned int>;
+  using LevelAndIndex = std::pair<uint32_t, uint32_t>;
 
-  std::vector<std::map<LevelAndIndex, List<P>>> particlesToSend(numRanks);
+  std::vector<ParticleMap<List<P>>> particlesToSend(numRanks);
 
 #pragma omp parallel
   {
@@ -580,7 +582,7 @@ ParticleContainer<P>::addParticles(const List<P>& a_particles)
       outcasts.join(a_particles);
     }
 
-    std::vector<std::map<LevelAndIndex, List<P>>> threadLocalParticlesToSend(numRanks);
+    std::vector<ParticleMap<List<P>>> threadLocalParticlesToSend(numRanks);
 
     // Collect particles owned by this rank/thread.
     this->transferParticlesToSingleList(outcasts, m_particles);
@@ -598,7 +600,7 @@ ParticleContainer<P>::addParticles(const List<P>& a_particles)
 
   // If using MPI then we have to scatter the particles across MPI ranks.
 #ifdef CH_MPI
-  std::map<LevelAndIndex, List<P>> receivedParticles;
+  ParticleMap<List<P>> receivedParticles;
 
   ParticleOps::scatterParticles(receivedParticles, particlesToSend);
 
@@ -630,12 +632,12 @@ ParticleContainer<P>::addParticlesDestructive(List<P>& a_particles)
   // TLDR: This routine is almost a precise copy of the remap routine, with the exception that the particles to be remapped
   //       are only the input particles rather than everything inside m_particles
 
-  const unsigned int numRanks = numProc();
-  const unsigned int myRank   = procID();
+  const uint32_t numRanks = numProc();
+  const uint32_t myRank   = procID();
 
-  using LevelAndIndex = std::pair<unsigned int, unsigned int>;
+  using LevelAndIndex = std::pair<uint32_t, uint32_t>;
 
-  std::vector<std::map<LevelAndIndex, List<P>>> particlesToSend(numRanks);
+  std::vector<ParticleMap<List<P>>> particlesToSend(numRanks);
 
 #pragma omp parallel
   {
@@ -646,7 +648,7 @@ ParticleContainer<P>::addParticlesDestructive(List<P>& a_particles)
       outcasts.catenate(a_particles);
     }
 
-    std::vector<std::map<LevelAndIndex, List<P>>> threadLocalParticlesToSend(numRanks);
+    std::vector<ParticleMap<List<P>>> threadLocalParticlesToSend(numRanks);
 
     // Collect particles owned by this rank/thread.
     this->transferParticlesToSingleList(outcasts, m_particles);
@@ -664,7 +666,7 @@ ParticleContainer<P>::addParticlesDestructive(List<P>& a_particles)
 
   // If using MPI then we have to scatter the particles across MPI ranks.
 #ifdef CH_MPI
-  std::map<LevelAndIndex, List<P>> receivedParticles;
+  ParticleMap<List<P>> receivedParticles;
 
   ParticleOps::scatterParticles(receivedParticles, particlesToSend);
 
@@ -778,18 +780,18 @@ ParticleContainer<P>::addParticles(const ParticleContainer<P>& a_otherContainer)
     // If we're adding particles across realms we need to collect the input particles onto lists that get remapped
     // into m_particles. A full explanation of how this works is given in the remap routin.
 
-    const unsigned int numRanks = numProc();
-    const unsigned int myRank   = procID();
+    const uint32_t numRanks = numProc();
+    const uint32_t myRank   = procID();
 
-    using LevelAndIndex = std::pair<unsigned int, unsigned int>;
+    using LevelAndIndex = std::pair<uint32_t, uint32_t>;
 
-    std::vector<std::map<LevelAndIndex, List<P>>> particlesToSend(numRanks);
+    std::vector<ParticleMap<List<P>>> particlesToSend(numRanks);
 
 #pragma omp parallel
     {
       List<P> outcasts;
 
-      std::vector<std::map<LevelAndIndex, List<P>>> threadLocalParticlesToSend(numRanks);
+      std::vector<ParticleMap<List<P>>> threadLocalParticlesToSend(numRanks);
 
       // Collect particles owned by this rank/thread, but on the other realm.
       a_otherContainer.copyParticlesToSingleList(outcasts, a_otherContainer.getParticles());
@@ -807,7 +809,7 @@ ParticleContainer<P>::addParticles(const ParticleContainer<P>& a_otherContainer)
 
     // If using MPI then we have to scatter the particles across MPI ranks.
 #ifdef CH_MPI
-    std::map<LevelAndIndex, List<P>> receivedParticles;
+    ParticleMap<List<P>> receivedParticles;
 
     ParticleOps::scatterParticles(receivedParticles, particlesToSend);
 
@@ -865,18 +867,18 @@ ParticleContainer<P>::addParticlesDestructive(ParticleContainer<P>& a_otherConta
     // If we're adding particles across realms we need to collect the input particles onto lists that get remapped
     // into m_particles. A full explanation of how this works is given in the remap routin.
 
-    const unsigned int numRanks = numProc();
-    const unsigned int myRank   = procID();
+    const uint32_t numRanks = numProc();
+    const uint32_t myRank   = procID();
 
-    using LevelAndIndex = std::pair<unsigned int, unsigned int>;
+    using LevelAndIndex = std::pair<uint32_t, uint32_t>;
 
-    std::vector<std::map<LevelAndIndex, List<P>>> particlesToSend(numRanks);
+    std::vector<ParticleMap<List<P>>> particlesToSend(numRanks);
 
 #pragma omp parallel
     {
       List<P> outcasts;
 
-      std::vector<std::map<LevelAndIndex, List<P>>> threadLocalParticlesToSend(numRanks);
+      std::vector<ParticleMap<List<P>>> threadLocalParticlesToSend(numRanks);
 
       // Collect particles owned by this rank/thread, but on the other realm.
       a_otherContainer.transferParticlesToSingleList(outcasts, a_otherContainer.getParticles());
@@ -894,7 +896,7 @@ ParticleContainer<P>::addParticlesDestructive(ParticleContainer<P>& a_otherConta
 
     // If using MPI then we have to scatter the particles across MPI ranks.
 #ifdef CH_MPI
-    std::map<LevelAndIndex, List<P>> receivedParticles;
+    ParticleMap<List<P>> receivedParticles;
 
     ParticleOps::scatterParticles(receivedParticles, particlesToSend);
 
@@ -987,21 +989,21 @@ ParticleContainer<P>::remap()
   //    5) If using MPI, scatter the particles to the appropriate ranks.
   //    6) Assign particles locally from the particles that were scattered to this rank.
 
-  const unsigned int numRanks = numProc();
-  const unsigned int myRank   = procID();
+  const uint32_t numRanks = numProc();
+  const uint32_t myRank   = procID();
 
-  using LevelAndIndex = std::pair<unsigned int, unsigned int>;
+  using LevelAndIndex = std::pair<uint32_t, uint32_t>;
 
   // These are the particles that get sent to each MPI rank. The pair contains the grid level and grid index.
   // Each MPI rank (and OpenMP thread) goes through it's particles and checks if they've falled off the grid. If they have,
   // then the particles are moved onto appropriate lists that will get sent to each rank.
-  std::vector<std::map<LevelAndIndex, List<P>>> particlesToSend(numRanks);
+  std::vector<ParticleMap<List<P>>> particlesToSend(numRanks);
 
 #pragma omp parallel
   {
     List<P> outcasts;
 
-    std::vector<std::map<LevelAndIndex, List<P>>> threadLocalParticlesToSend(numRanks);
+    std::vector<ParticleMap<List<P>>> threadLocalParticlesToSend(numRanks);
 
     // Collect particles owned by this rank/thread.
     this->transferParticlesToSingleList(outcasts, m_particles);
@@ -1019,7 +1021,7 @@ ParticleContainer<P>::remap()
 
   // If using MPI then we have to scatter the particles across MPI ranks.
 #ifdef CH_MPI
-  std::map<LevelAndIndex, List<P>> receivedParticles;
+  ParticleMap<List<P>> receivedParticles;
 
   ParticleOps::scatterParticles(receivedParticles, particlesToSend);
 
@@ -1107,14 +1109,13 @@ ParticleContainer<P>::copyParticlesToSingleList(List<P>& a_list, const AMRPartic
 
 template <typename P>
 inline void
-ParticleContainer<P>::mapParticlesToAMRGrid(
-  std::vector<std::map<std::pair<unsigned int, unsigned int>, List<P>>>& a_mappedParticles,
-  List<P>&                                                               a_unmappedParticles) const noexcept
+ParticleContainer<P>::mapParticlesToAMRGrid(std::vector<ParticleMap<List<P>>>& a_mappedParticles,
+                                            List<P>&                           a_unmappedParticles) const noexcept
 {
   CH_TIME("ParticleContainer::mapParticlesToAMRGrid");
 
-  const unsigned int numRanks = numProc();
-  const unsigned int myRank   = procID();
+  const uint32_t numRanks = numProc();
+  const uint32_t myRank   = procID();
 
   std::vector<RealVect> quasiDx(1 + m_finestLevel);
 
@@ -1135,20 +1136,20 @@ ParticleContainer<P>::mapParticlesToAMRGrid(
 
       if (myLevelTiles.find(particleTile) != myLevelTiles.end()) {
         // Found the particle on this level and this rank is the one who owns it.
-        const unsigned int gridIndex = myLevelTiles.at(particleTile);
-        const unsigned int toRank    = myRank;
+        const uint32_t gridIndex = myLevelTiles.at(particleTile);
+        const uint32_t toRank    = myRank;
 
-        a_mappedParticles[toRank][std::pair<unsigned int, unsigned int>(lvl, gridIndex)].transfer(lit);
+        a_mappedParticles[toRank][std::pair<uint32_t, uint32_t>(lvl, gridIndex)].transfer(lit);
 
         foundTile = true;
       }
 #ifdef CH_MPI
       else if (otherLevelTiles.find(particleTile) != otherLevelTiles.end()) {
         // Particle was found on this level but no on this rank.
-        const unsigned int  gridIndex = otherLevelTiles.at(particleTile).first;
-        const unsigned int& toRank    = otherLevelTiles.at(particleTile).second;
+        const uint32_t  gridIndex = otherLevelTiles.at(particleTile).first;
+        const uint32_t& toRank    = otherLevelTiles.at(particleTile).second;
 
-        a_mappedParticles[toRank][std::pair<unsigned int, unsigned int>(lvl, gridIndex)].transfer(lit);
+        a_mappedParticles[toRank][std::pair<uint32_t, uint32_t>(lvl, gridIndex)].transfer(lit);
 
         foundTile = true;
       }
@@ -1167,18 +1168,17 @@ ParticleContainer<P>::mapParticlesToAMRGrid(
 
 template <typename P>
 inline void
-ParticleContainer<P>::catenateParticleMaps(
-  std::vector<std::map<std::pair<unsigned int, unsigned int>, List<P>>>& a_globalParticles,
-  std::vector<std::map<std::pair<unsigned int, unsigned int>, List<P>>>& a_localParticles) const noexcept
+ParticleContainer<P>::catenateParticleMaps(std::vector<ParticleMap<List<P>>>& a_globalParticles,
+                                           std::vector<ParticleMap<List<P>>>& a_localParticles) const noexcept
 {
   CH_TIME("ParticleContainer::catenateParticleMaps");
 
-  const unsigned int numRanks = numProc();
+  const uint32_t numRanks = numProc();
 
-  using LevelAndIndex = std::pair<unsigned int, unsigned int>;
+  using LevelAndIndex = std::pair<uint32_t, uint32_t>;
 
   for (int irank = 0; irank < numRanks; irank++) {
-    std::map<LevelAndIndex, List<P>>& globalParticles = a_globalParticles[irank];
+    ParticleMap<List<P>>& globalParticles = a_globalParticles[irank];
 
     for (auto& m : a_localParticles[irank]) {
       globalParticles[m.first].catenate(m.second);
@@ -1188,8 +1188,8 @@ ParticleContainer<P>::catenateParticleMaps(
 
 template <typename P>
 inline void
-ParticleContainer<P>::assignLocalParticles(std::map<std::pair<unsigned int, unsigned int>, List<P>>& a_mappedParticles,
-                                           AMRParticles<P>& a_particleData) const noexcept
+ParticleContainer<P>::assignLocalParticles(ParticleMap<List<P>>& a_mappedParticles,
+                                           AMRParticles<P>&      a_particleData) const noexcept
 {
   CH_TIME("ParticleContainer::assignLocalParticles");
 
@@ -1200,9 +1200,9 @@ ParticleContainer<P>::assignLocalParticles(std::map<std::pair<unsigned int, unsi
       for (auto mapIter = a_mappedParticles.begin(); mapIter != a_mappedParticles.end(); mapIter++) {
 #pragma omp task firstprivate(mapIter)
         {
-          const unsigned int gridLevel = mapIter->first.first;
-          const unsigned int gridIndex = mapIter->first.second;
-          const DataIndex    din       = m_levelTiles[gridLevel]->getMyGrids().at(gridIndex);
+          const uint32_t  gridLevel = mapIter->first.first;
+          const uint32_t  gridIndex = mapIter->first.second;
+          const DataIndex din       = m_levelTiles[gridLevel]->getMyGrids().at(gridIndex);
 
           List<P>& particles   = mapIter->second;
           List<P>& myParticles = (*a_particleData[gridLevel])[din].listItems();
@@ -1297,21 +1297,21 @@ ParticleContainer<P>::regrid(const Vector<DisjointBoxLayout>&         a_grids,
   this->setupParticleData(a_lmin, m_finestLevel);
 
   // Perform the remapping operation.
-  const unsigned int numRanks = numProc();
-  const unsigned int myRank   = procID();
+  const uint32_t numRanks = numProc();
+  const uint32_t myRank   = procID();
 
-  using LevelAndIndex = std::pair<unsigned int, unsigned int>;
+  using LevelAndIndex = std::pair<uint32_t, uint32_t>;
 
   // These are the particles that get sent to each MPI rank. The pair contains the grid level and grid index.
   // Each MPI rank (and OpenMP thread) goes through it's particles and checks if they've falled off the grid. If they have,
   // then the particles are moved onto appropriate lists that will get sent to each rank.
-  std::vector<std::map<LevelAndIndex, List<P>>> particlesToSend(numRanks);
+  std::vector<ParticleMap<List<P>>> particlesToSend(numRanks);
 
 #pragma omp parallel
   {
     List<P> outcasts;
 
-    std::vector<std::map<LevelAndIndex, List<P>>> threadLocalParticlesToSend(numRanks);
+    std::vector<ParticleMap<List<P>>> threadLocalParticlesToSend(numRanks);
 
     // Collect particles owned by this rank/thread.
     this->transferParticlesToSingleList(outcasts, m_cacheParticles);
@@ -1329,7 +1329,7 @@ ParticleContainer<P>::regrid(const Vector<DisjointBoxLayout>&         a_grids,
 
   // If using MPI then we have to scatter the particles across MPI ranks.
 #ifdef CH_MPI
-  std::map<LevelAndIndex, List<P>> receivedParticles;
+  ParticleMap<List<P>> receivedParticles;
 
   ParticleOps::scatterParticles(receivedParticles, particlesToSend);
 

--- a/Source/Particle/CD_ParticleMap.H
+++ b/Source/Particle/CD_ParticleMap.H
@@ -1,0 +1,76 @@
+/* chombo-discharge
+ * Copyright © 2021 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_ParticleOpsImplem.H
+  @brief  Implementation of CD_ParticleOps.H
+  @author Robert Marskar
+*/
+
+#ifndef CD_ParticleMap_H
+#define CD_ParticleMap_H
+
+// Std includes
+#include <cstdint>
+#include <utility>
+#include <unordered_map>
+#include <map>
+
+// Our includes
+#include <CD_NamespaceHeader.H>
+
+// Compile-time sanity checks (optional but nice)
+static_assert(sizeof(uint32_t) == 4, "uint32_t must be 32 bits");
+static_assert(sizeof(uint64_t) == 8, "uint64_t must be 64 bits");
+static_assert(sizeof(size_t) == 8, "size_t must be 64 bits");
+
+/*!
+  @brief Function for encoding a pair of integers onto a 64-bit integer.
+  @param[in] a_level Level index
+  @param[in] a_gridIndex Grid index
+  @details Used for hash maps.
+*/
+static inline uint64_t
+encodePair(uint32_t a_level, uint32_t a_gridIndex) noexcept
+{
+  return (std::uint64_t(a_level) << 32) | std::uint64_t(a_gridIndex);
+}
+
+/*!
+  @brief Function for decoding a 64-bit integer into two integers.
+  @details Used for reversing hash maps.
+  @param[in] key Hash key as 64-bit integer. 
+*/
+static inline std::pair<uint32_t, uint32_t>
+decodePair(uint64_t key) noexcept
+{
+  return {uint32_t(key >> 32), uint32_t(key)};
+}
+
+/*!
+  @brief Simple pair-hashing struct for interfacing into unordered_map
+*/
+struct PairHash
+{
+  std::size_t
+  operator()(const std::pair<uint32_t, uint32_t>& p) const noexcept
+  {
+    return encodePair(p.first, p.second);
+  }
+};
+
+/*!
+  @brief Underlying particle map when gathering/scattering particles
+*/
+template <typename T>
+#if 0
+using ParticleMap = std::unordered_map<std::pair<uint32_t, uint32_t>, T, PairHash>;
+#else
+using ParticleMap = std::map<std::pair<unsigned int, unsigned int>, T>;
+#endif
+
+#include <CD_NamespaceFooter.H>
+
+#endif

--- a/Source/Particle/CD_ParticleMap.H
+++ b/Source/Particle/CD_ParticleMap.H
@@ -62,14 +62,11 @@ struct PairHash
 };
 
 /*!
-  @brief Underlying particle map when gathering/scattering particles
+  @brief Underlying particle map when gathering/scattering particles.
+  @detail This is a map that maps a list of particles to a specific grid level and grid patch.
 */
 template <typename T>
-#if 0
 using ParticleMap = std::unordered_map<std::pair<uint32_t, uint32_t>, T, PairHash>;
-#else
-using ParticleMap = std::map<std::pair<unsigned int, unsigned int>, T>;
-#endif
 
 #include <CD_NamespaceFooter.H>
 

--- a/Source/Particle/CD_ParticleOps.H
+++ b/Source/Particle/CD_ParticleOps.H
@@ -221,8 +221,6 @@ public:
   static inline void
   setValue(ParticleContainer<P>& a_particles, const RealVect a_value) noexcept;
 
-
-
 #ifdef CH_MPI
   /*!
     @brief Scatter particles across MPI ranks
@@ -235,8 +233,8 @@ public:
   */
   template <typename P>
   static inline void
-  scatterParticles(std::map<std::pair<unsigned int, unsigned int>, List<P>>&              a_receivedParticles,
-                   std::vector<std::map<std::pair<unsigned int, unsigned int>, List<P>>>& a_sentParticles) noexcept;
+  scatterParticles(ParticleMap<List<P>>&              a_receivedParticles,
+                   std::vector<ParticleMap<List<P>>>& a_sentParticles) noexcept;
 
 #endif
 };

--- a/Source/Particle/CD_ParticleOps.H
+++ b/Source/Particle/CD_ParticleOps.H
@@ -20,6 +20,7 @@
 
 // Our includes
 #include <CD_EBAMRData.H>
+#include <CD_ParticleMap.H>
 #include <CD_NamespaceHeader.H>
 
 template <typename P>
@@ -219,6 +220,8 @@ public:
   template <typename P, RealVect& (P::*particleVectorField)()>
   static inline void
   setValue(ParticleContainer<P>& a_particles, const RealVect a_value) noexcept;
+
+
 
 #ifdef CH_MPI
   /*!

--- a/Source/Particle/CD_ParticleOpsImplem.H
+++ b/Source/Particle/CD_ParticleOpsImplem.H
@@ -624,7 +624,7 @@ ParticleOps::scatterParticles(ParticleMap<List<P>>&              a_receivedParti
     std::vector<int> v(v64.size());
 
     for (size_t i = 0; i < v64.size(); ++i) {
-      CH_assert(v64[i] <= static_cast<u64>(std::numeric_limits<int>::max()));
+      CH_assert(v64[i] <= static_cast<uint64_t>(std::numeric_limits<int>::max()));
 
       v[i] = static_cast<int>(v64[i]);
     }

--- a/Source/Particle/CD_ParticleOpsImplem.H
+++ b/Source/Particle/CD_ParticleOpsImplem.H
@@ -12,6 +12,9 @@
 #ifndef CD_ParticleOpsImplem_H
 #define CD_ParticleOpsImplem_H
 
+// Std includes
+#include <cstdint>
+
 // Chombo includes
 #include <CH_Timer.H>
 #include <PolyGeom.H>
@@ -534,10 +537,10 @@ ParticleOps::scatterParticles(ParticleMap<List<P>>&              a_receivedParti
 
   const size_t linearSize = P().size();
 
-  std::vector<uint32_t> sendSizes(numProc(), 0);
-  std::vector<uint32_t> recvSizes(numProc(), 0);
+  std::vector<uint64_t> sendSizes(numProc(), 0);
+  std::vector<uint64_t> recvSizes(numProc(), 0);
 
-  // Figure out the size of a_sentParticles[irank]
+  // Figure out the size sent from this rank to other ranks.
   for (int irank = 0; irank < numRanks; irank++) {
     sendSizes[irank] = 0;
 
@@ -546,17 +549,18 @@ ParticleOps::scatterParticles(ParticleMap<List<P>>&              a_receivedParti
 
     // Size of particles along.
     for (const auto& m : particlesToRank) {
-      sendSizes[irank] += m.second.length();
+      sendSizes[irank] += (uint64_t)m.second.length();
     }
     sendSizes[irank] *= linearSize;
 
-    // Add in the map keys and the list length
+    // Send size = #particles * linearSize + level index (uint32_t) + grid index(uint32_t) + list length (size_t)
     sendSizes[irank] += particlesToRank.size() * (2 * sizeof(uint32_t) + sizeof(size_t));
   }
 
-  mpiErr = MPI_Alltoall(&sendSizes[0], 1, MPI_UNSIGNED, &recvSizes[0], 1, MPI_UNSIGNED, Chombo_MPI::comm);
+  // Collectively exchange send & receive sizes
+  mpiErr = MPI_Alltoall(&sendSizes[0], 1, MPI_UINT64_T, &recvSizes[0], 1, MPI_UINT64_T, Chombo_MPI::comm);
   if (mpiErr != MPI_SUCCESS) {
-    MayDay::Error("ParticleOps::scatterParticles - MPI communication error in MPI_AlltoAll");
+    MayDay::Error("ParticleOps::scatterParticles - MPI communication error in MPI_AlltoAll(1)");
   }
 
   // Sanity check
@@ -564,91 +568,103 @@ ParticleOps::scatterParticles(ParticleMap<List<P>>&              a_receivedParti
     MayDay::Error("ParticleOps::scatterParticles - 'recvSizes[procID()] != 0' failed");
   }
 
-  std::vector<MPI_Request> recvReq(numRanks - 1);
-  std::vector<char*>       recvBuf(numRanks, nullptr);
+  // Lambda for computing message displacements
+  auto computeDisplacements = [](const std::vector<uint64_t>& counts) -> std::vector<uint64_t> {
+    std::vector<uint64_t> displacements(counts.size(), 0);
 
-  std::vector<MPI_Request> sendReq(numRanks - 1);
-  std::vector<char*>       sendBuf(numRanks, nullptr);
-
-  int recvReqCount = 0;
-  int sendReqCount = 0;
-
-  for (int irank = 0; irank < numRanks; irank++) {
-    if (recvSizes[irank] > 0) {
-      recvBuf[irank] = new char[recvSizes[irank]];
-
-      MPI_Irecv(recvBuf[irank], recvSizes[irank], MPI_CHAR, irank, 1, Chombo_MPI::comm, &recvReq[recvReqCount]);
-
-      recvReqCount++;
+    for (size_t i = 1; i < counts.size(); i++) {
+      displacements[i] = displacements[i - 1] + counts[i - 1];
     }
-  }
 
-  // Pack data into buffers
+    return displacements;
+  };
+
+  const std::vector<uint64_t> sendDisplacements = computeDisplacements(sendSizes);
+  const std::vector<uint64_t> recvDisplacements = computeDisplacements(recvSizes);
+
+  const uint64_t totalSend = sendDisplacements.back() + sendSizes.back();
+  const uint64_t totalRecv = recvDisplacements.back() + recvSizes.back();
+
+  std::vector<char> sendBuffer(totalSend);
+  std::vector<char> recvBuffer(totalRecv);
+
+  // Pack data sent from this rank into buffers
   for (int irank = 0; irank < numRanks; irank++) {
-    if (sendSizes[irank] > 0) {
-      sendBuf[irank] = new char[sendSizes[irank]];
+    if (sendSizes[irank] == 0) {
+      continue;
+    }
 
-      char* data = sendBuf[irank];
+    char* data = sendBuffer.data() + sendDisplacements[irank];
 
-      const ParticleMap<List<P>>& particles = a_sentParticles[irank];
+    // Linearize each entry in the map onto the send buffer. We encode this by (level, index, list length, List<P>)
+    for (const auto& cur : a_sentParticles[irank]) {
 
-      // Linearize each entry in the map onto the send buffer. We encode this by (level, index, list length, List<P>)
-      for (const auto& cur : particles) {
+      // and grid index
+      *((uint32_t*)data) = cur.first.first;
+      data += sizeof(uint32_t);
+      *((uint32_t*)data) = cur.first.second;
+      data += sizeof(uint32_t);
 
-        // and grid index
-        *((uint32_t*)data) = cur.first.first;
-        data += sizeof(uint32_t);
-        *((uint32_t*)data) = cur.first.second;
-        data += sizeof(uint32_t);
+      // List length aka number of particles
+      *((size_t*)data) = cur.second.length();
+      data += sizeof(size_t);
 
-        // List length aka number of particles
-        *((size_t*)data) = cur.second.length();
-        data += sizeof(size_t);
+      // Linearize the particle list
+      for (ListIterator<P> lit(cur.second); lit.ok(); ++lit) {
+        const P& p = lit();
 
-        // Linearize the particle list
-        for (ListIterator<P> lit(cur.second); lit.ok(); ++lit) {
-          const P& p = lit();
-
-          p.linearOut((void*)data);
-          data += linearSize;
-        }
+        p.linearOut((void*)data);
+        data += linearSize;
       }
-
-      // Send from me to the other rank.
-      MPI_Isend(sendBuf[irank], sendSizes[irank], MPI_CHAR, irank, 1, Chombo_MPI::comm, &sendReq[sendReqCount]);
-
-      sendReqCount++;
     }
   }
 
-  std::vector<MPI_Status> recvStatus(numRanks - 1);
-  std::vector<MPI_Status> sendStatus(numRanks - 1);
+  // MPI requires stuff as int
+  auto uint64ToInt = [](const std::vector<uint64_t>& v64) -> std::vector<int> {
+    std::vector<int> v(v64.size());
 
-  if (sendReqCount > 0) {
-    mpiErr = MPI_Waitall(sendReqCount, &sendReq[0], &sendStatus[0]);
+    for (size_t i = 0; i < v64.size(); ++i) {
+      CH_assert(v64[i] <= static_cast<u64>(std::numeric_limits<int>::max()));
 
-    if (mpiErr != MPI_SUCCESS) {
-      MayDay::Error("ParticleOps::scatterParticles: send communication failed");
+      v[i] = static_cast<int>(v64[i]);
     }
+
+    return v;
+  };
+
+  std::vector<int> sendCounts = uint64ToInt(sendSizes);
+  std::vector<int> recvCounts = uint64ToInt(recvSizes);
+  std::vector<int> sendDispl  = uint64ToInt(sendDisplacements);
+  std::vector<int> recvDispl  = uint64ToInt(recvDisplacements);
+
+  mpiErr = MPI_Alltoallv(sendBuffer.data(),
+                         sendCounts.data(),
+                         sendDispl.data(),
+                         MPI_CHAR,
+                         recvBuffer.data(),
+                         recvCounts.data(),
+                         recvDispl.data(),
+                         MPI_CHAR,
+                         Chombo_MPI::comm);
+
+  if (mpiErr != MPI_SUCCESS) {
+    MayDay::Error("ParticleOps::scatterParticles - MPI communication error in MPI_AlltoAll(2)");
   }
 
-  if (recvReqCount > 0) {
-    mpiErr = MPI_Waitall(recvReqCount, &recvReq[0], &recvStatus[0]);
-
-    if (mpiErr != MPI_SUCCESS) {
-      MayDay::Error("ParticleOps::scatterParticles: receive communication failed");
-    }
-  }
-
-  // Unpack the send buffers
+  // Clear the send buffers.
   for (int irank = 0; irank < numRanks; irank++) {
-    P p;
+    a_sentParticles[irank].clear();
+  }
 
-    if (recvSizes[irank] > 0) {
+  // Unpack data
+  for (int irank = 0; irank < numRanks; irank++) {
+    if (recvSizes[irank] == 0) {
+      continue;
+    }
+    else {
+      char* data = recvBuffer.data() + recvDisplacements[irank];
 
-      char* data = recvBuf[irank];
-
-      uint32_t in = 0;
+      uint64_t in = 0;
 
       while (in < recvSizes[irank]) {
 
@@ -664,7 +680,9 @@ ParticleOps::scatterParticles(ParticleMap<List<P>>&              a_receivedParti
         data += sizeof(size_t);
 
         for (size_t ipart = 0; ipart < numParticles; ipart++) {
-          p.linearIn((void*)data);
+          P p;
+
+          p.linearIn(static_cast<void*>(data));
           data += linearSize;
 
           a_receivedParticles[std::pair<uint32_t, uint32_t>(lvl, idx)].add(p);
@@ -672,18 +690,6 @@ ParticleOps::scatterParticles(ParticleMap<List<P>>&              a_receivedParti
 
         in += 2 * sizeof(uint32_t) + sizeof(size_t) + numParticles * linearSize;
       }
-    }
-  }
-
-  // Delete buffers
-  for (int irank = 0; irank < numRanks; irank++) {
-    a_sentParticles[irank].clear();
-
-    if (sendSizes[irank] > 0) {
-      delete[] sendBuf[irank];
-    }
-    if (recvSizes[irank] > 0) {
-      delete[] recvBuf[irank];
     }
   }
 }

--- a/Source/Particle/CD_ParticleOpsImplem.H
+++ b/Source/Particle/CD_ParticleOpsImplem.H
@@ -23,6 +23,8 @@
 #include <CD_Random.H>
 #include <CD_NamespaceHeader.H>
 
+#warning "scatterParticles should use collectives rather than multiple small send messages"
+
 inline IntVect
 ParticleOps::getParticleCellIndex(const RealVect& a_particlePosition,
                                   const RealVect& a_probLo,
@@ -519,9 +521,8 @@ ParticleOps::setValue(ParticleContainer<P>& a_particles, const RealVect a_value)
 #ifdef CH_MPI
 template <typename P>
 inline void
-ParticleOps::scatterParticles(
-  std::map<std::pair<unsigned int, unsigned int>, List<P>>&              a_receivedParticles,
-  std::vector<std::map<std::pair<unsigned int, unsigned int>, List<P>>>& a_sentParticles) noexcept
+ParticleOps::scatterParticles(ParticleMap<List<P>>&              a_receivedParticles,
+                              std::vector<ParticleMap<List<P>>>& a_sentParticles) noexcept
 {
   CH_TIME("ParticleOps::scatterParticles");
 
@@ -533,15 +534,15 @@ ParticleOps::scatterParticles(
 
   const size_t linearSize = P().size();
 
-  std::vector<unsigned int> sendSizes(numProc(), 0);
-  std::vector<unsigned int> recvSizes(numProc(), 0);
+  std::vector<uint32_t> sendSizes(numProc(), 0);
+  std::vector<uint32_t> recvSizes(numProc(), 0);
 
   // Figure out the size of a_sentParticles[irank]
   for (int irank = 0; irank < numRanks; irank++) {
     sendSizes[irank] = 0;
 
     // Figure out the message size sent from this rank.
-    const std::map<std::pair<unsigned int, unsigned int>, List<P>>& particlesToRank = a_sentParticles[irank];
+    const ParticleMap<List<P>>& particlesToRank = a_sentParticles[irank];
 
     // Size of particles along.
     for (const auto& m : particlesToRank) {
@@ -550,7 +551,7 @@ ParticleOps::scatterParticles(
     sendSizes[irank] *= linearSize;
 
     // Add in the map keys and the list length
-    sendSizes[irank] += particlesToRank.size() * (2 * sizeof(unsigned int) + sizeof(size_t));
+    sendSizes[irank] += particlesToRank.size() * (2 * sizeof(uint32_t) + sizeof(size_t));
   }
 
   mpiErr = MPI_Alltoall(&sendSizes[0], 1, MPI_UNSIGNED, &recvSizes[0], 1, MPI_UNSIGNED, Chombo_MPI::comm);
@@ -589,16 +590,16 @@ ParticleOps::scatterParticles(
 
       char* data = sendBuf[irank];
 
-      const std::map<std::pair<unsigned int, unsigned int>, List<P>>& particles = a_sentParticles[irank];
+      const ParticleMap<List<P>>& particles = a_sentParticles[irank];
 
       // Linearize each entry in the map onto the send buffer. We encode this by (level, index, list length, List<P>)
       for (const auto& cur : particles) {
 
         // and grid index
-        *((unsigned int*)data) = cur.first.first;
-        data += sizeof(unsigned int);
-        *((unsigned int*)data) = cur.first.second;
-        data += sizeof(unsigned int);
+        *((uint32_t*)data) = cur.first.first;
+        data += sizeof(uint32_t);
+        *((uint32_t*)data) = cur.first.second;
+        data += sizeof(uint32_t);
 
         // List length aka number of particles
         *((size_t*)data) = cur.second.length();
@@ -647,16 +648,16 @@ ParticleOps::scatterParticles(
 
       char* data = recvBuf[irank];
 
-      unsigned int in = 0;
+      uint32_t in = 0;
 
       while (in < recvSizes[irank]) {
 
         // Level and grid index
-        unsigned int lvl = *((unsigned int*)data);
-        data += sizeof(unsigned int);
+        uint32_t lvl = *((uint32_t*)data);
+        data += sizeof(uint32_t);
 
-        unsigned int idx = *((unsigned int*)data);
-        data += sizeof(unsigned int);
+        uint32_t idx = *((uint32_t*)data);
+        data += sizeof(uint32_t);
 
         // List length aka number of particles
         size_t numParticles = *((size_t*)data);
@@ -666,10 +667,10 @@ ParticleOps::scatterParticles(
           p.linearIn((void*)data);
           data += linearSize;
 
-          a_receivedParticles[std::pair<unsigned int, unsigned int>(lvl, idx)].add(p);
+          a_receivedParticles[std::pair<uint32_t, uint32_t>(lvl, idx)].add(p);
         }
 
-        in += 2 * sizeof(unsigned int) + sizeof(size_t) + numParticles * linearSize;
+        in += 2 * sizeof(uint32_t) + sizeof(size_t) + numParticles * linearSize;
       }
     }
   }

--- a/Source/Particle/CD_ParticleOpsImplem.H
+++ b/Source/Particle/CD_ParticleOpsImplem.H
@@ -619,7 +619,7 @@ ParticleOps::scatterParticles(ParticleMap<List<P>>&              a_receivedParti
     }
   }
 
-  // MPI requires stuff as int
+  // MPI requires stuff as int -- make sure that we can convert properly
   auto uint64ToInt = [](const std::vector<uint64_t>& v64) -> std::vector<int> {
     std::vector<int> v(v64.size());
 


### PR DESCRIPTION
# Summary

This PR replaces the particle scatter functionality to use collectives (MPI_Alltoallv) rather than single-message sends from each rank. This is supposedly good when running things at scale (1k cores and above).

Closes #589 

### Background

The previous particle scatter routine would use individual send/receive requests, which can swamp the bandwidth when running things at large scale, despite the fact that the were non-blocking (MPI_Isend). 

### Solution

Replace the peer-to-peer communication by a single MPI collective (MPI_alltoall). This is blocking, since I can't figure out any way of squeezing actual communication-overlapping work into this relic of a framework. 

### Side-effects

Accidental bugs or other types of conflicts (looking at you, 32-bit systems).

### Alternative solutions 

None considered (yet).

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR
