### PR TITLE
Minor fix in initializer functions

### DIFF
--- a/Source/Driver/CD_Initialize.H
+++ b/Source/Driver/CD_Initialize.H
@@ -33,7 +33,7 @@
 /*!
   @brief Global chombo-discharge ParmParse input parameter object. This must have global lifetime.
 */
-extern ParmParse dischargeParser;
+extern ParmParse* dischargeParser;
 
 /*!
   @brief Global chombo-discharge input file name

--- a/Source/Driver/CD_Initialize.cpp
+++ b/Source/Driver/CD_Initialize.cpp
@@ -30,7 +30,7 @@
 #include <CD_NamespaceHeader.H>
 
 std::string dischargeInputFile;
-ParmParse   dischargeParser;
+ParmParse*  dischargeParser;
 
 #if defined(CH_USE_PETSC)
 PetscErrorCode
@@ -49,11 +49,10 @@ initialize(int argc, char* argv[])
 
   if (argc >= 2) {
     dischargeInputFile = argv[1];
-    dischargeParser.define(argc - 2, argv + 2, nullptr, argv[1]);
+    dischargeParser    = new ParmParse(argc - 2, argv + 2, nullptr, argv[1]);
   }
   else {
     dischargeInputFile = "<No file provided>";
-    dischargeParser.define(argc - 2, argv + 2, nullptr, nullptr);
   }
 
 #ifdef _OPENMP
@@ -118,6 +117,8 @@ int
 #endif
 finalize()
 {
+  delete dischargeParser;
+
   CH_TIMER_REPORT();
 
 #if defined(CH_USE_PETSC)


### PR DESCRIPTION
# Summary

Bug fix for ParmParse when exiting/finalizing chombo-discharge.

### Background

The ParmParse that is built in the initializer function would do a dirty exit when finalizing programs. 

### Solution

Properly delete ParmParse on exit.

### Side-effects

None.

### Alternative solutions 

None considered.

# Checklist

- [ ] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [ ] I have added all relevant user documentation to Sphinx.
- [ ] I have added all relevant APIs to the doxygen documentation.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes
- [x] I have added appropriate labels to this PR
