### PR TITLE
HDF5 bug fix in ItoKMCStepper

### DIFF
--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -1574,9 +1574,10 @@ ItoKMCStepper<I, C, R, F>::prePlot() noexcept
 
   if (numPhysicsPlotVars > 0) {
     m_amr->allocate(m_physicsPlotVariables, m_fluidRealm, m_plasmaPhase, numPhysicsPlotVars);
+
+    this->computePhysicsPlotVariables(m_physicsPlotVariables);
   }
 
-  this->computePhysicsPlotVariables(m_physicsPlotVariables);
   this->computeCurrentDensity(this->m_currentDensity);
   m_ito->depositParticles();
 }


### PR DESCRIPTION
# Summary

Fix an HDF5 bug in ItoKMCStepper when the user did not ask for any physics plot variables.

Closes #619 

### Background

ItoKMCStepper contained a bug where if the user did not ask for any plot variables, storage for the variables was never allocated (correct behavior). However, the calculation routine was still being called, which caused the code to reach into invalid memory.

### Solution

Move physics plot variable calculation within the if condition that checks if one actually have plot variables.

### Side-effects

None.

### Alternative solutions 

None considered.

# Checklist

- [ ] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [ ] I have added all relevant user documentation to Sphinx.
- [ ] I have added all relevant APIs to the doxygen documentation.
- [ ] I have run CheckDocs.py and fixed potentially broken literalincludes
- [ ] I have added appropriate labels to this PR
