### PR TITLE
Turn on/off options parsing in derived class

### DIFF
--- a/Physics/ItoKMC/TimeSteppers/ItoKMCBackgroundEvaluator/CD_ItoKMCBackgroundEvaluatorImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCBackgroundEvaluator/CD_ItoKMCBackgroundEvaluatorImplem.H
@@ -20,7 +20,7 @@ using namespace Physics::ItoKMC;
 
 template <typename I, typename C, typename R, typename F>
 ItoKMCBackgroundEvaluator<I, C, R, F>::ItoKMCBackgroundEvaluator(RefCountedPtr<ItoKMCPhysics>& a_physics) noexcept
-  : ItoKMCGodunovStepper<I, C, R, F>(a_physics)
+  : ItoKMCGodunovStepper<I, C, R, F>(a_physics, false)
 {
   CH_TIME("ItoKMCBackgroundEvaluator::ItoKMCBackgroundEvaluator");
 
@@ -39,7 +39,7 @@ ItoKMCBackgroundEvaluator<I, C, R, F>::ItoKMCBackgroundEvaluator(RefCountedPtr<I
   this->parseOptions();
 
   // Parse BackgroundEvaluator-specific options
-  ParmParse pp("ItoKMCBackgroundEvaluator");
+  ParmParse pp(this->m_name.c_str());
   pp.query("max_field_exit_crit", m_maxFieldExitCrit);
   pp.query("rel_field_exit_crit", m_relFieldExitCrit);
   pp.query("optical_solver", m_opticalSolver);

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepper.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepper.H
@@ -34,10 +34,12 @@ namespace Physics {
       ItoKMCGodunovStepper() = delete;
 
       /*!
-	@brief Full constructor. 
-	@param[in] a_phyics Physics implementation. 
+	@brief Full constructor.
+	@param[in] a_physics      Physics implementation.
+	@param[in] a_parseOptions If true, parse options immediately. Set to false when constructing through a derived class
+	                          that will re-parse with its own name.
       */
-      ItoKMCGodunovStepper(RefCountedPtr<ItoKMCPhysics>& a_physics);
+      ItoKMCGodunovStepper(RefCountedPtr<ItoKMCPhysics>& a_physics, bool a_parseOptions = true);
 
       /*!
 	@brief Destructor. Does nothing

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
@@ -28,7 +28,7 @@
 using namespace Physics::ItoKMC;
 
 template <typename I, typename C, typename R, typename F>
-ItoKMCGodunovStepper<I, C, R, F>::ItoKMCGodunovStepper(RefCountedPtr<ItoKMCPhysics>& a_physics)
+ItoKMCGodunovStepper<I, C, R, F>::ItoKMCGodunovStepper(RefCountedPtr<ItoKMCPhysics>& a_physics, bool a_parseOptions)
   : ItoKMCStepper<I, C, R, F>(a_physics)
 {
   CH_TIME("ItoKMCGodunovStepper::ItoKMCGodunovStepper");
@@ -42,7 +42,9 @@ ItoKMCGodunovStepper<I, C, R, F>::ItoKMCGodunovStepper(RefCountedPtr<ItoKMCPhysi
   this->m_prevDt                   = 0.0;
   this->m_maxFieldAbort            = std::numeric_limits<Real>::max();
 
-  this->parseOptions();
+  if (a_parseOptions) {
+    this->parseOptions();
+  }
 }
 
 template <typename I, typename C, typename R, typename F>


### PR DESCRIPTION
# Summary

This PR lets derived class optionally turn off input-options parsing in classes that derive from ItoKMCGodunovStepper.

### Background

ItoKMCGodunovStepper would parse input variables in the constructor, which messed with derived classes that wanted their own names to be used as a prefix. This caused run-time errors.

### Solution

Add an option in the base constructor that lets the user turn off parsing until the base constructor has exited.

### Side-effects

None.

### Alternative solutions 

None considered.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes
- [x] I have added appropriate labels to this PR
