### PR TITLE
Update EBGeometry submodule and adapt to its renamed BVH API

### DIFF
--- a/Geometries/Aerosol/CD_Aerosol.cpp
+++ b/Geometries/Aerosol/CD_Aerosol.cpp
@@ -67,7 +67,7 @@ Aerosol::Aerosol()
       pp2.get("radius", radius);
       pp2.getarr("center", v, 0, SpaceDim);
 
-      auto c = EBGeometry::Vec3T<Real>::zero();
+      auto c = EBGeometry::Vec3T<Real>::zeros();
       for (int dir = 0; dir < SpaceDim; dir++) {
         c[dir] = v[dir];
       }

--- a/Geometries/DiskProfiledPlane/CD_DiskProfiledPlane.cpp
+++ b/Geometries/DiskProfiledPlane/CD_DiskProfiledPlane.cpp
@@ -82,7 +82,7 @@ DiskProfiledPlane::defineElectrode() noexcept
   // Create disk electrode using EBGeometry. This is an elongation of the union of a torus and a cylinder. Created
   // in the xy-plane and then put into place later.
 
-  auto torus    = std::make_shared<TorusSDF<Real>>(Vec3::zero(), wheelRadius, wheelCurvature);
+  auto torus    = std::make_shared<TorusSDF<Real>>(Vec3::zeros(), wheelRadius, wheelCurvature);
   auto cylinder = std::make_shared<CylinderSDF<Real>>(Vec3::unit(2) * wheelCurvature,
                                                       -Vec3::unit(2) * wheelCurvature,
                                                       wheelRadius);
@@ -90,7 +90,7 @@ DiskProfiledPlane::defineElectrode() noexcept
   // Make smooth union and put into place.
   auto wheel = Union<Real>(torus, cylinder);
   if (stemRadius > 0.0) {
-    auto holder = std::make_shared<CapsuleSDF<Real>>(Vec3::zero(), 1.E10 * Vec3::unit(1), stemRadius);
+    auto holder = std::make_shared<CapsuleSDF<Real>>(Vec3::zeros(), 1.E10 * Vec3::unit(1), stemRadius);
     wheel       = SmoothUnion<Real>(wheel, holder, wheelSmooth);
   }
   if (wheelThickness > 0.0) {
@@ -169,18 +169,18 @@ DiskProfiledPlane::defineDielectric() noexcept
     profile = std::make_shared<RoundedBoxSDF<Real>>(squareDim, boxCurvature);
   }
   else if (str == "sphere") {
-    profile = std::make_shared<SphereSDF<Real>>(Vec3::zero(), sphereRadius);
+    profile = std::make_shared<SphereSDF<Real>>(Vec3::zeros(), sphereRadius);
   }
   else if (str == "cylinder_x") {
-    profile = std::make_shared<SphereSDF<Real>>(Vec3::zero(), cylinderRadius);
+    profile = std::make_shared<SphereSDF<Real>>(Vec3::zeros(), cylinderRadius);
     profile = Elongate<Real>(profile, std::numeric_limits<Real>::max() * Vec3::unit(0));
   }
   else if (str == "cylinder_y") {
-    profile = std::make_shared<SphereSDF<Real>>(Vec3::zero(), cylinderRadius);
+    profile = std::make_shared<SphereSDF<Real>>(Vec3::zeros(), cylinderRadius);
     profile = Elongate<Real>(profile, std::numeric_limits<Real>::max() * Vec3::unit(1));
   }
   else if (str == "cylinder_z") {
-    profile = std::make_shared<SphereSDF<Real>>(Vec3::zero(), cylinderRadius);
+    profile = std::make_shared<SphereSDF<Real>>(Vec3::zeros(), cylinderRadius);
     profile = Elongate<Real>(profile, std::numeric_limits<Real>::max() * Vec3::unit(2));
   }
   else if (str == "none") {

--- a/Geometries/GECReferenceCell/CD_GECReferenceCell.cpp
+++ b/Geometries/GECReferenceCell/CD_GECReferenceCell.cpp
@@ -34,7 +34,7 @@ GECReferenceCell::GECReferenceCell()
   const Real eps = 2.1;
 
   // Construct the lower (non-powered) electrode parts.
-  const Vec3 zero = Vec3::zero();
+  const Vec3 zero = Vec3::zeros();
   const Vec3 yhat = Vec3::unit(1);
 
   ImpFunc innerElectrodeLo, insulatorLo, outerElectrodeLo;

--- a/Geometries/MechanicalShaft/CD_MechanicalShaft.cpp
+++ b/Geometries/MechanicalShaft/CD_MechanicalShaft.cpp
@@ -79,7 +79,7 @@ MechanicalShaft::defineElectrode() noexcept
 
   Vector<Real> v;
   std::string  orientation = "+z";
-  Vec3         translate   = Vec3::zero();
+  Vec3         translate   = Vec3::zeros();
 
   bool live        = false;
   Real length      = -1.0;
@@ -118,8 +118,8 @@ MechanicalShaft::defineElectrode() noexcept
 
   outerCylinder = std::make_shared<EBGeometry::CylinderSDF<Real>>(zLo, zHi, outerRadius - halfCurv);
   innerCylinder = std::make_shared<EBGeometry::CylinderSDF<Real>>(zLo, zHi, innerRadius + halfCurv);
-  outerTorus    = std::make_shared<EBGeometry::TorusSDF<Real>>(Vec3::zero(), outerRadius - halfCurv, halfCurv);
-  innerTorus    = std::make_shared<EBGeometry::TorusSDF<Real>>(Vec3::zero(), innerRadius + halfCurv, halfCurv);
+  outerTorus    = std::make_shared<EBGeometry::TorusSDF<Real>>(Vec3::zeros(), outerRadius - halfCurv, halfCurv);
+  innerTorus    = std::make_shared<EBGeometry::TorusSDF<Real>>(Vec3::zeros(), innerRadius + halfCurv, halfCurv);
 
   hollowCylinder = EBGeometry::Difference<Real>(outerCylinder, innerCylinder);
   hollowCylinder = EBGeometry::Union<Real>(hollowCylinder, outerTorus);
@@ -177,7 +177,7 @@ MechanicalShaft::defineDielectric() noexcept
   std::string orientation = "+z";
 
   Real eps       = -1.0;
-  Vec3 translate = Vec3::zero();
+  Vec3 translate = Vec3::zeros();
 
   Vector<Real> v;
 
@@ -257,7 +257,7 @@ MechanicalShaft::getSimpleCylinder() const noexcept
 
   CH_assert(radius > 0.0);
 
-  return std::make_shared<EBGeometry::InfiniteCylinderSDF<Real>>(Vec3::zero(), radius, 2);
+  return std::make_shared<EBGeometry::InfiniteCylinderSDF<Real>>(Vec3::zeros(), radius, 2);
 }
 
 std::shared_ptr<ImpFunc>
@@ -338,7 +338,7 @@ MechanicalShaft::getCircularProfiles() const noexcept
 
   const Real inf = std::numeric_limits<Real>::max();
 
-  const Vec3 center = Vec3::zero();
+  const Vec3 center = Vec3::zeros();
   const Vec3 transl = profileTranslate * Vec3::unit(2);
   const Vec3 period = Vec3(inf, inf, profilePeriod);
   const Vec3 repLo  = profileRepLo * Vec3::unit(2);

--- a/Geometries/RandomInterface/CD_RandomInterface.cpp
+++ b/Geometries/RandomInterface/CD_RandomInterface.cpp
@@ -107,23 +107,23 @@ RandomInterface::RandomInterface() noexcept
   int noiseOctaves1 = 0;
   int noiseOctaves2 = 0;
 
-  Vec3 noiseFrequency1 = Vec3::zero();
-  Vec3 noiseFrequency2 = Vec3::zero();
+  Vec3 noiseFrequency1 = Vec3::zeros();
+  Vec3 noiseFrequency2 = Vec3::zeros();
 
-  Vec3 point1 = Vec3::zero();
-  Vec3 point2 = Vec3::zero();
+  Vec3 point1 = Vec3::zeros();
+  Vec3 point2 = Vec3::zeros();
 
-  Vec3 normal1 = Vec3::zero();
-  Vec3 normal2 = Vec3::zero();
+  Vec3 normal1 = Vec3::zeros();
+  Vec3 normal2 = Vec3::zeros();
 
-  Vec3 clampLo1 = Vec3::zero();
-  Vec3 clampLo2 = Vec3::zero();
+  Vec3 clampLo1 = Vec3::zeros();
+  Vec3 clampLo2 = Vec3::zeros();
 
-  Vec3 clampHi1 = Vec3::zero();
-  Vec3 clampHi2 = Vec3::zero();
+  Vec3 clampHi1 = Vec3::zeros();
+  Vec3 clampHi2 = Vec3::zeros();
 
-  Vec3 clampDx1 = Vec3::zero();
-  Vec3 clampDx2 = Vec3::zero();
+  Vec3 clampDx1 = Vec3::zeros();
+  Vec3 clampDx2 = Vec3::zeros();
 
   pp.get("reseed", reseed);
   pp.get("smooth_len", smoothLength);

--- a/Geometries/RodNeedleDisk/CD_RodNeedleDisk.cpp
+++ b/Geometries/RodNeedleDisk/CD_RodNeedleDisk.cpp
@@ -69,7 +69,7 @@ RodNeedleDisk::defineRodNeedle() noexcept
 
   Vector<Real> v;
   std::string  orientation = "+z";
-  Vec3         translate   = Vec3::zero();
+  Vec3         translate   = Vec3::zeros();
 
   pp.get("rod_live", rodLive);
   pp.get("use_rod", useRod);
@@ -208,7 +208,7 @@ RodNeedleDisk::defineDisk()
 
   Vector<Real> v;
   std::string  orientation = "+z";
-  Vec3         translate   = Vec3::zero();
+  Vec3         translate   = Vec3::zeros();
 
   pp.get("use_disk", useDisk);
   pp.get("disk_live", diskLive);
@@ -236,7 +236,7 @@ RodNeedleDisk::defineDisk()
     std::shared_ptr<ImpFunc> disk;
 
     cylinder = std::make_shared<EBGeometry::CylinderSDF<Real>>(zLo, zHi, diskRadius);
-    torus    = std::make_shared<EBGeometry::TorusSDF<Real>>(Vec3::zero(), diskRadius, 0.5 * diskCurvature);
+    torus    = std::make_shared<EBGeometry::TorusSDF<Real>>(Vec3::zeros(), diskRadius, 0.5 * diskCurvature);
     disk     = EBGeometry::Union<Real>(cylinder, torus);
     disk     = EBGeometry::Elongate<Real>(disk, Vec3(0.0, 0.0, 0.5 * diskThickness));
     disk     = EBGeometry::Translate<Real>(disk, Vec3(0.0, 0.0, -diskPoint));

--- a/Geometries/SpherePlane/CD_SpherePlane.cpp
+++ b/Geometries/SpherePlane/CD_SpherePlane.cpp
@@ -77,8 +77,8 @@ SpherePlane::SpherePlane() noexcept
     std::shared_ptr<ImpFunc> holder;
     std::shared_ptr<ImpFunc> arrangement;
 
-    sphere = std::make_shared<EBGeometry::SphereSDF<Real>>(Vec3::zero(), sphereRadius);
-    holder = std::make_shared<EBGeometry::CylinderSDF<Real>>(Vec3::zero(),
+    sphere = std::make_shared<EBGeometry::SphereSDF<Real>>(Vec3::zeros(), sphereRadius);
+    holder = std::make_shared<EBGeometry::CylinderSDF<Real>>(Vec3::zeros(),
                                                              sphereHolderLength * Vec3::unit(1),
                                                              sphereHolderRadius);
 
@@ -96,7 +96,7 @@ SpherePlane::SpherePlane() noexcept
     disk   = std::make_shared<EBGeometry::RoundedCylinderSDF<Real>>(0.5 * (diskRadius + diskCurvature),
                                                                   diskCurvature,
                                                                   diskThickness);
-    holder = std::make_shared<EBGeometry::CylinderSDF<Real>>(Vec3::zero(),
+    holder = std::make_shared<EBGeometry::CylinderSDF<Real>>(Vec3::zeros(),
                                                              -diskHolderLength * Vec3::unit(1),
                                                              diskHolderRadius);
 

--- a/Geometries/Tessellation/CD_Tessellation.cpp
+++ b/Geometries/Tessellation/CD_Tessellation.cpp
@@ -40,7 +40,7 @@ Tessellation::Tessellation()
   pp.get("flip_inside", flipInside);
 
   // Read the PLY file and put it in a linearized BVH hierarchy.
-  auto implicitFunction = EBGeometry::Parser::readIntoLinearBVH<T>(filename);
+  auto implicitFunction = EBGeometry::Parser::readIntoTriangleBVH<T>(filename);
 
   // Put our level-set into Chombo datastructures.
   RefCountedPtr<BaseIF> baseIF = RefCountedPtr<BaseIF>(new EBGeometryIF<T>(implicitFunction, flipInside, zCoord));

--- a/Source/ImplicitFunctions/CD_SphereArray.cpp
+++ b/Source/ImplicitFunctions/CD_SphereArray.cpp
@@ -57,7 +57,7 @@ SphereArray::SphereArray(const Real      a_radius,
         const Vec3 center(x, y, z);
 
         spheres.emplace_back(std::make_shared<Sphere>(center, a_radius));
-        boundingVolumes.emplace_back(center - a_radius * Vec3::one(), center + a_radius * Vec3::one());
+        boundingVolumes.emplace_back(center - a_radius * Vec3::ones(), center + a_radius * Vec3::ones());
 #if CH_SPACEDIM == 3
       }
 #endif
@@ -66,7 +66,7 @@ SphereArray::SphereArray(const Real      a_radius,
 
   // Make the slow and fast unions.
   m_slowUnion  = EBGeometry::Union<Real>(spheres);
-  m_fastUnion  = EBGeometry::FastUnion<Real, Sphere, AABB, K>(spheres, boundingVolumes);
+  m_fastUnion  = std::make_shared<EBGeometry::BVHUnionIF<Real, Sphere, AABB, K>>(spheres, boundingVolumes);
   m_useFast    = a_useFast;
   m_flipInside = a_flipInside;
 }

--- a/Source/Utilities/CD_TriangleCollection.H
+++ b/Source/Utilities/CD_TriangleCollection.H
@@ -133,7 +133,7 @@ protected:
   /**
     @brief Triangle collection -- stored in a BVH-tree for faster lookup
   */
-  std::shared_ptr<EBGeometry::BVH::LinearBVH<Real, Triangle, BV, K>> m_bvh;
+  std::shared_ptr<EBGeometry::BVH::PackedBVH<Real, Triangle, K>> m_bvh;
 };
 
 #include <CD_NamespaceFooter.H>

--- a/Source/Utilities/CD_TriangleCollection.cpp
+++ b/Source/Utilities/CD_TriangleCollection.cpp
@@ -54,13 +54,13 @@ TriangleCollection::define(const std::vector<std::shared_ptr<Triangle>>& a_trian
   }
 
   // Create the root BVH node.
-  auto bvh = std::make_shared<EBGeometry::BVH::NodeT<Real, Triangle, BV, K>>(triList);
+  auto bvh = std::make_shared<EBGeometry::BVH::TreeBVH<Real, Triangle, BV, K>>(triList);
 
   // Sort the BVH tree.
   bvh->topDownSortAndPartition();
 
   // Flatten the tree onto a linear representation.
-  m_bvh = bvh->flattenTree();
+  m_bvh = bvh->pack();
 
   m_isDefined = true;
 }
@@ -72,7 +72,7 @@ TriangleCollection::getClosestTriangles(const Vec3& a_point) const noexcept
 
   using BVHMeta    = Real;
   using TriAndDist = std::pair<std::shared_ptr<const Triangle>, Real>;
-  using Node       = EBGeometry::BVH::LinearNodeT<Real, Triangle, BV, K>;
+  using Node       = EBGeometry::BVH::PackedBVH<Real, Triangle, K>::Node;
 
   BVHMeta shortestDistanceSoFar = std::numeric_limits<Real>::max();
 
@@ -80,38 +80,39 @@ TriangleCollection::getClosestTriangles(const Vec3& a_point) const noexcept
 
   // Visitation pattern. Go into the node if the point is inside or the distance to the BV is shorter than the shortest distance
   // that we've found so far.
-  EBGeometry::BVH::Visiter<Node, Real> visiter = [&shortestDistanceSoFar](const Node& /*a_node*/,
-                                                                          const BVHMeta& a_bvDist) noexcept -> bool {
+  EBGeometry::BVH::PrunePredicate<Node, Real> prunePredicate =
+    [&shortestDistanceSoFar](const Node& /*a_node*/, const BVHMeta& a_bvDist) noexcept -> bool {
     return a_bvDist <= 0.0 || a_bvDist <= shortestDistanceSoFar;
   };
 
-  // Sorter for BVH nodes. When visiting an internal node, we sort its children based on the distance to the respective bounding volumes. In
+  // Ordering for BVH nodes. When visiting an internal node, we sort its children based on the distance to the respective bounding volumes. In
   // the BVH traversel, we then visit the closest nodes first.
-  EBGeometry::BVH::Sorter<Node, Real, K> sorter =
-    [](std::array<std::pair<std::shared_ptr<const Node>, Real>, K>& a_leaves) noexcept -> void {
+  EBGeometry::BVH::PackedChildOrderer<Real, K> childOrderer =
+    [](std::array<std::pair<uint32_t, Real>, K>& a_leaves) noexcept -> void {
     std::sort(a_leaves.begin(),
               a_leaves.end(),
-              [](const std::pair<std::shared_ptr<const Node>, Real>& n1,
-                 const std::pair<std::shared_ptr<const Node>, Real>& n2) -> bool {
+              [](const std::pair<uint32_t, Real>& n1, const std::pair<uint32_t, Real>& n2) -> bool {
                 return n1.second > n2.second;
               });
   };
 
-  // Meta-data updater for the BVH nodes. This enters into the visitor pattern where we attach the distance to each
+  // Node-key factory for the BVH nodes. This enters into the traversal where we attach the distance to each
   // BVH node. This is important when we want to check if we should actually go into the node.
-  EBGeometry::BVH::MetaUpdater<Node, BVHMeta> metaUpdater = [&a_point](const Node& a_node) noexcept -> BVHMeta {
+  EBGeometry::BVH::NodeKeyFactory<Node, BVHMeta> nodeKeyFactory = [&a_point](const Node& a_node) noexcept -> BVHMeta {
     return a_node.getDistanceToBoundingVolume(a_point);
   };
 
-  // Update rule for the BVH leaf nodes. This is called at each leaf node, and provides some logic as to what to do
+  // Evaluation rule for the BVH leaf nodes. This is called at each leaf node, and provides some logic as to what to do
   // when we finally get to the bottom of the tree. Here, we compute the distance to the triangles and if the distance
   // is shorter than the smallest distance we've found so far, we append those triangles to the list of triangles that
   // will be returned to the user.
-  EBGeometry::BVH::Updater<Triangle> updater =
-    [&shortestDistanceSoFar, &a_point, &candidates](
-      const std::vector<std::shared_ptr<const Triangle>>& a_triangles) noexcept -> void {
-    for (const auto& f : a_triangles) {
-      const Real distToTri = std::abs(f->signedDistance(a_point));
+  EBGeometry::BVH::PackedLeafEvaluator<Triangle> leafEvaluator =
+    [&shortestDistanceSoFar, &a_point, &candidates](const std::vector<std::shared_ptr<const Triangle>>& a_triangles,
+                                                    size_t                                              a_offset,
+                                                    size_t a_count) noexcept -> void {
+    for (size_t i = a_offset; i < a_offset + a_count; i++) {
+      const auto& f         = a_triangles[i];
+      const Real  distToTri = std::abs(f->signedDistance(a_point));
 
       if (distToTri <= shortestDistanceSoFar) {
         candidates.emplace_back(f, distToTri);
@@ -121,7 +122,7 @@ TriangleCollection::getClosestTriangles(const Vec3& a_point) const noexcept
   };
 
   // Traverse the BVH tree with the above rules. This builds the candidate list.
-  m_bvh->traverse(updater, visiter, sorter, metaUpdater);
+  m_bvh->traverse(leafEvaluator, prunePredicate, childOrderer, nodeKeyFactory);
 
   // Sort the candidate triangles based on their distance.
   std::sort(candidates.begin(), candidates.end(), [](const TriAndDist& a, const TriAndDist& b) {


### PR DESCRIPTION
# Summary

### Background

EBGeometry renamed its BVH API in the version carrying the new `PackedBVH`/`PointCloudBVH`. The pinned submodule and its call sites no longer match.

### Solution

Bump `Submodules/EBGeometry` and mechanically adapt the affected consumers. No behavior change. Renames absorbed:

- Traversal roles: `Visiter`→`PrunePredicate`, `Sorter`→`ChildOrderer`, `Updater`→`LeafEvaluator`, `MetaUpdater`→`NodeKeyFactory`.
- Types: `NodeT`→`TreeBVH`, `LinearBVH`/`LinearNodeT`→`PackedBVH`/`PackedBVH::Node` (drops the `BV` template parameter); `flattenTree()`→`pack()`.
- CSG: `FastUnion`→`BVHUnionIF` (returned by value). `Vec3T`: `one/zero`→`ones/zeros`. Parser: `readIntoLinearBVH`→`readIntoTriangleBVH`.

`CD_TriangleCollection.cpp`'s `traverse()` callbacks also needed packed/indexed parameter types (leaf evaluator takes `(primitives, offset, count)`; child orderer sorts `(uint32_t, key)`), not just renames.

### Side-effects

None. Prerequisite for the follow-up PR that consumes `PointCloudBVH`.

### Alternative solutions

None.

### PR-review checklist

Mandatory:

- [x] I have run the test suite and made sure that it passed.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information.
- [ ] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [ ] I have run clang-tidy and fixed all reported errors.
- [x] I have made sure that this PR does not change benchmark files (unless it is intended to do so).