### PR TITLE
Add ItoKMCBackgroundEvaluator for evaluating changes in the background field

### DIFF
--- a/Physics/ItoKMC/TimeSteppers/ItoKMCBackgroundEvaluator/CD_ItoKMCBackgroundEvaluator.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCBackgroundEvaluator/CD_ItoKMCBackgroundEvaluator.H
@@ -1,0 +1,178 @@
+/* chombo-discharge
+ * Copyright © 2025 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_ItoKMCBackgroundEvaluator.H
+  @brief  File containing a subclass of ItoKMCGodunovStepper.
+  @author Robert Marskar
+*/
+
+#ifndef CD_ItoKMCBackgroundEvaluator_H
+#define CD_ItoKMCBackgroundEvaluator_H
+
+// Our includes
+#include <CD_ItoKMCGodunovStepper.H>
+#include <CD_NamespaceHeader.H>
+
+namespace Physics {
+  namespace ItoKMC {
+
+    /*!
+      @brief Implementation of ItoKMCGodunovStepper that also evaluates the background field at every regrid/time step.
+    */
+    template <typename I = ItoSolver, typename C = CdrCTU, typename R = McPhoto, typename F = FieldSolverGMG>
+    class ItoKMCBackgroundEvaluator : public ItoKMCGodunovStepper<I, C, R, F>
+    {
+    public:
+      /*!
+	@brief Constructor.
+	@param[in] a_physics Physics kernel that will be used.
+      */
+      ItoKMCBackgroundEvaluator(RefCountedPtr<ItoKMCPhysics>& a_physics) noexcept;
+
+      /*!
+	@brief Post-initialization operations. Computes the background field.
+      */
+      virtual void
+      postInitialize() noexcept override final;
+
+      /*!
+	@brief Post-regrid operations. Computes the background field.
+      */
+      virtual void
+      postRegrid() noexcept override final;
+
+      /*!
+	@brief Post-checkpoint operations. Computes the background field.
+      */
+      virtual void
+      postCheckpointSetup() noexcept override final;
+
+      /*!
+	@brief Print a new step report. This is the old one plus the maximum field change.
+      */
+      virtual void
+      printStepReport() noexcept override final;
+
+      /*!
+	@brief Overriden advance method.
+	@param[in] a_dt Time step
+      */
+      virtual Real
+      advance(const Real a_dt) override;
+
+      /*!
+	@brief Compute a time step used for the advance method
+	@note This function returns a zero value if space charge effects have set in, which lets Driver put plot files in the crash folder.
+      */
+      virtual Real
+      computeDt() override;
+
+    protected:
+      /*!
+	@brief Exit criterion for maximum field -- if the background field changes by this much the simulation is terminated.
+      */
+      Real m_maxFieldExitCrit;
+
+      /*!
+	@brief Exit criterion for relative field -- if the relative change in the background field in any cell changes by this much the simulation is terminated.
+      */
+      Real m_relFieldExitCrit;
+
+      /*!
+        @brief Initial time step size.
+        Introduced to limit the initial particles from moving to far in the initial timestep.
+
+        Default constructed to 0.0, which indicates normal operation.
+        */
+      Real m_maxInitialTimeStep;
+
+      /*!
+	@brief Change in max field.
+      */
+      Real m_maxFieldChange;
+
+      /*!
+	@brief Change in relative field.
+      */
+      Real m_relFieldChange;
+
+      /*!
+        @brief Total charge on the electrode, given by \int(eps*E dA)
+      */
+      Real m_electrodeCharge;
+
+      /*!
+        @brief Total charge that left through the electrode in the last time step.
+      */
+      Real m_ohmicCharge;
+
+      /*!
+        @brief Integrated optical emissions (phi)
+      */
+      Real m_sumOpticalPhi;
+
+      /*!
+        @brief Integrated optical emissions (source term)
+      */
+      Real m_sumOpticalSrc;
+
+      /*!
+        @brief Name of the optical solver
+      */
+      std::string m_opticalSolver;
+
+      /*!
+	@brief For storing the background field.
+	@details This field is space- and surface-charge free and is filled by computeBackgroundField
+      */
+      MFAMRCellData m_backgroundField;
+
+      /*!
+	@brief Computes the background field. I.e., it allocates and fills m_backgroundField.
+      */
+      virtual void
+      computeBackgroundField() noexcept;
+
+      /*!
+	@brief Evaluate the maximum change in the background field.
+	@return Returns a pair: relative change, maximum change
+      */
+      [[nodiscard]]
+      virtual std::pair<Real, Real>
+      evaluateSpaceChargeEffects() noexcept;
+
+      /*!
+        @brief Compute total charge on electrode
+        @details This returns \int(eps * E)*dA
+      */
+      [[nodiscard]]
+      virtual Real
+      integrateElectrodeSurfaceCharge() const noexcept;
+
+      /*!
+        @brief Compute the total ohmic current through the electrode.
+        @details This returns the total charge that left the electrode in the last time step.
+      */
+      [[nodiscard]]
+      virtual Real
+      integrateOhmicCharge() const noexcept;
+
+      /*!
+        @brief Integrate the sum of the optical excitations.
+        @details This returns the sum of the emissions, and the sum of the excitations.
+      */
+      [[nodiscard]]
+      virtual std::pair<Real, Real>
+      integrateOpticalExcitations() const noexcept;
+    };
+  } // namespace ItoKMC
+} // namespace Physics
+
+#include <CD_NamespaceFooter.H>
+
+#include <CD_ItoKMCBackgroundEvaluatorImplem.H>
+
+#endif

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCBackgroundEvaluator/CD_ItoKMCBackgroundEvaluator.options
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCBackgroundEvaluator/CD_ItoKMCBackgroundEvaluator.options
@@ -40,9 +40,7 @@ ItoKMCBackgroundEvaluator.rho_filter_max_stride                    = 1          
 ItoKMCBackgroundEvaluator.rho_filter_alpha                         = 0.5                ## Filtering factor (0.5 is a bilinear filter)
 ItoKMCBackgroundEvaluator.eb_tolerance                             = 0.0                ## EB intersection test tolerance
 ItoKMCBackgroundEvaluator.algorithm                                = euler_maruyama     ## Integration algorithm. 'euler_maruyama' or 'trapezoidal'
-
-# BackgroundEvaluator-specific options
-ItoKMCBackgroundEvaluator.max_field_exit_crit       = 1.E99    ## Exit if max field change (any cell) exceeds this (fraction)
-ItoKMCBackgroundEvaluator.rel_field_exit_crit       = 1.E99    ## Exit if relative field change (any cell) exceeds this (fraction)
-ItoKMCBackgroundEvaluator.optical_solver            = 2PN2     ## Name of optical CDR solver to track
-ItoKMCBackgroundEvaluator.max_initial_time_step     = 0.0      ## Max initial time step (0 = normal operation)
+ItoKMCBackgroundEvaluator.max_field_exit_crit                      = 1.E99              ## Exit if max field change (any cell) exceeds this (fraction)
+ItoKMCBackgroundEvaluator.rel_field_exit_crit                      = 1.E99              ## Exit if relative field change (any cell) exceeds this (fraction)
+ItoKMCBackgroundEvaluator.optical_solver                           = 2PN2               ## Name of optical CDR solver to track
+ItoKMCBackgroundEvaluator.max_initial_time_step                    = 0.0                ## Max initial time step (0 = normal operation)

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCBackgroundEvaluator/CD_ItoKMCBackgroundEvaluator.options
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCBackgroundEvaluator/CD_ItoKMCBackgroundEvaluator.options
@@ -1,0 +1,48 @@
+# ====================================================================================================
+# ItoKMCBackgroundEvaluator class options
+# ====================================================================================================
+ItoKMCBackgroundEvaluator.checkpoint_particles                     = true               ## If true, regrid on restart is supported (otherwise it's not)
+ItoKMCBackgroundEvaluator.verbosity                                = -1                 ## Verbosity
+ItoKMCBackgroundEvaluator.secondary_emission                       = after_reactions    ## When to emit secondary particles. Either 'before_reactions' or 'after_reactions'
+ItoKMCBackgroundEvaluator.abort_on_failure                         = true               ## Abort on Poisson solver failure or not
+ItoKMCBackgroundEvaluator.abort_max_field                          = 10000              ## Abort if reduced field exceeds this value
+ItoKMCBackgroundEvaluator.redistribute_cdr                         = true               ## Turn on/off reactive redistribution
+ItoKMCBackgroundEvaluator.profile                                  = false              ## Turn on/off run-time profiling
+ItoKMCBackgroundEvaluator.plt_vars                                 = current_density    ## 'conductivity', 'current_density', 'particles_per_patch'
+ItoKMCBackgroundEvaluator.dual_grid                                = true               ## Turn on/off dual-grid functionality
+ItoKMCBackgroundEvaluator.load_balance_fluid                       = false              ## Turn on/off fluid realm load balancing.
+ItoKMCBackgroundEvaluator.load_balance_particles                   = true               ## Turn on/off particle load balancing
+ItoKMCBackgroundEvaluator.load_indices                             = -1                 ## Which particle containers to use for load balancing (-1 => all)
+ItoKMCBackgroundEvaluator.load_per_cell                            = 1.0                ## Default load per grid cell.
+ItoKMCBackgroundEvaluator.box_sorting                              = morton             ## Box sorting when load balancing
+ItoKMCBackgroundEvaluator.particles_per_cell                       = 64                 ## Max computational particles per cell
+ItoKMCBackgroundEvaluator.merge_interval                           = 1                  ## Time steps between superparticle merging
+ItoKMCBackgroundEvaluator.regrid_superparticles                    = false              ## Make superparticles during regrids
+ItoKMCBackgroundEvaluator.physics_dt_factor                        = 1.0                ## Physics-based time step factor
+ItoKMCBackgroundEvaluator.min_particle_advection_cfl               = 0.0                ## Advective time step CFL restriction
+ItoKMCBackgroundEvaluator.max_particle_advection_cfl               = 1.0                ## Advective time step CFL restriction
+ItoKMCBackgroundEvaluator.min_particle_diffusion_cfl               = 0.0                ## Diffusive time step CFL restriction
+ItoKMCBackgroundEvaluator.max_particle_diffusion_cfl               = 1.E99              ## Diffusive time step CFL restriction
+ItoKMCBackgroundEvaluator.min_particle_advection_diffusion_cfl     = 0.0                ## Advection-diffusion time step CFL restriction
+ItoKMCBackgroundEvaluator.max_particle_advection_diffusion_cfl     = 1.E99              ## Advection-diffusion time step CFL restriction
+ItoKMCBackgroundEvaluator.fluid_advection_diffusion_cfl            = 0.5                ## Advection-diffusion time step CFL restriction
+ItoKMCBackgroundEvaluator.relax_dt_factor                          = 100.0              ## Relaxation time step restriction.
+ItoKMCBackgroundEvaluator.min_dt                                   = 0.0                ## Minimum permitted time step
+ItoKMCBackgroundEvaluator.max_dt                                   = 1.E99              ## Maximum permitted time step
+ItoKMCBackgroundEvaluator.max_growth_dt                            = 1.E99              ## Maximum permitted time step increase (dt * factor)
+ItoKMCBackgroundEvaluator.max_shrink_dt                            = 1.E99              ## Maximum permissible time step reduction (dt/factor)
+ItoKMCBackgroundEvaluator.extend_conductivity                      = true               ## Permit particles to live outside the EB to avoid bad gradients near EB
+ItoKMCBackgroundEvaluator.cond_filter_num                          = 0                  ## Number of filterings for conductivity
+ItoKMCBackgroundEvaluator.cond_filter_max_stride                   = 1                  ## Maximum stride for filter
+ItoKMCBackgroundEvaluator.cond_filter_alpha                        = 0.5                ## Filtering factor (0.5 is a bilinear filter)
+ItoKMCBackgroundEvaluator.rho_filter_num                           = 0                  ## Number of filterings for the space-density
+ItoKMCBackgroundEvaluator.rho_filter_max_stride                    = 1                  ## Maximum stride for filter
+ItoKMCBackgroundEvaluator.rho_filter_alpha                         = 0.5                ## Filtering factor (0.5 is a bilinear filter)
+ItoKMCBackgroundEvaluator.eb_tolerance                             = 0.0                ## EB intersection test tolerance
+ItoKMCBackgroundEvaluator.algorithm                                = euler_maruyama     ## Integration algorithm. 'euler_maruyama' or 'trapezoidal'
+
+# BackgroundEvaluator-specific options
+ItoKMCBackgroundEvaluator.max_field_exit_crit       = 1.E99    ## Exit if max field change (any cell) exceeds this (fraction)
+ItoKMCBackgroundEvaluator.rel_field_exit_crit       = 1.E99    ## Exit if relative field change (any cell) exceeds this (fraction)
+ItoKMCBackgroundEvaluator.optical_solver            = 2PN2     ## Name of optical CDR solver to track
+ItoKMCBackgroundEvaluator.max_initial_time_step     = 0.0      ## Max initial time step (0 = normal operation)

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCBackgroundEvaluator/CD_ItoKMCBackgroundEvaluatorImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCBackgroundEvaluator/CD_ItoKMCBackgroundEvaluatorImplem.H
@@ -1,0 +1,471 @@
+/* chombo-discharge
+ * Copyright © 2025 SINTEF Energy Research.
+ * Please refer to Copyright.txt and LICENSE in the chombo-discharge root directory.
+ */
+
+/*!
+  @file   CD_ItoKMCBackgroundEvaluatorImplem.H
+  @brief  Implementation of CD_ItoKMCBackgroundEvaluator.H
+  @author Robert Marskar
+*/
+
+#ifndef CD_ItoKMCBackgroundEvaluatorImplem_H
+#define CD_ItoKMCBackgroundEvaluatorImplem_H
+
+// Our includes
+#include <CD_ItoKMCBackgroundEvaluator.H>
+#include <CD_NamespaceHeader.H>
+
+using namespace Physics::ItoKMC;
+
+template <typename I, typename C, typename R, typename F>
+ItoKMCBackgroundEvaluator<I, C, R, F>::ItoKMCBackgroundEvaluator(RefCountedPtr<ItoKMCPhysics>& a_physics) noexcept
+  : ItoKMCGodunovStepper<I, C, R, F>(a_physics)
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::ItoKMCBackgroundEvaluator");
+
+  // Set default values
+  m_maxFieldExitCrit   = std::numeric_limits<Real>::max();
+  m_relFieldExitCrit   = std::numeric_limits<Real>::max();
+  m_maxFieldChange     = -1.0;
+  m_relFieldChange     = -1.0;
+  m_electrodeCharge    = 0.0;
+  m_ohmicCharge        = 0.0;
+  m_opticalSolver      = "2PN2";
+  m_maxInitialTimeStep = 0.0;
+
+  // Override the name and re-parse ALL options (ItoKMCStepper + GodunovStepper) using the new prefix
+  this->m_name = "ItoKMCBackgroundEvaluator";
+  this->parseOptions();
+
+  // Parse BackgroundEvaluator-specific options
+  ParmParse pp("ItoKMCBackgroundEvaluator");
+  pp.query("max_field_exit_crit", m_maxFieldExitCrit);
+  pp.query("rel_field_exit_crit", m_relFieldExitCrit);
+  pp.query("optical_solver", m_opticalSolver);
+  pp.query("max_initial_time_step", m_maxInitialTimeStep);
+}
+
+template <typename I, typename C, typename R, typename F>
+void
+ItoKMCBackgroundEvaluator<I, C, R, F>::postInitialize() noexcept
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::postInitialize");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::postInitialize" << endl;
+  }
+
+  ItoKMCGodunovStepper<I, C, R, F>::postInitialize();
+
+  this->computeBackgroundField();
+}
+
+template <typename I, typename C, typename R, typename F>
+void
+ItoKMCBackgroundEvaluator<I, C, R, F>::postRegrid() noexcept
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::postRegrid");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::postRegrid" << endl;
+  }
+
+  ItoKMCGodunovStepper<I, C, R, F>::postRegrid();
+
+  this->computeBackgroundField();
+}
+
+template <typename I, typename C, typename R, typename F>
+void
+ItoKMCBackgroundEvaluator<I, C, R, F>::postCheckpointSetup() noexcept
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::postCheckpointSetup");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::postCheckpointSetup" << endl;
+  }
+
+  ItoKMCGodunovStepper<I, C, R, F>::postCheckpointSetup();
+
+  this->computeBackgroundField();
+}
+
+template <typename I, typename C, typename R, typename F>
+Real
+ItoKMCBackgroundEvaluator<I, C, R, F>::advance(const Real a_dt)
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::advance");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::advance" << endl;
+  }
+
+  const Real actualDt = ItoKMCGodunovStepper<I, C, R, F>::advance(a_dt);
+
+  const std::pair<Real, Real> fieldChange      = this->evaluateSpaceChargeEffects();
+  const Real                  electrodeQ       = this->integrateElectrodeSurfaceCharge();
+  const Real                  ohmicQ           = this->integrateOhmicCharge();
+  const std::pair<Real, Real> opticalEmissions = this->integrateOpticalExcitations();
+
+  m_relFieldChange  = fieldChange.first;
+  m_maxFieldChange  = fieldChange.second;
+  m_electrodeCharge = electrodeQ;
+  m_ohmicCharge     = ohmicQ;
+  m_sumOpticalPhi   = opticalEmissions.first;
+  m_sumOpticalSrc   = opticalEmissions.second;
+
+  return actualDt;
+}
+
+template <typename I, typename C, typename R, typename F>
+Real
+ItoKMCBackgroundEvaluator<I, C, R, F>::computeDt()
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::computeDt");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::computeDt" << endl;
+  }
+
+  Real newDt = 0.0;
+
+  const bool noElectronsPresent = false;
+
+  bool abortCondition = false; // make sure all simultaneous abort reasons are stated in the log
+
+  if ((m_maxFieldChange > m_maxFieldExitCrit) && (m_maxFieldExitCrit > 0.0)) {
+    pout()
+      << "ItoKMCBackgroundEvaluator -- abort because the max field (in any cell) changed by more than specified threshold (max_field_exit_crit)"
+      << endl;
+    abortCondition = true;
+  }
+
+  if ((m_relFieldChange > m_relFieldExitCrit) && (m_relFieldExitCrit > 0.0)) {
+    pout()
+      << "ItoKMCBackgroundEvaluator -- abort because the relative field change in a cell is larger than specified threshold (rel_field_exit_crit)"
+      << endl;
+    abortCondition = true;
+  }
+
+  if (noElectronsPresent) { // Abort if we're out of electrons.
+    pout() << "ItoKMCBackgroundEvaluator -- abort because no electrons are present" << endl;
+    abortCondition = true;
+  }
+  if (abortCondition) {
+    newDt = 0.0;
+  }
+  else {
+    newDt = ItoKMCGodunovStepper<I, C, R, F>::computeDt();
+  }
+
+  if (this->m_timeStep == 0 && m_maxInitialTimeStep > 0.0 && newDt > m_maxInitialTimeStep)
+    newDt = m_maxInitialTimeStep;
+
+  return newDt;
+}
+
+template <typename I, typename C, typename R, typename F>
+void
+ItoKMCBackgroundEvaluator<I, C, R, F>::printStepReport() noexcept
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::printStepReport");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::printStepReport" << endl;
+  }
+
+  std::ios::fmtflags oldFlags = pout().flags();
+
+  ItoKMCGodunovStepper<I, C, R, F>::printStepReport();
+
+  // Append the step report.
+  const std::string whitespace = "                                   ";
+  pout().precision(12);
+  pout() << whitespace + "Delta E(max)      = " << 100.0 * m_maxFieldChange << " (%)" << endl;
+  pout() << whitespace + "Delta E(rel)      = " << 100.0 * m_relFieldChange << " (%)" << endl;
+  pout() << whitespace + "Q (electrode)     = " << std::scientific << m_electrodeCharge << " (C)" << endl;
+  pout() << whitespace + "Q (ohmic)         = " << std::scientific << m_ohmicCharge << " (C)" << endl;
+  pout() << whitespace + "Sum (phi_optical) = " << std::scientific << m_sumOpticalPhi << endl;
+  pout() << whitespace + "Sum (src_optical) = " << std::scientific << m_sumOpticalSrc << " (1/s)" << endl;
+
+  pout().flags(oldFlags);
+}
+
+template <typename I, typename C, typename R, typename F>
+void
+ItoKMCBackgroundEvaluator<I, C, R, F>::computeBackgroundField() noexcept
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::computeBackgroundField");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::computeBackgroundField" << endl;
+  }
+
+  // Allocate the background field, storage for the potential, storage for the space-charge, and storage for the
+  // surface charge.
+  MFAMRCellData phi;
+  MFAMRCellData rho;
+  EBAMRIVData   sigma;
+
+  (this->m_amr)->allocate(phi, this->m_fluidRealm, 1);
+  (this->m_amr)->allocate(rho, this->m_fluidRealm, 1);
+  (this->m_amr)->allocate(sigma, this->m_fluidRealm, this->m_plasmaPhase, 1);
+  (this->m_amr)->allocate(m_backgroundField, this->m_fluidRealm, SpaceDim);
+
+  // Copy the potential over from the field solver so we have a better initial guess for the potential. The
+  // space-charge and surface charge must be zero.
+  (this->m_amr)->copyData(phi, (this->m_fieldSolver)->getPotential());
+
+  DataOps::setValue(rho, 0.0);
+  DataOps::setValue(sigma, 0.0);
+
+  // Reset the field solver permittivities. Note that this discards the semi-implicit coefficients for the field update,
+  // but these are refilled on the next solver time step anyways.
+  (this->m_fieldSolver)->setPermittivities();
+
+  const MFAMRCellData& permCell = (this->m_fieldSolver)->getPermittivityCell();
+  const MFAMRFluxData& permFace = (this->m_fieldSolver)->getPermittivityFace();
+  const MFAMRIVData&   permEB   = (this->m_fieldSolver)->getPermittivityEB();
+
+  (this->m_fieldSolver)->setSolverPermittivities(permCell, permFace, permEB);
+
+  // Solve the damn thing, and then compute the electric field onto m_backgroundField.
+  (this->m_fieldSolver)->solve(phi, rho, sigma, false);
+  (this->m_fieldSolver)->computeElectricField(m_backgroundField, phi);
+}
+
+template <typename I, typename C, typename R, typename F>
+std::pair<Real, Real>
+ItoKMCBackgroundEvaluator<I, C, R, F>::evaluateSpaceChargeEffects() noexcept
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::evaluateSpaceChargeEffects");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::evaluateSpaceChargeEffects" << endl;
+  }
+
+  EBAMRCellData poissonNorm;
+  EBAMRCellData laplaceNorm;
+  EBAMRCellData poissonField;
+  EBAMRCellData laplaceField;
+  EBAMRCellData deltaE;
+
+  (this->m_amr)->allocate(poissonNorm, this->m_fluidRealm, this->m_plasmaPhase, 1);
+  (this->m_amr)->allocate(laplaceNorm, this->m_fluidRealm, this->m_plasmaPhase, 1);
+  (this->m_amr)->allocate(poissonField, this->m_fluidRealm, this->m_plasmaPhase, SpaceDim);
+  (this->m_amr)->allocate(laplaceField, this->m_fluidRealm, this->m_plasmaPhase, SpaceDim);
+  (this->m_amr)->allocate(deltaE, this->m_fluidRealm, this->m_plasmaPhase, 1);
+
+  // Get the fields in the plasma phase -- the actual field and the background field.
+  const MFAMRCellData electricField = (this->m_fieldSolver)->getElectricField();
+
+  DataOps::copy(poissonField, (this->m_amr)->alias(this->m_plasmaPhase, electricField));
+  DataOps::copy(laplaceField, (this->m_amr)->alias(this->m_plasmaPhase, m_backgroundField));
+
+  (this->m_amr)->interpToCentroids(poissonField, this->m_fluidRealm, this->m_plasmaPhase);
+  (this->m_amr)->interpToCentroids(laplaceField, this->m_fluidRealm, this->m_plasmaPhase);
+
+  // Compute the field magnitude, and then the relative change in field magnitude.
+  DataOps::vectorLength(poissonNorm, poissonField);
+  DataOps::vectorLength(laplaceNorm, laplaceField);
+
+  DataOps::copy(deltaE, poissonNorm);
+  DataOps::incr(deltaE, laplaceNorm, -1.0);
+  DataOps::divideFallback(deltaE, laplaceNorm, 0.0);
+
+  (this->m_amr)->arithmeticAverage(deltaE, this->m_fluidRealm, this->m_plasmaPhase);
+  (this->m_amr)->interpGhost(deltaE, this->m_fluidRealm, this->m_plasmaPhase);
+
+  // Iterate through the grid cells and figure out where the field change the most.
+  //
+  // PS: I'm doing this with a direct loop because DataOps::getMaxMin will do ALL cells, including ones that are
+  //     covered by a finer level. But we only want to evaluate the valid region.
+  Real relChange = -1.0;
+  Real maxChange = -1.0;
+
+  Real maxSpaceChargeField = 0.0;
+  Real minSpaceChargeField = 0.0;
+  Real maxBackgroundField  = 0.0;
+  Real minBackgroundField  = 0.0;
+
+  DataOps::getMaxMin(maxSpaceChargeField, minSpaceChargeField, poissonNorm, 0);
+  DataOps::getMaxMin(maxBackgroundField, minBackgroundField, laplaceNorm, 0);
+
+  for (int lvl = 0; lvl <= (this->m_amr)->getFinestLevel(); lvl++) {
+    const DisjointBoxLayout& dbl   = (this->m_amr)->getGrids(this->m_fluidRealm)[lvl];
+    const DataIterator&      dit   = dbl.dataIterator();
+    const EBISLayout&        ebisl = (this->m_amr)->getEBISLayout(this->m_fluidRealm, this->m_plasmaPhase)[lvl];
+
+    const int nbox = dit.size();
+
+#pragma omp parallel for schedule(runtime) reduction(max : relChange)
+    for (int mybox = 0; mybox < nbox; mybox++) {
+      const DataIndex&     din        = dit[mybox];
+      const Box            box        = dbl[din];
+      const EBISBox&       ebisbox    = ebisl[din];
+      const BaseFab<bool>& validCells = (*(this->m_amr)->getValidCells(this->m_fluidRealm)[lvl])[din];
+
+      const EBCellFAB& data    = (*deltaE[lvl])[din];
+      const FArrayBox& dataReg = data.getFArrayBox();
+
+      auto regularKernel = [&](const IntVect& iv) -> void {
+        if (validCells(iv) && ebisbox.isRegular(iv)) {
+          relChange = std::max(relChange, std::abs(dataReg(iv, 0)));
+        }
+      };
+
+      auto irregularKernel = [&](const VolIndex& vof) -> void {
+        if (validCells(vof.gridIndex()) && ebisbox.isIrregular(vof.gridIndex())) {
+          relChange = std::max(relChange, std::abs(data(vof, 0)));
+        }
+      };
+
+      VoFIterator& vofit = (*(this->m_amr)->getVofIterator(this->m_fluidRealm, this->m_plasmaPhase)[lvl])[din];
+
+      BoxLoops::loop(box, regularKernel);
+      BoxLoops::loop(vofit, irregularKernel);
+    }
+  }
+
+  relChange = ParallelOps::max(relChange);
+  maxChange = maxSpaceChargeField / maxBackgroundField - 1.0;
+
+  return std::make_pair(relChange, maxChange);
+}
+
+template <typename I, typename C, typename R, typename F>
+Real
+ItoKMCBackgroundEvaluator<I, C, R, F>::integrateElectrodeSurfaceCharge() const noexcept
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::integrateElectrodeSurfaceCharge");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::integrateElectrodeSurfaceCharge" << endl;
+  }
+
+  Real Enorm = 0.0;
+
+  const Real eps = Units::eps0 * this->m_computationalGeometry->getGasPermittivity();
+
+  const MFAMRCellData& electricFieldCell = (this->m_fieldSolver)->getElectricField();
+  const MFAMRCellData& permittivityCell  = (this->m_fieldSolver)->getPermittivityCell();
+  const EBAMRCellData  permittivity      = (this->m_amr)->alias(this->m_plasmaPhase, permittivityCell);
+
+  // Allocates data and computes the electric field on the cell centroid(s).
+  EBAMRCellData electricField;
+  (this->m_amr)->allocate(electricField, this->m_fluidRealm, this->m_plasmaPhase, SpaceDim);
+  DataOps::copy(electricField, (this->m_amr)->alias(this->m_plasmaPhase, electricFieldCell));
+  (this->m_amr)->interpToCentroids(electricField, this->m_fluidRealm, this->m_plasmaPhase);
+
+  for (int lvl = 0; lvl <= (this->m_amr)->getFinestLevel(); lvl++) {
+    const DisjointBoxLayout& dbl   = (this->m_amr)->getGrids(this->m_fluidRealm)[lvl];
+    const EBISLayout&        ebisl = (this->m_amr)->getEBISLayout(this->m_fluidRealm, this->m_plasmaPhase)[lvl];
+    const DataIterator&      dit   = dbl.dataIterator();
+    const Real               dx    = (this->m_amr)->getDx()[lvl];
+    const Real               dA    = std::pow(dx, SpaceDim - 1);
+
+    const int numBoxes = dit.size();
+
+#pragma omp parallel for schedule(runtime) reduction(+ : Enorm)
+    for (int mybox = 0; mybox < numBoxes; mybox++) {
+      const DataIndex&     din        = dit[mybox];
+      const EBISBox&       ebisbox    = ebisl[din];
+      const EBCellFAB&     E          = (*electricField[lvl])[din];
+      const EBCellFAB&     eps        = (*permittivity[lvl])[din];
+      const BaseFab<bool>& validCells = (*(this->m_amr)->getValidCells(this->m_fluidRealm)[lvl])[din];
+
+      auto kernel = [&](const VolIndex& vof) -> void {
+        if (ebisbox.isIrregular(vof.gridIndex()) && validCells(vof.gridIndex(), 0)) {
+          const RealVect normalVector = ebisbox.normal(vof);
+          const RealVect e            = RealVect(D_DECL(E(vof, 0), E(vof, 1), E(vof, 2)));
+          const Real     areaFrac     = ebisbox.bndryArea(vof);
+
+          Enorm += eps(vof, 0) * e.dotProduct(normalVector) * areaFrac * dA;
+        }
+      };
+
+      VoFIterator& vofit = (*(this->m_amr)->getVofIterator(this->m_fluidRealm, this->m_plasmaPhase)[lvl])[din];
+
+      BoxLoops::loop(vofit, kernel);
+    }
+  }
+
+  return eps * ParallelOps::sum(Enorm);
+}
+
+template <typename I, typename C, typename R, typename F>
+Real
+ItoKMCBackgroundEvaluator<I, C, R, F>::integrateOhmicCharge() const noexcept
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::integrateOhmicCharge");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::integrateOhmicCharge" << endl;
+  }
+
+  return 0.0;
+}
+
+template <typename I, typename C, typename R, typename F>
+std::pair<Real, Real>
+ItoKMCBackgroundEvaluator<I, C, R, F>::integrateOpticalExcitations() const noexcept
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::integrateOpticalExcitations");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::integrateOpticalExcitations" << endl;
+  }
+
+  Real sumPhi = 0.0;
+  Real sumSrc = 0.0;
+
+  for (CdrIterator<CdrSolver> solverIt = (this->m_cdr)->iterator(); solverIt.ok(); ++solverIt) {
+    const RefCountedPtr<CdrSolver>& solver = solverIt();
+
+    if (solver->getName() == m_opticalSolver) {
+      for (int lvl = 0; lvl <= (this->m_amr)->getFinestLevel(); lvl++) {
+        const DisjointBoxLayout& dbl   = (this->m_amr)->getGrids(this->m_fluidRealm)[lvl];
+        const EBISLayout&        ebisl = (this->m_amr)->getEBISLayout(this->m_fluidRealm, this->m_plasmaPhase)[lvl];
+        const DataIterator&      dit   = dbl.dataIterator();
+        const Real               dx    = (this->m_amr)->getDx()[lvl];
+        const Real               dV    = std::pow(dx, SpaceDim);
+
+        const int numBoxes = dit.size();
+
+#pragma omp parallel for schedule(runtime) reduction(+ : sumPhi, sumSrc)
+        for (int mybox = 0; mybox < numBoxes; mybox++) {
+          const DataIndex&     din        = dit[mybox];
+          const Box            cellBox    = dbl[din];
+          const EBISBox&       ebisbox    = ebisl[din];
+          const BaseFab<bool>& validCells = (*(this->m_amr)->getValidCells(this->m_fluidRealm)[lvl])[din];
+
+          const EBCellFAB& phi = (*(solver->getPhi()[lvl]))[din];
+          const EBCellFAB& src = (*(solver->getSource()[lvl]))[din];
+
+          const FArrayBox& phiReg = phi.getFArrayBox();
+          const FArrayBox& srcReg = src.getFArrayBox();
+
+          auto regularKernel = [&](const IntVect& iv) -> void {
+            if (ebisbox.isRegular(iv) && validCells(iv)) {
+              sumPhi += phiReg(iv, 0) * dV;
+              sumSrc += srcReg(iv, 0) * dV;
+            }
+          };
+
+          auto irregularKernel = [&](const VolIndex& vof) -> void {
+            if (ebisbox.isIrregular(vof.gridIndex()) && validCells(vof.gridIndex(), 0)) {
+              const Real kappa = ebisbox.volFrac(vof);
+
+              sumPhi += phi(vof, 0) * dV;
+              sumSrc += src(vof, 0) * dV;
+            }
+          };
+
+          VoFIterator& vofit = (*(this->m_amr)->getVofIterator(this->m_fluidRealm, this->m_plasmaPhase)[lvl])[din];
+
+          BoxLoops::loop(cellBox, regularKernel);
+          BoxLoops::loop(vofit, irregularKernel);
+        }
+      }
+    }
+  }
+
+  sumPhi = ParallelOps::sum(sumPhi);
+  sumSrc = ParallelOps::sum(sumSrc);
+
+  return std::make_pair(sumPhi, sumSrc);
+}
+
+#include <CD_NamespaceFooter.H>
+
+#endif


### PR DESCRIPTION
# Summary

This PR adds a new time stepper that works just like ItoKMCGodunovStepper, but also evaluates changes in the Laplacian (i.e., space-charge free field). Exit criteria for terminating a simulation based on user-supplied threshold values are included.

### Background

When running ItoKMC calculations, its beneficial to include termination criteria which halts the simulation when space charge effects set it. 

### Solution

Add a new class that derives from ItoKMCGodunovStepper, but includes termination criteria based on the background field.

### Side-effects

None.

### Alternative solutions 

None considered.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes
- [x] I have added appropriate labels to this PR
