### PR TITLE
Consolidate particle point-location into a shared LevelTiles core

### DIFF
--- a/Docs/Sphinx/source/Source/Realm.rst
+++ b/Docs/Sphinx/source/Source/Realm.rst
@@ -47,11 +47,11 @@ The lookup is exposed through ``Realm::getLevelAndBox``, which returns the fines
 
 .. code-block:: c++
 
-   const Realm::LevelAndBox result = realm.getLevelAndBox(position);
-   // result.level    -- AMR level containing the point (-1 if none)
-   // result.boxIndex -- global grid-box index on that level
-   // result.rank     -- MPI rank owning that box
-   // result.valid    -- false if no box covers the point (i.e. off-domain)
+   const LevelTiles::LevelAndBox result = realm.getLevelAndBox(position);
+   // result.level     -- AMR level containing the point (-1 if none)
+   // result.gridIndex -- global grid-box index on that level
+   // result.rank      -- MPI rank owning that box
+   // result.valid     -- false if no box covers the point (i.e. off-domain)
 
 This is the same mapping the particle infrastructure uses to bin particles during ``remap()`` (see :ref:`Chap:Particles`).
 ``ParticleContainer`` aliases the realm's tile hash grid rather than building its own, so the ``Realm`` is the single source of truth for point-to-patch ownership.

--- a/Source/AmrMesh/CD_LevelTiles.H
+++ b/Source/AmrMesh/CD_LevelTiles.H
@@ -14,12 +14,17 @@
 #define CD_LEVELTILES_H
 
 // Std includes
+#include <cmath>
 #include <cstddef>
 #include <unordered_map>
 #include <vector>
 
 // Chombo includes
 #include <IntVect.H>
+#include <RealVect.H>
+#include <Vector.H>
+#include <RefCountedPtr.H>
+#include <SPMD.H>
 #include <DisjointBoxLayout.H>
 #include <DataIndex.H>
 
@@ -110,6 +115,85 @@ public:
    */
   virtual const std::unordered_map<unsigned int, DataIndex>&
   getMyGrids() const noexcept;
+
+  /**
+   * @brief Result of a point->block query. See findDestination.
+   */
+  struct LevelAndBox
+  {
+    /**
+     * @brief Owning AMR level (finest tile that contains the point), or -1 if not found.
+     */
+    int level;
+
+    /**
+     * @brief Global grid/box index of the covering box within that level's LevelTiles.
+     */
+    unsigned int gridIndex;
+
+    /**
+     * @brief MPI rank owning that box.
+     */
+    int rank;
+
+    /**
+     * @brief True if a covering tile/box was found (false when the point is off-domain).
+     */
+    bool valid;
+  };
+
+  /**
+   * @brief Map a physical position to its owning (level, grid index, rank) via the finest containing tile.
+   * @details Shared, header-inlined point->block core used by both ParticleContainer::findDestination (the
+   * per-particle remap hot path) and Realm::getLevelAndBox. The position is mapped to a min-block-size tile by
+   * integer division, then looked up in each level's tile->box hash, finest level first. It is O(1) per level (a
+   * tile computation plus an unordered_map lookup), never a linear scan over patches, and works for
+   * variable-sized/anisotropic boxes because every box is registered under all the min tiles it covers.
+   * @param[in] a_pos          Physical position to locate.
+   * @param[in] a_probLo       Lower-left corner of the domain.
+   * @param[in] a_dx           Per-level grid spacing, indexed [level][dir] (isotropic per level).
+   * @param[in] a_minBlockSize Tile size in cells (min_block_size).
+   * @param[in] a_levelTiles   Per-level tile->box maps (the single source of truth).
+   * @param[in] a_finestLevel  Finest AMR level to search.
+   * @return {level, gridIndex, rank, valid}; valid==false (other fields unspecified) if no tile owns the cell.
+   */
+  static inline LevelAndBox
+  findDestination(const RealVect&                          a_pos,
+                  const RealVect&                          a_probLo,
+                  const Vector<RealVect>&                  a_dx,
+                  const int                                a_minBlockSize,
+                  const Vector<RefCountedPtr<LevelTiles>>& a_levelTiles,
+                  const int                                a_finestLevel) noexcept
+  {
+    // Finest level whose min-block tile contains the point wins.
+    for (int lvl = a_finestLevel; lvl >= 0; lvl--) {
+      IntVect tile;
+
+      for (int dir = 0; dir < SpaceDim; dir++) {
+        tile[dir] = static_cast<int>(std::floor((a_pos[dir] - a_probLo[dir]) / (a_minBlockSize * a_dx[lvl][dir])));
+      }
+
+      const LevelTiles& tiles = *a_levelTiles[lvl];
+
+      const auto& myTiles = tiles.getMyTiles();
+      const auto  mit     = myTiles.find(tile);
+
+      if (mit != myTiles.end()) {
+        return LevelAndBox{lvl, mit->second, procID(), true};
+      }
+
+#ifdef CH_MPI
+      const auto& otherTiles = tiles.getOtherTiles();
+      const auto  oit        = otherTiles.find(tile);
+
+      if (oit != otherTiles.end()) {
+        return LevelAndBox{lvl, oit->second.first, static_cast<int>(oit->second.second), true};
+      }
+#endif
+    }
+
+    return LevelAndBox{-1, 0u, -1, false};
+  }
 
 protected:
   /**

--- a/Source/AmrMesh/CD_Realm.H
+++ b/Source/AmrMesh/CD_Realm.H
@@ -540,35 +540,17 @@ public:
   getLevelTiles() const noexcept;
 
   /**
-   * @brief Result of a point->block query. See getLevelAndBox.
-   */
-  struct LevelAndBox
-  {
-    /** @brief AMR level containing the point, or -1 if not found. */
-    int level;
-
-    /** @brief Global box/grid index within that level's LevelTiles. */
-    unsigned int boxIndex;
-
-    /** @brief MPI rank owning that box. */
-    int rank;
-
-    /** @brief True if a covering box was found. */
-    bool valid;
-  };
-
-  /**
    * @brief Find the (finest) grid box covering a physical position.
-   * @details O(1) point->block query implemented on the Realm's LevelTiles: the position is mapped to a
-   * min_block_size tile by integer division, then looked up in the per-level tile->box hash, finest level
-   * first. Works for variable-sized/anisotropic boxes because every box is registered under all the min
-   * tiles it covers. This is the same mapping ParticleContainer uses to bin particles, exposed for any
-   * user that needs to know which box owns a point.
+   * @details O(1) point->block query delegating to the shared LevelTiles::findDestination core over this
+   * Realm's LevelTiles: the position is mapped to a min_block_size tile by integer division, then looked up in
+   * the per-level tile->box hash, finest level first. Works for variable-sized/anisotropic boxes because every
+   * box is registered under all the min tiles it covers. This is the same mapping ParticleContainer uses to bin
+   * particles, exposed for any user that needs to know which box owns a point.
    * @param[in] a_pos Physical position.
-   * @return {level, boxIndex, rank, valid}. valid is false (and the other fields are unspecified) when no
-   * box covers the point.
+   * @return {level, gridIndex, rank, valid}. valid is false (and the other fields are unspecified) when no box
+   * covers the point.
    */
-  LevelAndBox
+  LevelTiles::LevelAndBox
   getLevelAndBox(const RealVect& a_pos) const noexcept;
 
 #ifdef CH_USE_PETSC

--- a/Source/AmrMesh/CD_Realm.cpp
+++ b/Source/AmrMesh/CD_Realm.cpp
@@ -1804,34 +1804,18 @@ Realm::getTrivialParticleGhostMask() const noexcept
   return trivial;
 }
 
-Realm::LevelAndBox
+LevelTiles::LevelAndBox
 Realm::getLevelAndBox(const RealVect& a_pos) const noexcept
 {
-  // Finest level whose min-tile contains the point wins.
-  for (int lvl = m_finestLevel; lvl >= 0; lvl--) {
-    IntVect tile;
-    for (int dir = 0; dir < SpaceDim; dir++) {
-      tile[dir] = static_cast<int>(std::floor((a_pos[dir] - m_probLo[dir]) / (m_minBlockSize * m_dx[lvl])));
-    }
+  // Adapt the isotropic per-level scalar dx to the per-direction form the shared core takes, then delegate to
+  // LevelTiles::findDestination -- the single point->block core that ParticleContainer also routes through.
+  Vector<RealVect> dx(m_finestLevel + 1);
 
-    const LevelTiles& tiles = *m_levelTiles[lvl];
-
-    const auto& myTiles = tiles.getMyTiles();
-    const auto  mit     = myTiles.find(tile);
-    if (mit != myTiles.end()) {
-      return LevelAndBox{lvl, mit->second, procID(), true};
-    }
-
-#ifdef CH_MPI
-    const auto& otherTiles = tiles.getOtherTiles();
-    const auto  oit        = otherTiles.find(tile);
-    if (oit != otherTiles.end()) {
-      return LevelAndBox{lvl, oit->second.first, static_cast<int>(oit->second.second), true};
-    }
-#endif
+  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
+    dx[lvl] = m_dx[lvl] * RealVect::Unit;
   }
 
-  return LevelAndBox{-1, 0u, -1, false};
+  return LevelTiles::findDestination(a_pos, m_probLo, dx, m_minBlockSize, m_levelTiles, m_finestLevel);
 }
 
 #ifdef CH_USE_PETSC

--- a/Source/Particle/CD_NearestNeighborParticleMerge.H
+++ b/Source/Particle/CD_NearestNeighborParticleMerge.H
@@ -869,7 +869,7 @@ applyVerdicts(const std::vector<NNMergeVerdict>& a_incomingVerdicts,
 /**
  * @brief Result of locating a physical position against the AMR grid -- see placeMergedParticles().
  * @details Deliberately independent of any AmrMesh/Realm/ParticleContainer type (this header
- * stays Amr-agnostic) -- mirrors ParticleContainer::Destination's fields exactly,
+ * stays Amr-agnostic) -- mirrors LevelTiles::LevelAndBox's fields exactly,
  * since that IS the intended real implementation: an O(1) point->block query on the realm's
  * LevelTiles tile->box hash (the SAME lookup a ParticleContainer already uses internally to
  * route its own particles during remap()), never a linear scan over patches. Reusing

--- a/Source/Particle/CD_NearestNeighborParticleMergeImplem.H
+++ b/Source/Particle/CD_NearestNeighborParticleMergeImplem.H
@@ -1328,13 +1328,13 @@ mergeNearestNeighborsRound(AmrMesh&                      a_amr,
   // 7. placeMergedParticles(), then exchange and apply the scatter bucket.
   //
   // O(1) point->block query (see NNParticleLocation/PositionLocator). ParticleContainer::
-  // findDestination() is the same tile-hash lookup a_particles uses to route its own particles
-  // during remap(); reusing it keeps one source of truth for "which box owns this position"
-  // instead of a linear scan or a parallel implementation that could drift.
+  // findDestination() delegates to the shared LevelTiles::findDestination core -- the same tile-hash
+  // lookup a_particles uses to route its own particles during remap(); reusing it keeps one source of
+  // truth for "which box owns this position" instead of a linear scan or a parallel copy that could drift.
   const PositionLocator locate = [&a_particles](const RealVect& a_pos) -> NNParticleLocation {
     const auto dst = a_particles.findDestination(a_pos);
 
-    return NNParticleLocation{dst.found, dst.level, dst.gridIndex, dst.rank};
+    return NNParticleLocation{dst.valid, dst.level, dst.gridIndex, dst.rank};
   };
 
   std::map<std::pair<int, unsigned int>, std::vector<NNMergeParticle<Packed>>> localByPatch;

--- a/Source/Particle/CD_ParticleContainer.H
+++ b/Source/Particle/CD_ParticleContainer.H
@@ -881,41 +881,16 @@ public:
   ///@}
 
   /**
-   * @brief Resolved remap destination of a particle: owning (level, grid index, rank).
-   */
-  struct Destination
-  {
-    /**
-     * @brief Owning level (finest tile that contains the particle).
-     */
-    int level;
-
-    /**
-     * @brief Owning grid index within that level's LevelTiles.
-     */
-    unsigned int gridIndex;
-
-    /**
-     * @brief Owning rank.
-     */
-    int rank;
-
-    /**
-     * @brief False if the particle is off-domain (owned by no tile).
-     */
-    bool found;
-  };
-
-  /**
    * @brief Map a position to its owning (level, grid index, rank) via the finest containing tile.
-   * @details Public because the distributed nearest-neighbor particle merge
-   * (ParticleManagement::mergeNearestNeighborsRound) locates each newly created merged particle's
-   * owning patch/rank through the SAME tile-hash query remap() uses internally, rather than a linear
-   * scan over patches -- see NNParticleLocation / PositionLocator in CD_NearestNeighborParticleMerge.H.
+   * @details Thin wrapper over the shared LevelTiles::findDestination point->block core, passing this
+   * container's aliased grid metadata (probLo, dx, minBlockSize, level tiles). Public because the distributed
+   * nearest-neighbor particle merge (ParticleManagement::mergeNearestNeighborsRound) locates each newly created
+   * merged particle's owning patch/rank through the SAME tile-hash query remap() uses internally, rather than a
+   * linear scan over patches -- see NNParticleLocation / PositionLocator in CD_NearestNeighborParticleMerge.H.
    * @param[in] a_pos Particle position.
-   * @return The resolved destination; found==false if no tile on any level owns the cell.
+   * @return The resolved destination; valid==false if no tile on any level owns the cell.
    */
-  Destination
+  LevelTiles::LevelAndBox
   findDestination(const RealVect& a_pos) const;
 
 protected:

--- a/Source/Particle/CD_ParticleContainerImplem.H
+++ b/Source/Particle/CD_ParticleContainerImplem.H
@@ -36,37 +36,10 @@
 #include <CD_NamespaceHeader.H>
 
 template <typename P, typename Traits>
-inline typename ParticleContainer<P, Traits>::Destination
+inline LevelTiles::LevelAndBox
 ParticleContainer<P, Traits>::findDestination(const RealVect& a_pos) const
 {
-  // Finest level whose tile contains the particle wins.
-  for (int lvl = m_finestLevel; lvl >= 0; lvl--) {
-    IntVect tile;
-
-    for (int dir = 0; dir < SpaceDim; dir++) {
-      tile[dir] = static_cast<int>(std::floor((a_pos[dir] - m_probLo[dir]) / (m_minBlockSize * m_dx[lvl][dir])));
-    }
-
-    const LevelTiles& tiles = *m_levelTiles[lvl];
-
-    const auto& myTiles = tiles.getMyTiles();
-    const auto  mit     = myTiles.find(tile);
-
-    if (mit != myTiles.end()) {
-      return Destination{lvl, mit->second, procID(), true};
-    }
-
-#ifdef CH_MPI
-    const auto& otherTiles = tiles.getOtherTiles();
-    const auto  oit        = otherTiles.find(tile);
-
-    if (oit != otherTiles.end()) {
-      return Destination{lvl, oit->second.first, static_cast<int>(oit->second.second), true};
-    }
-#endif
-  }
-
-  return Destination{-1, 0u, -1, false};
+  return LevelTiles::findDestination(a_pos, m_probLo, m_dx, m_minBlockSize, m_levelTiles, m_finestLevel);
 }
 
 template <typename P, typename Traits>
@@ -86,10 +59,10 @@ ParticleContainer<P, Traits>::gatherToPool(const AMRParticlesSoA<P, Traits>& a_s
     unsigned long long outcast = 0;
 
     for (std::size_t i = 0; i < a_leaf.size(); i++) {
-      const RealVect    pos = a_leaf.position(i);
-      const Destination dst = this->findDestination(pos);
+      const RealVect pos = a_leaf.position(i);
+      const auto     dst = this->findDestination(pos);
 
-      if (!dst.found) {
+      if (!dst.valid) {
         outcast++;
         continue;
       }
@@ -189,8 +162,8 @@ ParticleContainer<P, Traits>::gatherMoversToPool()
             // Debug self-check of that invariant -- the destination the gather-all path would compute
             // must be exactly this (level, grid, rank). If this ever fires, the skip is unsound.
 #ifndef NDEBUG
-            const Destination chk = this->findDestination(pos);
-            CH_assert(chk.found && chk.level == lvl && chk.rank == procID() &&
+            const auto chk = this->findDestination(pos);
+            CH_assert(chk.valid && chk.level == lvl && chk.rank == procID() &&
                       m_levelTiles[lvl]->getMyGrids().at(chk.gridIndex) == a_din);
 #endif
             i++;
@@ -199,9 +172,9 @@ ParticleContainer<P, Traits>::gatherMoversToPool()
           }
         }
 
-        const Destination dst = this->findDestination(pos); // mover: route it
+        const auto dst = this->findDestination(pos); // mover: route it
 
-        if (dst.found) {
+        if (dst.valid) {
           Leaf& bin = a_target[dst.rank][PoolKey(dst.level, dst.gridIndex)];
 
           bin.append(pos, a_leaf.weight(i), a_leaf.gather(i));


### PR DESCRIPTION
# Summary

Particle point-location -- "given a physical position, which finest grid box/rank owns it" -- was implemented **twice** with line-for-line identical logic and field-for-field identical result structs:

- `ParticleContainer::findDestination` (the per-particle remap hot path)
- `Realm::getLevelAndBox` (no callers)

This extracts **one** shared, header-inlined core, `LevelTiles::findDestination`, and has both sites delegate to it. Pure refactor, no behavioral change. Closes #670.

### Background

Both functions mapped a position to a `min_block_size` tile by integer division, then looked it up finest-level-first in the per-level `LevelTiles` tile->box hash, and returned identical `{level, index, rank, valid}` structs. The operation is a pure geometric query over grid state (`LevelTiles`, `probLo`, `dx`, `minBlockSize`, `finestLevel`) -- none of it is particle-specific; `ParticleContainer` can answer it only because it holds aliased copies of that metadata from the `Realm`. Two independent copies can drift.

### Solution

- Add an inline `LevelTiles::findDestination(...)` core plus a unified `LevelTiles::LevelAndBox` result struct, hosted on `LevelTiles` -- which both `Realm` and `ParticleContainer` already include. This keeps the core header-inlinable for the hot path and does **not** pull `Realm` into the low-level container (`ParticleContainer` stays `Realm`-agnostic).
- `ParticleContainer::findDestination` becomes a one-line wrapper passing its aliased members, so the per-particle path keeps inlining with no conversion.
- `Realm::getLevelAndBox` becomes a thin wrapper that delegates to the core.
- The two result structs (`ParticleContainer::Destination`, `Realm::LevelAndBox`) are unified into `LevelTiles::LevelAndBox`; the nearest-neighbor merge's `PositionLocator` uses the shared type.
- `dx` representation: the core takes `Vector<RealVect>` (`ParticleContainer`'s native form) so the hot path passes `m_dx` with zero conversion and no new member. `Realm` (no callers, cold) adapts its isotropic scalar `m_dx` once before delegating. The alternative scalar `Vector<Real>` signature would have rippled into `ParticleContainer::getDx()` (public, returns `Vector<RealVect>`, consumed by `ParticleOps`).
- The merge keeps routing through `ParticleContainer::findDestination`, which is now itself a thin delegate to the shared core -- so the single-source-of-truth guarantee holds without adding new `AmrMesh`/`Realm` coupling to the merge.

### Side-effects

- No behavioral change; the relocated arithmetic is unchanged.
- The core is header-only/inline, preserving the per-particle hot path's inlinability.
- `Realm::getLevelAndBox` now builds a small per-level `Vector<RealVect>` from its scalar `dx` before delegating -- off any hot path (the method has no callers).
- No `literalinclude` line ranges were affected (the edits in `CD_ParticleContainer.H` sit past its last referenced range); the `Realm.rst` point-query example was updated to the unified type/field names.

### Alternative solutions 

- **Host the core on `Realm`** (the originally-floated option): forces `ParticleContainer` to either gain a `Realm` include on the per-particle path or keep its own copy -- i.e. it does not fully kill the duplication. Hosting on `LevelTiles` avoids that.
- **Scalar `Vector<Real>` dx in the core signature:** cleaner abstraction, but would require either a redundant scalar member on `ParticleContainer` or changing `m_dx`'s type and thus the public `getDx()` contract. Deferred in favor of the zero-overhead `Vector<RealVect>` form.
- **Rewire the merge to build its `PositionLocator` from `Realm`/the core directly:** deferred -- `findDestination` is now a thin delegate, so this yields no functional change while adding coupling. Straightforward follow-up if desired.

### PR-review checklist

Mandatory:

- [x] I have run the test suite and made sure that it passed.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information.
- [x] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [ ] I have run clang-tidy and fixed all reported errors.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpDRSdK6PL3JxKzDmF3YrT)_