### PR TITLE
Bug fix in DischargeInceptionStepper voltage sampling

### DIFF
--- a/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
+++ b/Physics/DischargeInception/CD_DischargeInceptionStepperImplem.H
@@ -2489,7 +2489,7 @@ DischargeInceptionStepper<P, F, C>::computeInceptionIntegralStationary() noexcep
   // Compute the critical field and the minimum possible inception voltage.
   const Real Ecrit = this->getCriticalField();
 
-  Real curVoltage = (1.0 + m_relativeDeltaU) * Ecrit / maxField;
+  Real curVoltage = m_relativeDeltaU * Ecrit / maxField;
   Real curMaxK    = 0.0;
   int  curIter    = 0;
 
@@ -2534,12 +2534,21 @@ DischargeInceptionStepper<P, F, C>::computeInceptionIntegralStationary() noexcep
 
     curMaxK = std::max(maxKPlus, maxKMinu);
 
-    // Figure out the next voltage.
+    // Figure out the next voltage. User linear extrapolation near the first point and log-linear otherwise.
     K2 = curMaxK;
     U2 = curVoltage;
 
-    const Real dKdU        = (K2 - K1) / (U2 - U1);
-    const Real nextVoltage = U1 + ((K2 - K1) + m_deltaK) / dKdU;
+    Real nextVoltage;
+    if (K1 <= 0.0) {
+      const Real dKdU = (K2 - K1) / (U2 - U1);
+
+      nextVoltage = U1 + ((K2 - K1) + m_deltaK) / dKdU;
+    }
+    else {
+      const Real dKdU = std::log(K2 / K1) / (U2 - U1);
+
+      nextVoltage = U1 + std::log((K2 + m_deltaK) / K1) / dKdU;
+    }
 
     K1 = K2;
     U1 = U2;

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -356,6 +356,10 @@ ItoKMCJSON::initializeGasLaw()
 
     this->throwParserError(parseError);
   }
+
+  if (m_json["gas"]["law"].contains("plot")) {
+    m_plotGas = m_json["gas"]["law"]["plot"].get<bool>();
+  }
 }
 
 void


### PR DESCRIPTION
# Summary

This PR fixes a bug where the adaptive voltage sampling was unintentionally doubled. 

This PR also includes a fix in ItoKMCJSON where m_plotGas was not parsed correctly from the JSON file. Which makes we wonder why this worked at all in the past....

Closes #621 

### Background

In some simulations we observed that the DischargeInceptionStepper PDIV calculation would fail to obtain proper resolution of the ionization integral. This was tracked down to a bug in voltage sampling routine where the first voltage was doubled, rather than increased a small increment (typically 5-10%). 

### Solution

Remove the unwanted bug in the K-value sampling. I've also introduced log-linear sampling of the K-integral, and fixed the parser bug in ItoKMCJSON.

### Side-effects

None.

### Alternative solutions 

None considered.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes
- [x] I have added appropriate labels to this PR
