### PR TITLE
Update ItoKMC default input options

### DIFF
--- a/Physics/ItoKMC/TimeSteppers/ItoKMCBackgroundEvaluator/CD_ItoKMCBackgroundEvaluator.options
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCBackgroundEvaluator/CD_ItoKMCBackgroundEvaluator.options
@@ -9,13 +9,13 @@ ItoKMCBackgroundEvaluator.abort_max_field                          = 10000      
 ItoKMCBackgroundEvaluator.redistribute_cdr                         = true               ## Turn on/off reactive redistribution
 ItoKMCBackgroundEvaluator.profile                                  = false              ## Turn on/off run-time profiling
 ItoKMCBackgroundEvaluator.plt_vars                                 = current_density    ## 'conductivity', 'current_density', 'particles_per_patch'
-ItoKMCBackgroundEvaluator.dual_grid                                = true               ## Turn on/off dual-grid functionality
+ItoKMCBackgroundEvaluator.dual_grid                                = false              ## Turn on/off dual-grid functionality
 ItoKMCBackgroundEvaluator.load_balance_fluid                       = false              ## Turn on/off fluid realm load balancing.
-ItoKMCBackgroundEvaluator.load_balance_particles                   = true               ## Turn on/off particle load balancing
+ItoKMCBackgroundEvaluator.load_balance_particles                   = false              ## Turn on/off particle load balancing
 ItoKMCBackgroundEvaluator.load_indices                             = -1                 ## Which particle containers to use for load balancing (-1 => all)
 ItoKMCBackgroundEvaluator.load_per_cell                            = 1.0                ## Default load per grid cell.
 ItoKMCBackgroundEvaluator.box_sorting                              = morton             ## Box sorting when load balancing
-ItoKMCBackgroundEvaluator.particles_per_cell                       = 64                 ## Max computational particles per cell
+ItoKMCBackgroundEvaluator.particles_per_cell                       = 32                 ## Max computational particles per cell
 ItoKMCBackgroundEvaluator.merge_interval                           = 1                  ## Time steps between superparticle merging
 ItoKMCBackgroundEvaluator.regrid_superparticles                    = false              ## Make superparticles during regrids
 ItoKMCBackgroundEvaluator.physics_dt_factor                        = 1.0                ## Physics-based time step factor

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepper.options
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepper.options
@@ -9,13 +9,13 @@ ItoKMCGodunovStepper.abort_max_field                          = 10000           
 ItoKMCGodunovStepper.redistribute_cdr                         = true               ## Turn on/off reactive redistribution
 ItoKMCGodunovStepper.profile                                  = false              ## Turn on/off run-time profiling
 ItoKMCGodunovStepper.plt_vars                                 = current_density    ## 'conductivity', 'current_density', 'particles_per_patch'
-ItoKMCGodunovStepper.dual_grid                                = true               ## Turn on/off dual-grid functionality
+ItoKMCGodunovStepper.dual_grid                                = false              ## Turn on/off dual-grid functionality
 ItoKMCGodunovStepper.load_balance_fluid                       = false              ## Turn on/off fluid realm load balancing.
-ItoKMCGodunovStepper.load_balance_particles                   = true               ## Turn on/off particle load balancing
+ItoKMCGodunovStepper.load_balance_particles                   = false              ## Turn on/off particle load balancing
 ItoKMCGodunovStepper.load_indices                             = -1                 ## Which particle containers to use for load balancing (-1 => all)
 ItoKMCGodunovStepper.load_per_cell                            = 1.0                ## Default load per grid cell.
 ItoKMCGodunovStepper.box_sorting                              = morton             ## Box sorting when load balancing
-ItoKMCGodunovStepper.particles_per_cell                       = 64                 ## Max computational particles per cell
+ItoKMCGodunovStepper.particles_per_cell                       = 32                 ## Max computational particles per cell
 ItoKMCGodunovStepper.merge_interval                           = 1                  ## Time steps between superparticle merging
 ItoKMCGodunovStepper.regrid_superparticles                    = false              ## Make superparticles during regrids
 ItoKMCGodunovStepper.physics_dt_factor                        = 1.0                ## Physics-based time step factor


### PR DESCRIPTION
# Summary

This PR updates the ItoKMC stepper to not use dual-grid functionality by default. 

### Background

Dual grid is not always desired. Users can enable it if they want.

### Solution

Update input files.

### Side-effects

None.

### Alternative solutions 

None considered.

# Checklist

- [ ] I have run the test suite and made sure that it passed.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [ ] I have added all relevant user documentation to Sphinx.
- [ ] I have added all relevant APIs to the doxygen documentation.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes
- [x] I have added appropriate labels to this PR
