### PR TITLE
Cache for github actions to avoid full rebuilds

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,3 +17,4 @@
 - [ ] I have added all relevant APIs to the doxygen documentation.
 - [ ] I have run CheckDocs.py and fixed potentially broken literalincludes
 - [ ] I have added appropriate labels to this PR
+- [ ] I have run a PR review using `@claude review`

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -121,6 +121,8 @@ jobs:
       - name: Run tests
         working-directory: ${{ env.DISCHARGE_HOME}}/Exec/Tests
         if: always()
+        env:
+          OMP_STACKSIZE: "64M"
         run: |
           python3 tests.py -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -openmp=${{ matrix.omp }}
           if [[ $? == 0 ]]; then exit 0; else exit 1; fi
@@ -241,6 +243,8 @@ jobs:
       - name: Run tests
         working-directory: ${{ env.DISCHARGE_HOME}}/Exec/Tests
         if: always()
+        env:
+          OMP_STACKSIZE: "64M"
         run: |
           source /opt/intel/oneapi/setvars.sh
           python3 tests.py -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -openmp=${{ matrix.omp }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 150
     strategy:
-      max-parallel: 16
+      fail-fast: false
+      max-parallel: 8
       matrix:
         ver: [13]
         dim: [2, 3]
@@ -134,6 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 150
     strategy:
+      fail-fast: false
       matrix:
         dim: [2, 3]
         mpi: ["TRUE", "FALSE"]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: Exec/Tests/**/*.ex
-          key: gcc-test-execs-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Exec/Tests/**/*.cpp', 'Exec/Tests/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-gcc') }}
+          key: gcc-test-execs-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Exec/Tests/**/*.cpp', 'Exec/Tests/**/*.H', 'Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-gcc') }}
 
       - name: Compile tests
         if: steps.cache-tests.outputs.cache-hit != 'true'
@@ -189,7 +189,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: Submodules/Chombo-3.3/lib/lib*.a
-          key: oneapi-chombo-libs-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-${{ steps.submodule-sha.outputs.chombo-sha }}-${{ hashFiles('Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
+          key: oneapi-chombo-libs-${{ env.ONEAPI_CACHE_VERSION }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-${{ steps.submodule-sha.outputs.chombo-sha }}-${{ hashFiles('Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
 
       - name: Build Chombo
         if: steps.cache-chombo.outputs.cache-hit != 'true'
@@ -202,7 +202,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: Lib/lib*.a
-          key: oneapi-discharge-libs-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
+          key: oneapi-discharge-libs-${{ env.ONEAPI_CACHE_VERSION }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
 
       - name: Build chombo-discharge/source
         if: steps.cache-discharge.outputs.cache-hit != 'true'
@@ -227,7 +227,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: Exec/Tests/**/*.ex
-          key: oneapi-test-execs-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Exec/Tests/**/*.cpp', 'Exec/Tests/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
+          key: oneapi-test-execs-${{ env.ONEAPI_CACHE_VERSION }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Exec/Tests/**/*.cpp', 'Exec/Tests/**/*.H', 'Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
 
       - name: Compile tests
         if: steps.cache-tests.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
         dim: [2, 3]
         mpi: ["TRUE", "FALSE"]
         hdf: ["TRUE", "FALSE"]
-        omp: ["TRUE", "FALSE"]
+        omp: ["FALSE"]
 
     env:
       DISCHARGE_HOME: ${{github.workspace}}
@@ -136,7 +136,7 @@ jobs:
         dim: [2, 3]
         mpi: ["TRUE", "FALSE"]
         hdf: ["FALSE"]
-        omp: ["TRUE", "FALSE"]
+        omp: ["FALSE"]
 
     env:
       DISCHARGE_HOME: ${{github.workspace}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,16 +103,8 @@ jobs:
         run: |
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} discharge-physics
 
-      - name: Restore test executable cache
-        id: cache-tests
-        uses: actions/cache@v5
-        with:
-          path: Exec/Tests/**/*.ex
-          key: gcc-test-execs-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Exec/Tests/**/*.cpp', 'Exec/Tests/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-gcc') }}
-
       - name: Compile tests
         working-directory: ${{ env.DISCHARGE_HOME}}/Exec/Tests
-        if: steps.cache-tests.outputs.cache-hit != 'true'
         run: |
           python3 tests.py --compile --no_exec -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -hdf=${{ matrix.hdf }} -openmp=${{ matrix.omp }}
           if [[ $? == 0 ]]; then exit 0; else exit 1; fi
@@ -222,16 +214,8 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} discharge-physics
 
-      - name: Restore test executable cache
-        id: cache-tests
-        uses: actions/cache@v5
-        with:
-          path: Exec/Tests/**/*.ex
-          key: oneapi-test-execs-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Exec/Tests/**/*.cpp', 'Exec/Tests/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
-
       - name: Compile tests
         working-directory: ${{ env.DISCHARGE_HOME}}/Exec/Tests
-        if: steps.cache-tests.outputs.cache-hit != 'true'
         run: |
           source /opt/intel/oneapi/setvars.sh
           python3 tests.py --compile --no_exec -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -hdf=${{ matrix.hdf }} -openmp=${{ matrix.omp }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
         dim: [2, 3]
         mpi: ["TRUE", "FALSE"]
         hdf: ["TRUE", "FALSE"]
-        omp: ["FALSE"]
+        omp: ["TRUE", "FALSE"]
 
     env:
       DISCHARGE_HOME: ${{github.workspace}}
@@ -136,7 +136,7 @@ jobs:
         dim: [2, 3]
         mpi: ["TRUE", "FALSE"]
         hdf: ["FALSE"]
-        omp: ["FALSE"]
+        omp: ["TRUE", "FALSE"]
 
     env:
       DISCHARGE_HOME: ${{github.workspace}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,11 +103,18 @@ jobs:
         run: |
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} discharge-physics
 
+      - name: Restore test executable cache
+        id: cache-tests
+        uses: actions/cache@v5
+        with:
+          path: Exec/Tests/**/*.ex
+          key: gcc-test-execs-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Exec/Tests/**/*.cpp', 'Exec/Tests/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-gcc') }}
+
       - name: Compile tests
         working-directory: ${{ env.DISCHARGE_HOME}}/Exec/Tests
-        if: always()
+        if: steps.cache-tests.outputs.cache-hit != 'true'
         run: |
-          python3 tests.py --compile --clean --no_exec -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -hdf=${{ matrix.hdf }} -openmp=${{ matrix.omp }}
+          python3 tests.py --compile --no_exec -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -hdf=${{ matrix.hdf }} -openmp=${{ matrix.omp }}
           if [[ $? == 0 ]]; then exit 0; else exit 1; fi
 
       - name: Run tests
@@ -215,12 +222,19 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} discharge-physics
 
+      - name: Restore test executable cache
+        id: cache-tests
+        uses: actions/cache@v5
+        with:
+          path: Exec/Tests/**/*.ex
+          key: oneapi-test-execs-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Exec/Tests/**/*.cpp', 'Exec/Tests/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
+
       - name: Compile tests
         working-directory: ${{ env.DISCHARGE_HOME}}/Exec/Tests
-        if: always()
+        if: steps.cache-tests.outputs.cache-hit != 'true'
         run: |
           source /opt/intel/oneapi/setvars.sh
-          python3 tests.py --compile --clean --no_exec -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -hdf=${{ matrix.hdf }} -openmp=${{ matrix.omp }}
+          python3 tests.py --compile --no_exec -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -hdf=${{ matrix.hdf }} -openmp=${{ matrix.omp }}
           if [[ $? == 0 ]]; then exit 0; else exit 1; fi
 
       - name: Run tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
           check-path: ${{ matrix.directory }}
 
   Linux-GNU:
-    if: github.event.pull_request.draft == false    
+    if: github.event.pull_request.draft == false
     needs: Formatting
     name: Linux-GNU
     runs-on: ubuntu-latest
@@ -41,7 +41,7 @@ jobs:
         mpi: ["TRUE", "FALSE"]
         hdf: ["TRUE", "FALSE"]
         omp: ["TRUE", "FALSE"]
-        
+
     env:
       DISCHARGE_HOME: ${{github.workspace}}
       CHOMBO_HOME: ${{github.workspace}}/Submodules/Chombo-3.3/lib
@@ -51,6 +51,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Get submodule commit hashes
+        id: submodule-sha
+        run: |
+          echo "chombo-sha=$(git ls-tree HEAD Submodules/Chombo-3.3 | awk '{print $3}')" >> $GITHUB_OUTPUT
+          echo "ebgeo-sha=$(git ls-tree HEAD Submodules/EBGeometry | awk '{print $3}')"  >> $GITHUB_OUTPUT
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -62,38 +69,56 @@ jobs:
         run: |
           cp $DISCHARGE_HOME/Lib/Local/GitHub/Make.defs.linux-gcc $CHOMBO_HOME/mk/Make.defs.local
 
+      - name: Restore Chombo library cache
+        id: cache-chombo
+        uses: actions/cache@v4
+        with:
+          path: Submodules/Chombo-3.3/lib/lib*.a
+          key: gcc-chombo-libs-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-${{ steps.submodule-sha.outputs.chombo-sha }}-${{ hashFiles('Lib/Local/GitHub/Make.defs.linux-gcc') }}
+
       - name: Build Chombo
+        if: steps.cache-chombo.outputs.cache-hit != 'true'
         run: |
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} chombo
 
+      - name: Restore discharge library cache
+        id: cache-discharge
+        uses: actions/cache@v4
+        with:
+          path: Lib/lib*.a
+          key: gcc-discharge-libs-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-gcc') }}
+
       - name: Build chombo-discharge/source
+        if: steps.cache-discharge.outputs.cache-hit != 'true'
         run: |
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} discharge-source
 
       - name: Build chombo-discharge/geometries
+        if: steps.cache-discharge.outputs.cache-hit != 'true'
         run: |
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} discharge-geometries
 
       - name: Build chombo-discharge/physics
+        if: steps.cache-discharge.outputs.cache-hit != 'true'
         run: |
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} discharge-physics
 
       - name: Compile tests
         working-directory: ${{ env.DISCHARGE_HOME}}/Exec/Tests
-        if: always()        
+        if: always()
         run: |
           python3 tests.py --compile --clean --no_exec -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -hdf=${{ matrix.hdf }} -openmp=${{ matrix.omp }}
           if [[ $? == 0 ]]; then exit 0; else exit 1; fi
 
       - name: Run tests
         working-directory: ${{ env.DISCHARGE_HOME}}/Exec/Tests
-        if: always()        
+        if: always()
         run: |
           python3 tests.py -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -openmp=${{ matrix.omp }}
           if [[ $? == 0 ]]; then exit 0; else exit 1; fi
 
   Linux-oneAPI:
-    if: github.event.pull_request.draft == false    
+    if: github.event.pull_request.draft == false
     needs: Formatting
     name: Linux-oneAPI
     runs-on: ubuntu-latest
@@ -103,25 +128,41 @@ jobs:
         dim: [2, 3]
         mpi: ["TRUE", "FALSE"]
         hdf: ["FALSE"]
-        omp: ["TRUE", "FALSE"]        
-        
+        omp: ["TRUE", "FALSE"]
+
     env:
       DISCHARGE_HOME: ${{github.workspace}}
       CHOMBO_HOME: ${{github.workspace}}/Submodules/Chombo-3.3/lib
       CORES: 2
+      # Bump this string to force a full refresh of cached Intel apt packages.
+      ONEAPI_CACHE_VERSION: v2025.1
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
 
+      - name: Get submodule commit hashes
+        id: submodule-sha
+        run: |
+          echo "chombo-sha=$(git ls-tree HEAD Submodules/Chombo-3.3 | awk '{print $3}')" >> $GITHUB_OUTPUT
+          echo "ebgeo-sha=$(git ls-tree HEAD Submodules/EBGeometry | awk '{print $3}')"  >> $GITHUB_OUTPUT
+
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get -y --no-install-recommends install csh libgetopt-complete-perl
 
+      - name: Restore Intel apt package cache
+        uses: actions/cache@v4
+        with:
+          path: /var/cache/apt/archives
+          key: oneapi-apt-debs-${{ env.ONEAPI_CACHE_VERSION }}
+          restore-keys: |
+            oneapi-apt-debs-
+
       - name: Install Intel oneAPI
-        working-directory: /tmp        
+        working-directory: /tmp
         run: |
           wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
           sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
@@ -129,56 +170,74 @@ jobs:
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt-get update
           sudo apt-get install intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp
-          sudo apt-get install intel-oneapi-mpi intel-oneapi-mpi-devel intel-oneapi-mkl          
-           
+          sudo apt-get install intel-oneapi-mpi intel-oneapi-mpi-devel intel-oneapi-mkl
 
       - name: Copy makefile
         run: |
-          source /opt/intel/oneapi/setvars.sh                    
+          source /opt/intel/oneapi/setvars.sh
           cp $DISCHARGE_HOME/Lib/Local/GitHub/Make.defs.linux-oneAPI $CHOMBO_HOME/mk/Make.defs.local
 
+      - name: Restore Chombo library cache
+        id: cache-chombo
+        uses: actions/cache@v4
+        with:
+          path: Submodules/Chombo-3.3/lib/lib*.a
+          key: oneapi-chombo-libs-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-${{ steps.submodule-sha.outputs.chombo-sha }}-${{ hashFiles('Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
+
       - name: Build Chombo
+        if: steps.cache-chombo.outputs.cache-hit != 'true'
         run: |
           source /opt/intel/oneapi/setvars.sh
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} chombo
 
+      - name: Restore discharge library cache
+        id: cache-discharge
+        uses: actions/cache@v4
+        with:
+          path: Lib/lib*.a
+          key: oneapi-discharge-libs-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
+
       - name: Build chombo-discharge/source
+        if: steps.cache-discharge.outputs.cache-hit != 'true'
         run: |
-          source /opt/intel/oneapi/setvars.sh                    
+          source /opt/intel/oneapi/setvars.sh
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} discharge-source
 
       - name: Build chombo-discharge/geometries
+        if: steps.cache-discharge.outputs.cache-hit != 'true'
         run: |
-          source /opt/intel/oneapi/setvars.sh                    
+          source /opt/intel/oneapi/setvars.sh
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} discharge-geometries
 
       - name: Build chombo-discharge/physics
+        if: steps.cache-discharge.outputs.cache-hit != 'true'
         run: |
-          source /opt/intel/oneapi/setvars.sh                    
+          source /opt/intel/oneapi/setvars.sh
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} discharge-physics
 
       - name: Compile tests
         working-directory: ${{ env.DISCHARGE_HOME}}/Exec/Tests
-        if: always()        
+        if: always()
         run: |
-          source /opt/intel/oneapi/setvars.sh                              
+          source /opt/intel/oneapi/setvars.sh
           python3 tests.py --compile --clean --no_exec -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -hdf=${{ matrix.hdf }} -openmp=${{ matrix.omp }}
           if [[ $? == 0 ]]; then exit 0; else exit 1; fi
 
       - name: Run tests
         working-directory: ${{ env.DISCHARGE_HOME}}/Exec/Tests
-        if: always()        
+        if: always()
         run: |
-          source /opt/intel/oneapi/setvars.sh                              
+          source /opt/intel/oneapi/setvars.sh
           python3 tests.py -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -openmp=${{ matrix.omp }}
-          if [[ $? == 0 ]]; then exit 0; else exit 1; fi                                                  
+          if [[ $? == 0 ]]; then exit 0; else exit 1; fi
 
   Build-documentation:
     needs: Formatting
     runs-on : ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install depdencies
+
+      - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt install doxygen
@@ -186,6 +245,15 @@ jobs:
           sudo apt install texlive
           sudo apt install texlive-latex-extra
           sudo apt install latexmk
+
+      - name: Restore pip cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: docs-pip-sphinx5.0.0-rtd-bibtex
+
+      - name: Install Python dependencies
+        run: |
           python3 -m pip install sphinx==5.0.0 sphinx_rtd_theme sphinxcontrib-bibtex
 
       - name: Build doxygen
@@ -193,7 +261,7 @@ jobs:
           doxygen Docs/doxygen.conf
 
       - name: Build HTML documentation
-        working-directory: ${{ github.workspace }}/Docs/Sphinx        
+        working-directory: ${{ github.workspace }}/Docs/Sphinx
         run: |
           make html
 
@@ -213,11 +281,11 @@ jobs:
         run: |
           cp -a Sphinx/build/html/* ./
           mv Sphinx/build/latex/chombo-discharge.pdf ./
-          rm -rf Sphinx/build          
-        
+          rm -rf Sphinx/build
+
   CI-passed:
     needs: [Linux-GNU, Linux-oneAPI, Build-documentation]
     runs-on: ubuntu-latest
     steps:
       - name: Do nothing
-        run: |          
+        run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
         directory: [Source, Physics, Geometries, Exec]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run clang-format
         uses: jidicula/clang-format-action@v4.10.1
         with:
@@ -48,7 +48,7 @@ jobs:
       CORES: 2
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -71,7 +71,7 @@ jobs:
 
       - name: Restore Chombo library cache
         id: cache-chombo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: Submodules/Chombo-3.3/lib/lib*.a
           key: gcc-chombo-libs-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-${{ steps.submodule-sha.outputs.chombo-sha }}-${{ hashFiles('Lib/Local/GitHub/Make.defs.linux-gcc') }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: Restore discharge library cache
         id: cache-discharge
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: Lib/lib*.a
           key: gcc-discharge-libs-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-gcc') }}
@@ -134,11 +134,11 @@ jobs:
       DISCHARGE_HOME: ${{github.workspace}}
       CHOMBO_HOME: ${{github.workspace}}/Submodules/Chombo-3.3/lib
       CORES: 2
-      # Bump this string to force a full refresh of cached Intel apt packages.
+      # Bump this string to force a full reinstall of the cached Intel oneAPI installation.
       ONEAPI_CACHE_VERSION: v2025.1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -153,15 +153,15 @@ jobs:
           sudo apt-get update
           sudo apt-get -y --no-install-recommends install csh libgetopt-complete-perl
 
-      - name: Restore Intel apt package cache
-        uses: actions/cache@v4
+      - name: Restore Intel oneAPI installation cache
+        id: cache-oneapi
+        uses: actions/cache@v5
         with:
-          path: /var/cache/apt/archives
-          key: oneapi-apt-debs-${{ env.ONEAPI_CACHE_VERSION }}
-          restore-keys: |
-            oneapi-apt-debs-
+          path: /opt/intel/oneapi
+          key: oneapi-installation-${{ env.ONEAPI_CACHE_VERSION }}
 
       - name: Install Intel oneAPI
+        if: steps.cache-oneapi.outputs.cache-hit != 'true'
         working-directory: /tmp
         run: |
           wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
@@ -179,7 +179,7 @@ jobs:
 
       - name: Restore Chombo library cache
         id: cache-chombo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: Submodules/Chombo-3.3/lib/lib*.a
           key: oneapi-chombo-libs-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-${{ steps.submodule-sha.outputs.chombo-sha }}-${{ hashFiles('Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
@@ -192,7 +192,7 @@ jobs:
 
       - name: Restore discharge library cache
         id: cache-discharge
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: Lib/lib*.a
           key: oneapi-discharge-libs-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
@@ -235,7 +235,7 @@ jobs:
     needs: Formatting
     runs-on : ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -247,7 +247,7 @@ jobs:
           sudo apt install latexmk
 
       - name: Restore pip cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: docs-pip-sphinx5.0.0-rtd-bibtex
@@ -271,7 +271,7 @@ jobs:
           make latexpdf
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs
           path: Docs/Sphinx/build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,6 +48,7 @@ jobs:
       DISCHARGE_HOME: ${{github.workspace}}
       CHOMBO_HOME: ${{github.workspace}}/Submodules/Chombo-3.3/lib
       CORES: 2
+      GCC_CACHE_VERSION: v1
 
     steps:
       - uses: actions/checkout@v6
@@ -76,7 +77,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: Submodules/Chombo-3.3/lib/lib*.a
-          key: gcc-chombo-libs-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-${{ steps.submodule-sha.outputs.chombo-sha }}-${{ hashFiles('Lib/Local/GitHub/Make.defs.linux-gcc') }}
+          key: gcc-chombo-libs-${{ env.GCC_CACHE_VERSION }}-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-${{ steps.submodule-sha.outputs.chombo-sha }}-${{ hashFiles('Lib/Local/GitHub/Make.defs.linux-gcc') }}
 
       - name: Build Chombo
         if: steps.cache-chombo.outputs.cache-hit != 'true'
@@ -88,7 +89,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: Lib/lib*.a
-          key: gcc-discharge-libs-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-gcc') }}
+          key: gcc-discharge-libs-${{ env.GCC_CACHE_VERSION }}-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-gcc') }}
 
       - name: Build chombo-discharge/source
         if: steps.cache-discharge.outputs.cache-hit != 'true'
@@ -110,7 +111,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: Exec/Tests/**/*.ex
-          key: gcc-test-execs-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Exec/Tests/**/*.cpp', 'Exec/Tests/**/*.H', 'Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-gcc') }}
+          key: gcc-test-execs-${{ env.GCC_CACHE_VERSION }}-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Exec/Tests/**/*.cpp', 'Exec/Tests/**/*.H', 'Source/**/*.cpp', 'Source/**/*.H', 'Geometries/**/*.cpp', 'Geometries/**/*.H', 'Physics/**/*.cpp', 'Physics/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-gcc') }}
 
       - name: Compile tests
         if: steps.cache-tests.outputs.cache-hit != 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,15 @@ jobs:
         run: |
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} discharge-physics
 
+      - name: Restore test executables cache
+        id: cache-tests
+        uses: actions/cache@v5
+        with:
+          path: Exec/Tests/**/*.ex
+          key: gcc-test-execs-v${{ matrix.ver }}-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Exec/Tests/**/*.cpp', 'Exec/Tests/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-gcc') }}
+
       - name: Compile tests
+        if: steps.cache-tests.outputs.cache-hit != 'true'
         working-directory: ${{ env.DISCHARGE_HOME}}/Exec/Tests
         run: |
           python3 tests.py --compile --no_exec -cores=${{ env.CORES }} -dim=${{ matrix.dim }} -mpi=${{ matrix.mpi }} -hdf=${{ matrix.hdf }} -openmp=${{ matrix.omp }}
@@ -214,7 +222,15 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           make -s -j${{ env.CORES }} DIM=${{ matrix.dim }} USE_HDF=${{ matrix.hdf }} MPI=${{ matrix.mpi }} OPENMPCC=${{ matrix.omp }} discharge-physics
 
+      - name: Restore test executables cache
+        id: cache-tests
+        uses: actions/cache@v5
+        with:
+          path: Exec/Tests/**/*.ex
+          key: oneapi-test-execs-dim${{ matrix.dim }}-mpi${{ matrix.mpi }}-omp${{ matrix.omp }}-hdf${{ matrix.hdf }}-chombo${{ steps.submodule-sha.outputs.chombo-sha }}-ebgeo${{ steps.submodule-sha.outputs.ebgeo-sha }}-${{ hashFiles('Exec/Tests/**/*.cpp', 'Exec/Tests/**/*.H', 'Lib/Definitions.make', 'Lib/Local/GitHub/Make.defs.linux-oneAPI') }}
+
       - name: Compile tests
+        if: steps.cache-tests.outputs.cache-hit != 'true'
         working-directory: ${{ env.DISCHARGE_HOME}}/Exec/Tests
         run: |
           source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       max-parallel: 16
       matrix:
-        ver: [10, 13]
+        ver: [13]
         dim: [2, 3]
         mpi: ["TRUE", "FALSE"]
         hdf: ["TRUE", "FALSE"]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 150
     strategy:
+      max-parallel: 16
       matrix:
         ver: [10, 13]
         dim: [2, 3]

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -35,6 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,9 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   claude-review:
     # Optional: Filter by PR author

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,25 +1,18 @@
 name: Claude Code Review
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  issue_comment:
+    types: [created]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@claude review') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
     runs-on: ubuntu-latest
     permissions:
@@ -42,7 +35,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -34,6 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   claude:
     if: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.8
+    hooks:
+      - id: clang-format
+        types_or: [c++, c]
+
+  - repo: local
+    hooks:
+      - id: format-input-files
+        name: Format input files
+        entry: ./FormatInputFiles.sh
+        language: script
+        files: \.(inputs|options)$
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,18 @@
+ci:
+  skip: [cmake-generate-compile-commands, clang-tidy, doxygen-check]
+
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.8
     hooks:
       - id: clang-format
+        name: Format source files (clang-format)
         types_or: [c++, c]
 
   - repo: local
     hooks:
       - id: format-input-files
-        name: Format input files
+        name: Format input files (.options and .inputs)
         entry: ./FormatInputFiles.sh
         language: script
         files: \.(inputs|options)$

--- a/Docs/Sphinx/source/Contrib/Contributions.rst
+++ b/Docs/Sphinx/source/Contrib/Contributions.rst
@@ -42,9 +42,10 @@ Continuous integration
 
 ``chombo-discharge`` uses continuous integration (CI) with GitHub actions for:
 
-* Running the test suite (see :ref:`Chap:Testing`). 
+* Running the test suite (see :ref:`Chap:Testing`).
 * Building HTML, PDF, and doxygen documentation.
 * Ensuring correct code format.
+* Automated code review via Claude (triggered by commenting ``@claude review`` on the pull request).
 
 When submitting pull request for review, the above tests will start.
 In general, all the above tests should pass before merging the pull request into the main branch.

--- a/Exec/Tests/Geometry/Cylinder/regression3d.inputs
+++ b/Exec/Tests/Geometry/Cylinder/regression3d.inputs
@@ -4,7 +4,7 @@
 AmrMesh.lo_corner            = -1 -1 -1       ## Low corner of problem domain
 AmrMesh.hi_corner            = 1  1  1        ## High corner of problem domain
 AmrMesh.verbosity            = -1             ## Controls verbosity.
-AmrMesh.coarsest_domain      = 128 128 128    ## Number of cells on coarsest domain
+AmrMesh.coarsest_domain      = 64 64 64       ## Number of cells on coarsest domain
 AmrMesh.max_amr_depth        = 0              ## Maximum amr depth
 AmrMesh.max_sim_depth        = -1             ## Maximum simulation depth
 AmrMesh.fill_ratio           = 1.0            ## Fill ratio for grid generation

--- a/Exec/Tests/RadiativeTransfer/Eddington/regression2d.inputs
+++ b/Exec/Tests/RadiativeTransfer/Eddington/regression2d.inputs
@@ -4,8 +4,8 @@
 AmrMesh.lo_corner            = -1 -1 -1       ## Low corner of problem domain
 AmrMesh.hi_corner            = 1  1  1        ## High corner of problem domain
 AmrMesh.verbosity            = -1             ## Controls verbosity.
-AmrMesh.coarsest_domain      = 128 128 128    ## Number of cells on coarsest domain
-AmrMesh.max_amr_depth        = 3              ## Maximum amr depth
+AmrMesh.coarsest_domain      = 64 64 64       ## Number of cells on coarsest domain
+AmrMesh.max_amr_depth        = 1              ## Maximum amr depth
 AmrMesh.max_sim_depth        = -1             ## Maximum simulation depth
 AmrMesh.mg_coarsen           = 4              ## Pre-coarsening of MG levels, useful for deeper bottom solves
 AmrMesh.fill_ratio           = 1.0            ## Fill ratio for grid generation

--- a/Exec/Tests/tests.py
+++ b/Exec/Tests/tests.py
@@ -352,11 +352,11 @@ for test in config.sections():
                             os.environ['OMP_SCHEDULE'] = "dynamic"
                             os.environ['OMP_PROC_BIND'] = "true"
 
-                            runCommand = args.exec_mpi + " -np " + str(num_mpi_ranks) + " ./" + executable + " " + inputFile
+                            runCommand = args.exec_mpi + " -np " + str(num_mpi_ranks) + " ./" + executable + " " + os.path.abspath(inputFile)
                         else:
                             # MPI only case
                             num_mpi_ranks = args.cores
-                            runCommand = args.exec_mpi + " -np " + str(num_mpi_ranks) + " ./" + executable + " " + inputFile
+                            runCommand = args.exec_mpi + " -np " + str(num_mpi_ranks) + " ./" + executable + " " + os.path.abspath(inputFile)
                     else:
                         # No MPI case
                         if has_openmp:

--- a/Lib/Local/GitHub/Make.defs.linux-gcc
+++ b/Lib/Local/GitHub/Make.defs.linux-gcc
@@ -15,6 +15,7 @@ USE_EB         = TRUE
 USE_MF         = TRUE
 USE_HDF        = FALSE
 USE_MT         = FALSE
+USE_TIMER      = FALSE
 OPENMPCC       = FALSE
 HDFINCFLAGS    = -I/usr/lib/x86_64-linux-gnu/hdf5/serial/include
 HDFLIBFLAGS    = -L/usr/lib/x86_64-linux-gnu/hdf5/serial/lib -lhdf5 -lz

--- a/Lib/Local/GitHub/Make.defs.linux-gcc
+++ b/Lib/Local/GitHub/Make.defs.linux-gcc
@@ -15,7 +15,6 @@ USE_EB         = TRUE
 USE_MF         = TRUE
 USE_HDF        = FALSE
 USE_MT         = FALSE
-USE_TIMER      = FALSE
 OPENMPCC       = FALSE
 HDFINCFLAGS    = -I/usr/lib/x86_64-linux-gnu/hdf5/serial/include
 HDFLIBFLAGS    = -L/usr/lib/x86_64-linux-gnu/hdf5/serial/lib -lhdf5 -lz

--- a/Lib/Local/GitHub/Make.defs.linux-gcc
+++ b/Lib/Local/GitHub/Make.defs.linux-gcc
@@ -20,9 +20,9 @@ HDFINCFLAGS    = -I/usr/lib/x86_64-linux-gnu/hdf5/serial/include
 HDFLIBFLAGS    = -L/usr/lib/x86_64-linux-gnu/hdf5/serial/lib -lhdf5 -lz
 HDFMPIINCFLAGS = -I/usr/lib/x86_64-linux-gnu/hdf5/openmpi/include
 HDFMPILIBFLAGS = -L/usr/lib/x86_64-linux-gnu/hdf5/openmpi/lib -lhdf5 -lz
-cxxoptflags    = -O3 -march=native
+cxxoptflags    = -O3 -march=x86-64-v2
 cxxdbgflags    = -O0
-foptflags      = -O3 -march=native
+foptflags      = -O3 -march=x86-64-v2
 fdbgflags      = -O0
 syslibflags    = -llapack -lblas -ldl -lm -lgfortran
 

--- a/Lib/Local/GitHub/Make.defs.linux-oneAPI
+++ b/Lib/Local/GitHub/Make.defs.linux-oneAPI
@@ -20,9 +20,9 @@ OPENMPCC        = FALSE
 #HDFLIBFLAGS    = -L<hdf_serial_dir>/lib -lhdf5 -lz
 #HDFMPIINCFLAGS = -I<hdf_parallel_dir>/include
 #HDFMPILIBFLAGS = -L<hdf_parallel_dir>/lib -lhdf5 -lz
-cxxoptflags     = -O3 -march=native
+cxxoptflags     = -O3 -march=x86-64-v2
 cxxdbgflags     = -O0
-foptflags       = -O3 -march=native
+foptflags       = -O3 -march=x86-64-v2
 fdbgflags       = -O0
 syslibflags     = -qmkl=sequential -lstdc++ -lifcore
 

--- a/Lib/Local/GitHub/Make.defs.linux-oneAPI
+++ b/Lib/Local/GitHub/Make.defs.linux-oneAPI
@@ -15,7 +15,6 @@ USE_EB          = TRUE
 USE_MF          = TRUE
 USE_HDF         = FALSE
 USE_MT          = FALSE
-USE_TIMER       = FALSE
 OPENMPCC        = FALSE
 #HDFINCFLAGS    = -I<hdf_serial_dir>/include
 #HDFLIBFLAGS    = -L<hdf_serial_dir>/lib -lhdf5 -lz

--- a/Lib/Local/GitHub/Make.defs.linux-oneAPI
+++ b/Lib/Local/GitHub/Make.defs.linux-oneAPI
@@ -15,6 +15,7 @@ USE_EB          = TRUE
 USE_MF          = TRUE
 USE_HDF         = FALSE
 USE_MT          = FALSE
+USE_TIMER       = FALSE
 OPENMPCC        = FALSE
 #HDFINCFLAGS    = -I<hdf_serial_dir>/include
 #HDFLIBFLAGS    = -L<hdf_serial_dir>/lib -lhdf5 -lz

--- a/Source/RadiativeTransfer/CD_McPhoto.H
+++ b/Source/RadiativeTransfer/CD_McPhoto.H
@@ -646,10 +646,10 @@ protected:
 
   /*!
     @brief Random exponential trial
-    @param[in] a_mean Mean value in exponential distribution. 
+    @param[in] a_rate Rate (lambda) of the exponential distribution. Mean free path = 1/a_rate.
   */
   Real
-  randomExponential(const Real a_mean) const noexcept;
+  randomExponential(const Real a_rate) const noexcept;
 
   /*!
     @brief This computes the "conservative" deposition, multiplied by kappa

--- a/Source/RadiativeTransfer/CD_McPhoto.cpp
+++ b/Source/RadiativeTransfer/CD_McPhoto.cpp
@@ -11,6 +11,7 @@
 */
 
 // Std includes
+#include <limits>
 #include <time.h>
 #include <chrono>
 
@@ -880,9 +881,12 @@ McPhoto::domainBcMap(const int a_dir, const Side::LoHiSide a_side)
 }
 
 Real
-McPhoto::randomExponential(const Real a_mean) const noexcept
+McPhoto::randomExponential(const Real a_rate) const noexcept
 {
-  std::exponential_distribution<Real> dist(a_mean);
+  if (a_rate <= 0.0) {
+    return std::numeric_limits<Real>::infinity();
+  }
+  std::exponential_distribution<Real> dist(a_rate);
   return Random::get(dist);
 }
 
@@ -974,7 +978,6 @@ McPhoto::computeNumPhysicalPhotons(EBAMRCellData&       a_numPhysPhotonsTotal,
 size_t
 McPhoto::drawPhotons(const Real a_source, const Real a_volume, const Real a_dt) const noexcept
 {
-  CH_TIME("McPhoto::drawPhotons");
   if (m_verbosity > 5) {
     pout() << m_name + "::drawPhotons" << endl;
   }

--- a/Source/Utilities/CD_RandomImplem.H
+++ b/Source/Utilities/CD_RandomImplem.H
@@ -100,11 +100,13 @@ template <typename T, typename>
 inline T
 Random::getPoisson(const Real a_mean)
 {
-  CH_TIME("Random::getPoisson");
-
   CH_assert(s_seeded);
 
   T ret = (T)0;
+
+  if (a_mean <= 0.0) {
+    return ret;
+  }
 
   if (a_mean < 250.0) {
     std::poisson_distribution<T> poisson(a_mean);
@@ -124,7 +126,6 @@ template <typename T, typename>
 inline T
 Random::getBinomial(const T a_N, const Real a_p) noexcept
 {
-  CH_TIME("Random::getBinomial");
 
   CH_assert(s_seeded);
 
@@ -151,8 +152,6 @@ Random::getBinomial(const T a_N, const Real a_p) noexcept
 inline Real
 Random::getUniformReal01()
 {
-  CH_TIME("Random::getUniformReal01");
-
   CH_assert(s_seeded);
 
   return s_uniform01(s_rng);
@@ -161,8 +160,6 @@ Random::getUniformReal01()
 inline Real
 Random::getUniformReal11()
 {
-  CH_TIME("Random::getUniformReal11");
-
   CH_assert(s_seeded);
 
   return s_uniform11(s_rng);
@@ -171,8 +168,6 @@ Random::getUniformReal11()
 inline Real
 Random::getNormal01()
 {
-  CH_TIME("Random::getNormal01");
-
   CH_assert(s_seeded);
 
   return s_normal01(s_rng);
@@ -181,8 +176,6 @@ Random::getNormal01()
 inline RealVect
 Random::getDirection()
 {
-  CH_TIME("Random::getDirection");
-
   CH_assert(s_seeded);
 
   constexpr Real safety = 1.E-12;
@@ -220,8 +213,6 @@ template <typename T>
 inline Real
 Random::get(T& a_distribution)
 {
-  CH_TIME("Random::get");
-
   CH_assert(s_seeded);
 
   return a_distribution(s_rng);
@@ -231,8 +222,6 @@ template <typename T>
 inline size_t
 Random::getDiscrete(T& a_distribution)
 {
-  CH_TIME("Random::getDiscrete");
-
   CH_assert(s_seeded);
 
   return a_distribution(s_rng);
@@ -247,7 +236,6 @@ Random::randomPosition(const RealVect a_cellPos,
                        const Real     a_dx,
                        const Real     a_kappa) noexcept
 {
-  CH_TIME("Random::randomPosition(full)");
 
   RealVect pos;
 
@@ -270,16 +258,20 @@ Random::randomPosition(const RealVect a_lo,
                        const RealVect a_bndryCentroid,
                        const RealVect a_bndryNormal) noexcept
 {
-  CH_TIME("Random::randomPosition(partial)");
+  constexpr int maxIter = 100;
 
-  // Draw a position.
   RealVect pos   = Random::randomPosition(a_lo, a_hi);
   bool     valid = (pos - a_bndryCentroid).dotProduct(a_bndryNormal) >= 0.0;
 
-  // Rejectino sampling.
-  while (!valid) {
+  for (int iter = 0; !valid && iter < maxIter; ++iter) {
     pos   = Random::randomPosition(a_lo, a_hi);
     valid = (pos - a_bndryCentroid).dotProduct(a_bndryNormal) >= 0.0;
+  }
+
+  // Fall back to the boundary centroid for degenerate cut-cells where the
+  // valid half-space and the bounding box do not overlap.
+  if (!valid) {
+    pos = a_bndryCentroid;
   }
 
   return pos;
@@ -288,7 +280,6 @@ Random::randomPosition(const RealVect a_lo,
 inline RealVect
 Random::randomPosition(const RealVect a_lo, const RealVect a_hi) noexcept
 {
-  CH_TIME("Random::randomPosition(box)");
 
   RealVect pos = RealVect::Zero;
 


### PR DESCRIPTION
# Summary

This PR updates CI.yml so that it caches the required elements to avoid full rebuilds.

### Background

In the current CI, chombo-discharge is rebuilt every time, which causes excessive recompilation. This PR caches some things so that we build only the things that a PR touches.

### Solution

Update CI.yml with caching constraints.

### Side-effects

None.

### Alternative solutions 

None considered.

# Checklist

- [x] I have run the test suite and made sure that it passed.
- [x] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
- [x] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes
- [x] I have added appropriate labels to this PR
