### PR TITLE
Cache the mergers' regrid-invariant data on the realm

### DIFF
--- a/Docs/Sphinx/source/Source/Particles.rst
+++ b/Docs/Sphinx/source/Source/Particles.rst
@@ -391,7 +391,7 @@ For each source cell a mask lists the destination boxes (grid index and receivin
 There is one mask per direction, and the collection type is
 
 .. literalinclude:: ../../../../Source/AmrMesh/CD_ParticleGhostMask.H
-   :lines: 210
+   :lines: 224
    :language: c++
 
 The masks live on the :ref:`Chap:Realm` and are rebuilt at every regrid.

--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -15,6 +15,9 @@
 #ifndef CD_AMRMESH_H
 #define CD_AMRMESH_H
 
+// Std includes
+#include <set>
+
 // Chombo includes
 #include <DisjointBoxLayout.H>
 #include <ProblemDomain.H>
@@ -1757,6 +1760,16 @@ public:
   getDx() const;
 
   /**
+   * @brief Get spatial resolutions in the per-direction form.
+   * @details The isotropic getDx() widened to RealVect, which is what the point-location and particle
+   * merge code wants. Held rather than rebuilt by each caller: it is a pure function of the domain, so it
+   * does not even change at a regrid.
+   * @return Grid spacings on all levels, as RealVect.
+   */
+  const Vector<RealVect>&
+  getDxAsRealVect() const;
+
+  /**
    * @brief Get refinement ratios
    * @return Refinement ratios between consecutive levels
    */
@@ -1876,6 +1889,30 @@ public:
    */
   const AMRParticleGhostMask&
   getTrivialParticleGhostMask() const;
+
+  /**
+   * @brief Get the particle boundary-exposure mask on a realm for a registered width.
+   * @details True in every cell that has at least one outgoing ghost-shipment target in any direction, i.e.
+   * the OR of the three ghost masks above. Built at regrid, so a consumer can read the bit instead of
+   * re-deriving it per particle per timestep. Carries no ghost cells -- only cells holding a resident
+   * particle may be queried.
+   * @param[in] a_realm Realm name
+   * @param[in] a_width Registered ghost width.
+   * @return Per-level boolean mask over the valid grids.
+   */
+  const AMRMask&
+  getParticleGhostExposure(const std::string& a_realm, const int a_width) const;
+
+  /**
+   * @brief Get the particle ghost neighbor-rank set on a realm for a registered width.
+   * @details Every rank this rank exchanges particle ghosts with, in either direction, at a_width. Lets a
+   * consumer restrict a would-be all-to-all exchange to this set instead.
+   * @param[in] a_realm Realm name
+   * @param[in] a_width Registered ghost width.
+   * @return The neighbor-rank set.
+   */
+  const std::set<int>&
+  getParticleGhostNeighborRanks(const std::string& a_realm, const int a_width) const;
 
   /**
    * @brief Get the EBLevelGrid for a Realm and phase
@@ -2346,6 +2383,13 @@ protected:
    * @brief Level resolutions
    */
   Vector<Real> m_dx;
+
+  /**
+   * @brief Level resolutions in the per-direction form, i.e. m_dx widened to RealVect.
+   * @details Filled beside m_dx in buildDomains() and never touched again -- the grid spacing follows from
+   * the domain, not from the grids, so it survives a regrid unchanged.
+   */
+  Vector<RealVect> m_dxRealVect;
 
   /**
    * @brief Define Realms

--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -1760,16 +1760,6 @@ public:
   getDx() const;
 
   /**
-   * @brief Get spatial resolutions in the per-direction form.
-   * @details The isotropic getDx() widened to RealVect, which is what the point-location and particle
-   * merge code wants. Held rather than rebuilt by each caller: it is a pure function of the domain, so it
-   * does not even change at a regrid.
-   * @return Grid spacings on all levels, as RealVect.
-   */
-  const Vector<RealVect>&
-  getDxAsRealVect() const;
-
-  /**
    * @brief Get refinement ratios
    * @return Refinement ratios between consecutive levels
    */
@@ -2383,13 +2373,6 @@ protected:
    * @brief Level resolutions
    */
   Vector<Real> m_dx;
-
-  /**
-   * @brief Level resolutions in the per-direction form, i.e. m_dx widened to RealVect.
-   * @details Filled beside m_dx in buildDomains() and never touched again -- the grid spacing follows from
-   * the domain, not from the grids, so it survives a regrid unchanged.
-   */
-  Vector<RealVect> m_dxRealVect;
 
   /**
    * @brief Define Realms

--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -15,9 +15,6 @@
 #ifndef CD_AMRMESH_H
 #define CD_AMRMESH_H
 
-// Std includes
-#include <set>
-
 // Chombo includes
 #include <DisjointBoxLayout.H>
 #include <ProblemDomain.H>
@@ -1894,14 +1891,14 @@ public:
   getParticleGhostExposure(const std::string& a_realm, const int a_width) const;
 
   /**
-   * @brief Get the particle ghost neighbor-rank set on a realm for a registered width.
+   * @brief Get the particle ghost neighbor ranks on a realm for a registered width.
    * @details Every rank this rank exchanges particle ghosts with, in either direction, at a_width. Lets a
    * consumer restrict a would-be all-to-all exchange to this set instead.
    * @param[in] a_realm Realm name
    * @param[in] a_width Registered ghost width.
-   * @return The neighbor-rank set.
+   * @return The neighbor ranks, in ascending order.
    */
-  const std::set<int>&
+  const std::vector<int>&
   getParticleGhostNeighborRanks(const std::string& a_realm, const int a_width) const;
 
   /**

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -1030,6 +1030,7 @@ AmrMesh::buildDomains()
 
   m_domains.resize(numLevels);
   m_dx.resize(numLevels);
+  m_dxRealVect.resize(numLevels);
   m_grids.resize(numLevels);
 
   m_dx[0]      = (m_probHi[0] - m_probLo[0]) / m_numCells[0];
@@ -1040,6 +1041,10 @@ AmrMesh::buildDomains()
     m_domains[lvl] = m_domains[lvl - 1];
 
     m_domains[lvl].refine(m_refinementRatios[lvl - 1]);
+  }
+
+  for (int lvl = 0; lvl <= m_maxAmrDepth; lvl++) {
+    m_dxRealVect[lvl] = m_dx[lvl] * RealVect::Unit;
   }
 }
 
@@ -3222,6 +3227,17 @@ AmrMesh::getDx() const
   return m_dx;
 }
 
+const Vector<RealVect>&
+AmrMesh::getDxAsRealVect() const
+{
+  CH_TIME("AmrMesh::getDxAsRealVect()");
+  if (m_verbosity > 1) {
+    pout() << "AmrMesh::getDxAsRealVect()" << endl;
+  }
+
+  return m_dxRealVect;
+}
+
 const Vector<int>&
 AmrMesh::getRefinementRatios() const
 {
@@ -3528,6 +3544,39 @@ AmrMesh::getTrivialParticleGhostMask() const
   static const AMRParticleGhostMask trivial;
 
   return trivial;
+}
+
+const AMRMask&
+AmrMesh::getParticleGhostExposure(const std::string& a_realm, const int a_width) const
+{
+  CH_TIME("AmrMesh::getParticleGhostExposure(string, int)");
+  if (m_verbosity > 1) {
+    pout() << "AmrMesh::getParticleGhostExposure(string, int)" << endl;
+  }
+
+  if (!this->queryRealm(a_realm)) {
+    const std::string str = "AmrMesh::getParticleGhostExposure(string, int) - could not find realm '" + a_realm + "'";
+    MayDay::Abort(str.c_str());
+  }
+
+  return m_realms[a_realm]->getParticleGhostExposure(a_width);
+}
+
+const std::set<int>&
+AmrMesh::getParticleGhostNeighborRanks(const std::string& a_realm, const int a_width) const
+{
+  CH_TIME("AmrMesh::getParticleGhostNeighborRanks(string, int)");
+  if (m_verbosity > 1) {
+    pout() << "AmrMesh::getParticleGhostNeighborRanks(string, int)" << endl;
+  }
+
+  if (!this->queryRealm(a_realm)) {
+    const std::string str = "AmrMesh::getParticleGhostNeighborRanks(string, int) - could not find realm '" + a_realm +
+                            "'";
+    MayDay::Abort(str.c_str());
+  }
+
+  return m_realms[a_realm]->getParticleGhostNeighborRanks(a_width);
 }
 
 const Vector<RefCountedPtr<EBLevelGrid>>&

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -1030,7 +1030,6 @@ AmrMesh::buildDomains()
 
   m_domains.resize(numLevels);
   m_dx.resize(numLevels);
-  m_dxRealVect.resize(numLevels);
   m_grids.resize(numLevels);
 
   m_dx[0]      = (m_probHi[0] - m_probLo[0]) / m_numCells[0];
@@ -1041,10 +1040,6 @@ AmrMesh::buildDomains()
     m_domains[lvl] = m_domains[lvl - 1];
 
     m_domains[lvl].refine(m_refinementRatios[lvl - 1]);
-  }
-
-  for (int lvl = 0; lvl <= m_maxAmrDepth; lvl++) {
-    m_dxRealVect[lvl] = m_dx[lvl] * RealVect::Unit;
   }
 }
 
@@ -3225,17 +3220,6 @@ AmrMesh::getDx() const
   }
 
   return m_dx;
-}
-
-const Vector<RealVect>&
-AmrMesh::getDxAsRealVect() const
-{
-  CH_TIME("AmrMesh::getDxAsRealVect()");
-  if (m_verbosity > 1) {
-    pout() << "AmrMesh::getDxAsRealVect()" << endl;
-  }
-
-  return m_dxRealVect;
 }
 
 const Vector<int>&

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -3546,7 +3546,7 @@ AmrMesh::getParticleGhostExposure(const std::string& a_realm, const int a_width)
   return m_realms[a_realm]->getParticleGhostExposure(a_width);
 }
 
-const std::set<int>&
+const std::vector<int>&
 AmrMesh::getParticleGhostNeighborRanks(const std::string& a_realm, const int a_width) const
 {
   CH_TIME("AmrMesh::getParticleGhostNeighborRanks(string, int)");

--- a/Source/AmrMesh/CD_ParticleGhostMask.H
+++ b/Source/AmrMesh/CD_ParticleGhostMask.H
@@ -14,6 +14,7 @@
 #define CD_PARTICLEGHOSTMASK_H
 
 // Std includes
+#include <set>
 #include <vector>
 
 // Chombo includes
@@ -176,6 +177,16 @@ public:
    */
   inline bool
   hasTargetBoxes() const noexcept;
+
+  /**
+   * @brief Insert every rank appearing in this table's packed target list into a_ranks.
+   * @details One pass over the packed targets, ignoring which cell each belongs to -- the caller wants
+   * the set of ranks this box ships to, not the per-cell breakdown. Accumulates into the argument (does
+   * not clear it) so a caller can union several tables, e.g. every box of every level.
+   * @param[in,out] a_ranks Set that the target ranks are inserted into.
+   */
+  inline void
+  collectTargetRanks(std::set<int>& a_ranks) const noexcept;
 
 protected:
   /**

--- a/Source/AmrMesh/CD_ParticleGhostMask.H
+++ b/Source/AmrMesh/CD_ParticleGhostMask.H
@@ -14,7 +14,6 @@
 #define CD_PARTICLEGHOSTMASK_H
 
 // Std includes
-#include <set>
 #include <vector>
 
 // Chombo includes
@@ -179,14 +178,18 @@ public:
   hasTargetBoxes() const noexcept;
 
   /**
-   * @brief Insert every rank appearing in this table's packed target list into a_ranks.
+   * @brief Flag every rank appearing in this table's packed target list.
    * @details One pass over the packed targets, ignoring which cell each belongs to -- the caller wants
-   * the set of ranks this box ships to, not the per-cell breakdown. Accumulates into the argument (does
-   * not clear it) so a caller can union several tables, e.g. every box of every level.
-   * @param[in,out] a_ranks Set that the target ranks are inserted into.
+   * the ranks this box ships to, not the per-cell breakdown. A flag array rather than a deduplicating
+   * container because there is one packed entry per (boundary cell x target) but only a handful of
+   * distinct ranks: this way each entry costs a single store, and the caller collapses the flags once.
+   * Accumulates into the argument (does not clear it), so a caller can union several tables -- e.g.
+   * every box of every level.
+   * @param[in,out] a_isTarget Per-rank flags, indexed by rank and sized to the communicator. Entries
+   * are set to true; existing true entries are left alone.
    */
   inline void
-  collectTargetRanks(std::set<int>& a_ranks) const noexcept;
+  markTargetRanks(std::vector<bool>& a_isTarget) const noexcept;
 
 protected:
   /**

--- a/Source/AmrMesh/CD_ParticleGhostMaskImplem.H
+++ b/Source/AmrMesh/CD_ParticleGhostMaskImplem.H
@@ -139,6 +139,14 @@ ParticleGhostMask::hasTargetBoxes() const noexcept
   return !m_flatBox.empty();
 }
 
+inline void
+ParticleGhostMask::collectTargetRanks(std::set<int>& a_ranks) const noexcept
+{
+  for (const LevelTiles::BoxIDs& target : m_flat) {
+    a_ranks.insert(static_cast<int>(target.second));
+  }
+}
+
 #include <CD_NamespaceFooter.H>
 
 #endif

--- a/Source/AmrMesh/CD_ParticleGhostMaskImplem.H
+++ b/Source/AmrMesh/CD_ParticleGhostMaskImplem.H
@@ -140,10 +140,12 @@ ParticleGhostMask::hasTargetBoxes() const noexcept
 }
 
 inline void
-ParticleGhostMask::collectTargetRanks(std::set<int>& a_ranks) const noexcept
+ParticleGhostMask::markTargetRanks(std::vector<bool>& a_isTarget) const noexcept
 {
   for (const LevelTiles::BoxIDs& target : m_flat) {
-    a_ranks.insert(static_cast<int>(target.second));
+    CH_assert(target.second < a_isTarget.size());
+
+    a_isTarget[target.second] = true;
   }
 }
 

--- a/Source/AmrMesh/CD_Realm.H
+++ b/Source/AmrMesh/CD_Realm.H
@@ -533,6 +533,27 @@ public:
   getTrivialParticleGhostMask() const noexcept;
 
   /**
+   * @brief Get the boundary-exposure mask for a registered particle ghost width.
+   * @details See m_particleGhostExposure' own docs for what "exposed" means and why the mask carries no
+   * ghost cells.
+   * @param[in] a_width Registered ghost width.
+   * @return The per-level exposure mask for a_width. Aborts if the width was not registered.
+   */
+  const AMRMask&
+  getParticleGhostExposure(const int a_width) const noexcept;
+
+  /**
+   * @brief Get the particle ghost neighbor-rank set for a registered width.
+   * @details Every rank this rank exchanges particle ghosts with, in either direction, at a_width -- see
+   * m_particleGhostNeighborRanks' own docs. Lets a consumer restrict a would-be all-to-all exchange to
+   * this set instead.
+   * @param[in] a_width Registered ghost width.
+   * @return The neighbor-rank set for a_width. Aborts if the width was not registered.
+   */
+  const std::set<int>&
+  getParticleGhostNeighborRanks(const int a_width) const noexcept;
+
+  /**
    * @brief Get the tiled space
    * @return Level tiles
    */
@@ -665,6 +686,33 @@ protected:
    * (<finest); per source (coarse) box maps a source cell to the finer-level boxes whose ghosted region covers it.
    */
   std::map<int, AMRParticleGhostMask> m_particleGhostMaskCoarToFine;
+
+  /**
+   * @brief Particle boundary-exposure masks, keyed by ghost width. Per width: indexed by level, true in
+   * every cell that has at least one outgoing ghost-shipment target in ANY direction -- i.e. the OR over
+   * the same-level, fine-to-coarse and coarse-to-fine masks of numTargets(cell) > 0.
+   * @details A cell is "exposed" when a particle sitting in it is visible to some other box, so a consumer
+   * that wants to act on such a particle unilaterally cannot: some other box may be acting on the same
+   * particle in the same round. The mergers ask this question per particle, every timestep, for data that
+   * changes only when the masks it is derived from do -- hence caching it here, beside those masks and
+   * rebuilt by the same function.
+   *
+   * Carries NO ghost cells, deliberately: only cells holding a RESIDENT particle are ever queried, and
+   * resident means the cell lies in the patch's own box. A ghost particle's cell lies outside the box and
+   * would in any case violate ParticleGhostMask::numTargets()' own precondition.
+   */
+  std::map<int, AMRMask> m_particleGhostExposure;
+
+  /**
+   * @brief Particle ghost neighbor ranks, keyed by ghost width. The union, over every box THIS rank owns
+   * at every level, of the target ranks appearing in that width's same-level/fine-to-coarse/coarse-to-fine
+   * masks -- i.e. every rank this rank exchanges particle ghosts with in EITHER direction, at that width.
+   * @details Built once per regrid alongside the masks themselves (see defineParticleGhostMasks()); no MPI
+   * is needed because it relies only on ghost adjacency being symmetric (if a box grown by the ghost width
+   * reaches a neighbor, the same growth relation reaches back), a property the ghost-fill masks already
+   * depend on. Lets consumers replace an all-to-all exchange with one restricted to actual neighbors.
+   */
+  std::map<int, std::set<int>> m_particleGhostNeighborRanks;
 
 #ifdef CH_USE_PETSC
   /**
@@ -878,6 +926,29 @@ protected:
                                     const ProblemDomain&            a_fineDomain,
                                     const int                       a_refRat,
                                     const int                       a_ghost) noexcept;
+
+  /**
+   * @brief Define the boundary-exposure mask on one level from that level's three particle ghost masks.
+   * @details Sets a cell true iff it has at least one outgoing ghost-shipment target in any direction; see
+   * m_particleGhostExposure' own docs for what the mask is for. a_hasCoar/a_hasFine say whether the
+   * fine-to-coarse/coarse-to-fine masks are actually defined on this level -- they are allocated but left
+   * undefined on level 0 and on the finest level respectively, and must not be queried there.
+   * @param[out] a_exposure   Per-box boolean mask over a_dbl to fill (no ghost cells).
+   * @param[in]  a_dbl        This level's grids.
+   * @param[in]  a_same       This level's same-level ghost mask.
+   * @param[in]  a_fineToCoar This level's fine-to-coarse ghost mask. Only read if a_hasCoar.
+   * @param[in]  a_coarToFine This level's coarse-to-fine ghost mask. Only read if a_hasFine.
+   * @param[in]  a_hasCoar    Whether a coarser level exists (i.e. a_fineToCoar is defined).
+   * @param[in]  a_hasFine    Whether a finer level exists (i.e. a_coarToFine is defined).
+   */
+  void
+  defineParticleGhostExposure(LevelData<BaseFab<bool>>&            a_exposure,
+                              const DisjointBoxLayout&             a_dbl,
+                              const LayoutData<ParticleGhostMask>& a_same,
+                              const LayoutData<ParticleGhostMask>& a_fineToCoar,
+                              const LayoutData<ParticleGhostMask>& a_coarToFine,
+                              const bool                           a_hasCoar,
+                              const bool                           a_hasFine) noexcept;
 
   /**
    * @brief Define the PETSc composite grid

--- a/Source/AmrMesh/CD_Realm.H
+++ b/Source/AmrMesh/CD_Realm.H
@@ -543,14 +543,14 @@ public:
   getParticleGhostExposure(const int a_width) const noexcept;
 
   /**
-   * @brief Get the particle ghost neighbor-rank set for a registered width.
+   * @brief Get the particle ghost neighbor ranks for a registered width.
    * @details Every rank this rank exchanges particle ghosts with, in either direction, at a_width -- see
    * m_particleGhostNeighborRanks' own docs. Lets a consumer restrict a would-be all-to-all exchange to
    * this set instead.
    * @param[in] a_width Registered ghost width.
-   * @return The neighbor-rank set for a_width. Aborts if the width was not registered.
+   * @return The neighbor ranks for a_width, in ascending order. Aborts if the width was not registered.
    */
-  const std::set<int>&
+  const std::vector<int>&
   getParticleGhostNeighborRanks(const int a_width) const noexcept;
 
   /**
@@ -711,8 +711,12 @@ protected:
    * is needed because it relies only on ghost adjacency being symmetric (if a box grown by the ghost width
    * reaches a neighbor, the same growth relation reaches back), a property the ghost-fill masks already
    * depend on. Lets consumers replace an all-to-all exchange with one restricted to actual neighbors.
+   *
+   * Held as a sorted vector rather than a set: it has a handful of entries (the neighbor COUNT saturates
+   * as the communicator grows, so it is not O(numProc)), every consumer wants to walk it in rank order,
+   * and a vector is what they would otherwise copy it into on every exchange.
    */
-  std::map<int, std::set<int>> m_particleGhostNeighborRanks;
+  std::map<int, std::vector<int>> m_particleGhostNeighborRanks;
 
 #ifdef CH_USE_PETSC
   /**

--- a/Source/AmrMesh/CD_Realm.cpp
+++ b/Source/AmrMesh/CD_Realm.cpp
@@ -1137,7 +1137,12 @@ Realm::defineParticleGhostMasks() noexcept
     // Every rank this rank exchanges ghosts with at this width, in EITHER direction -- see
     // m_particleGhostNeighborRanks' own docs for why folding in only MY OWN outgoing targets (below)
     // is enough to also capture incoming ones, no communication required.
-    std::set<int>& neighborRanks = m_particleGhostNeighborRanks[ghost];
+    //
+    // Accumulated as per-rank flags and collapsed once, after every level has contributed. The masks
+    // hold one packed entry per (boundary cell x target) but only a handful of distinct ranks, so a
+    // flag store per entry beats inserting each one into a deduplicating container.
+    std::vector<int>& neighborRanks = m_particleGhostNeighborRanks[ghost];
+    std::vector<bool> isNeighbor(numProc(), false);
 
     for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
       const DisjointBoxLayout& dbl    = m_grids[lvl];
@@ -1202,14 +1207,23 @@ Realm::defineParticleGhostMasks() noexcept
       for (int mybox = 0; mybox < nbox; mybox++) {
         const DataIndex& din = dit[mybox];
 
-        (*same[lvl])[din].collectTargetRanks(neighborRanks);
+        (*same[lvl])[din].markTargetRanks(isNeighbor);
 
         if (lvl > 0) {
-          (*fineToCoar[lvl])[din].collectTargetRanks(neighborRanks);
+          (*fineToCoar[lvl])[din].markTargetRanks(isNeighbor);
         }
         if (lvl < m_finestLevel) {
-          (*coarToFine[lvl])[din].collectTargetRanks(neighborRanks);
+          (*coarToFine[lvl])[din].markTargetRanks(isNeighbor);
         }
+      }
+    }
+
+    // Collapse the flags. Scanning in rank order means the result is sorted by construction, which is
+    // what the point-to-point exchanges want: both sides must walk their shared neighbors in the same
+    // order for the sends and receives to line up.
+    for (int rank = 0; rank < numProc(); rank++) {
+      if (isNeighbor[rank]) {
+        neighborRanks.push_back(rank);
       }
     }
   }
@@ -1914,7 +1928,7 @@ Realm::getParticleGhostExposure(const int a_width) const noexcept
   return it->second;
 }
 
-const std::set<int>&
+const std::vector<int>&
 Realm::getParticleGhostNeighborRanks(const int a_width) const noexcept
 {
   const auto it = m_particleGhostNeighborRanks.find(a_width);

--- a/Source/AmrMesh/CD_Realm.cpp
+++ b/Source/AmrMesh/CD_Realm.cpp
@@ -1204,6 +1204,11 @@ Realm::defineParticleGhostMasks() noexcept
       const DataIterator& dit  = dbl.dataIterator();
       const int           nbox = dit.size();
 
+      // Serial (no omp): every box marks flags in the SAME isNeighbor array, and different boxes
+      // routinely share a target rank, so threads would write the same element concurrently. Distinct
+      // elements would not help either -- std::vector<bool> packs bits, so neighbouring ranks share a
+      // word. Per-thread arrays would fix it, but this runs once per regrid and costs one store per
+      // packed target, so there is nothing here worth buying with that memory.
       for (int mybox = 0; mybox < nbox; mybox++) {
         const DataIndex& din = dit[mybox];
 

--- a/Source/AmrMesh/CD_Realm.cpp
+++ b/Source/AmrMesh/CD_Realm.cpp
@@ -1102,6 +1102,8 @@ Realm::defineParticleGhostMasks() noexcept
   m_particleGhostMask.clear();
   m_particleGhostMaskFineToCoar.clear();
   m_particleGhostMaskCoarToFine.clear();
+  m_particleGhostExposure.clear();
+  m_particleGhostNeighborRanks.clear();
 
   // Particle ghost filling is intentionally NOT supported on periodic domains (a periodic ghost would
   // require wrapping particle copies across the domain). Abort rather than silently mis-fill if a width
@@ -1125,10 +1127,17 @@ Realm::defineParticleGhostMasks() noexcept
     AMRParticleGhostMask& same       = m_particleGhostMask[ghost];
     AMRParticleGhostMask& fineToCoar = m_particleGhostMaskFineToCoar[ghost];
     AMRParticleGhostMask& coarToFine = m_particleGhostMaskCoarToFine[ghost];
+    AMRMask&              exposure   = m_particleGhostExposure[ghost];
 
     same.resize(1 + m_finestLevel);
     fineToCoar.resize(1 + m_finestLevel);
     coarToFine.resize(1 + m_finestLevel);
+    exposure.resize(1 + m_finestLevel);
+
+    // Every rank this rank exchanges ghosts with at this width, in EITHER direction -- see
+    // m_particleGhostNeighborRanks' own docs for why folding in only MY OWN outgoing targets (below)
+    // is enough to also capture incoming ones, no communication required.
+    std::set<int>& neighborRanks = m_particleGhostNeighborRanks[ghost];
 
     for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
       const DisjointBoxLayout& dbl    = m_grids[lvl];
@@ -1167,6 +1176,92 @@ Realm::defineParticleGhostMasks() noexcept
                                                 m_refinementRatios[lvl],
                                                 ghost);
       }
+
+      // Derived quantities, folded in here rather than recomputed by consumers every timestep: both are
+      // pure functions of the three masks just built, so this is the only place their lifetime is defined.
+      exposure[lvl] = RefCountedPtr<LevelData<BaseFab<bool>>>(new LevelData<BaseFab<bool>>(dbl, 1, IntVect::Zero));
+
+      this->defineParticleGhostExposure(*exposure[lvl],
+                                        dbl,
+                                        *same[lvl],
+                                        *fineToCoar[lvl],
+                                        *coarToFine[lvl],
+                                        lvl > 0,
+                                        lvl < m_finestLevel);
+
+      // Fold this level's just-built masks' OWN (outgoing) target ranks into the running neighbor set.
+      // Ghost adjacency is symmetric (box growth intersection is a symmetric relation), so the ranks
+      // this rank ships TO at a given direction/width are exactly the ranks that ship back at the
+      // complementary direction (same-level ships back via the same mask; a coarse rank's C2F targets
+      // ship back via THEIR OWN F2C mask, and vice versa) -- the union across all three directions,
+      // over every level this rank owns boxes at, is therefore the full bidirectional neighbor set,
+      // with no MPI needed to discover it.
+      const DataIterator& dit  = dbl.dataIterator();
+      const int           nbox = dit.size();
+
+      for (int mybox = 0; mybox < nbox; mybox++) {
+        const DataIndex& din = dit[mybox];
+
+        (*same[lvl])[din].collectTargetRanks(neighborRanks);
+
+        if (lvl > 0) {
+          (*fineToCoar[lvl])[din].collectTargetRanks(neighborRanks);
+        }
+        if (lvl < m_finestLevel) {
+          (*coarToFine[lvl])[din].collectTargetRanks(neighborRanks);
+        }
+      }
+    }
+  }
+}
+
+void
+Realm::defineParticleGhostExposure(LevelData<BaseFab<bool>>&            a_exposure,
+                                   const DisjointBoxLayout&             a_dbl,
+                                   const LayoutData<ParticleGhostMask>& a_same,
+                                   const LayoutData<ParticleGhostMask>& a_fineToCoar,
+                                   const LayoutData<ParticleGhostMask>& a_coarToFine,
+                                   const bool                           a_hasCoar,
+                                   const bool                           a_hasFine) noexcept
+{
+  CH_TIME("Realm::defineParticleGhostExposure");
+  if (m_verbosity > 5) {
+    pout() << "Realm::defineParticleGhostExposure" << endl;
+  }
+
+  // Box-local: each box reads only its own three CSR tables and writes only its own BaseFab, so this is
+  // thread-safe over boxes for the same reason the mask builds above are. a_hasCoar/a_hasFine gate the two
+  // masks that are allocated-but-undefined at the hierarchy's ends (see defineParticleGhostMasks()'s
+  // CONTRACT comments); querying those would trip ParticleGhostMask::numTargets()' own assertion.
+  const DataIterator& dit  = a_dbl.dataIterator();
+  const int           nbox = dit.size();
+
+#pragma omp parallel for schedule(runtime)
+  for (int mybox = 0; mybox < nbox; mybox++) {
+    const DataIndex& din = dit[mybox];
+    const Box        box = a_dbl[din];
+
+    const ParticleGhostMask& same       = a_same[din];
+    const ParticleGhostMask& fineToCoar = a_fineToCoar[din];
+    const ParticleGhostMask& coarToFine = a_coarToFine[din];
+
+    BaseFab<bool>& exposure = a_exposure[din];
+
+    exposure.setVal(false);
+
+    for (BoxIterator bit(box); bit.ok(); ++bit) {
+      const IntVect iv = bit();
+
+      bool isExposed = same.numTargets(iv) > 0;
+
+      if (!isExposed && a_hasCoar) {
+        isExposed = fineToCoar.numTargets(iv) > 0;
+      }
+      if (!isExposed && a_hasFine) {
+        isExposed = coarToFine.numTargets(iv) > 0;
+      }
+
+      exposure(iv, 0) = isExposed;
     }
   }
 }
@@ -1802,6 +1897,36 @@ Realm::getTrivialParticleGhostMask() const noexcept
   static const AMRParticleGhostMask trivial;
 
   return trivial;
+}
+
+const AMRMask&
+Realm::getParticleGhostExposure(const int a_width) const noexcept
+{
+  const auto it = m_particleGhostExposure.find(a_width);
+
+  if (it == m_particleGhostExposure.end()) {
+    const std::string msg = "Realm::getParticleGhostExposure -- width = " + std::to_string(a_width) +
+                            " was not registered (call registerParticleGhostMask before regridding)";
+
+    MayDay::Abort(msg.c_str());
+  }
+
+  return it->second;
+}
+
+const std::set<int>&
+Realm::getParticleGhostNeighborRanks(const int a_width) const noexcept
+{
+  const auto it = m_particleGhostNeighborRanks.find(a_width);
+
+  if (it == m_particleGhostNeighborRanks.end()) {
+    const std::string msg = "Realm::getParticleGhostNeighborRanks -- width = " + std::to_string(a_width) +
+                            " was not registered (call registerParticleGhostMask before regridding)";
+
+    MayDay::Abort(msg.c_str());
+  }
+
+  return it->second;
 }
 
 LevelTiles::LevelAndBox

--- a/Source/ItoDiffusion/CD_ItoSolver.H
+++ b/Source/ItoDiffusion/CD_ItoSolver.H
@@ -998,26 +998,6 @@ public:
                            const bool         a_enableBoundaryCarve);
 
   /**
-   * @brief Allocate the kd merges' per-cell scratch holders, unless they are already current.
-   * @details Called by the kd merge entry points rather than unconditionally from allocate()/regrid(),
-   * for two reasons: an ItoKMC run holds one solver per species, so unconditional holders multiply the
-   * memory by the species count for solvers that may never run a kd merge; and the merge method can be
-   * chosen per call (ItoKMCStepper's regrid merge), so m_mergeMethod does not predict whether a kd
-   * merge will happen. The holders are invalidated at every allocate()/regrid(), so this allocates at
-   * most once per regrid for a solver that does use them.
-   */
-  void
-  defineKDMergeScratch() noexcept;
-
-  /**
-   * @brief Release the kd merges' per-cell scratch holders and mark them stale.
-   * @details Called from allocate()/regrid(), i.e. whenever the grids the holders were sized to have
-   * been replaced. The next kd merge re-allocates them through defineKDMergeScratch().
-   */
-  void
-  invalidateKDMergeScratch() noexcept;
-
-  /**
    * @brief Remap the bulk particle container.
    */
   virtual void
@@ -1516,7 +1496,8 @@ protected:
   /**
    * @brief Per-cell occupancy scratch for the kd merges (see ParticleManagement::mergeKDCarve).
    * @details Owned here, not by the merge, so the allocation happens once per regrid rather than once
-   * per merge call. Undefined until the first kd merge; see defineKDMergeScratch().
+   * per merge call. Allocated and released with the other mesh fields, in allocate()/regrid() and
+   * preRegrid() respectively.
    */
   EBAMRFAB m_kdMergeCellHistogram;
 
@@ -1524,12 +1505,6 @@ protected:
    * @brief Per-cell merge-quota scratch for the kd merges. Same lifetime as m_kdMergeCellHistogram.
    */
   EBAMRFAB m_kdMergeLeafQuota;
-
-  /**
-   * @brief Whether the kd merge scratch holders above match the current grids.
-   * @details Cleared at every allocate()/regrid(); defineKDMergeScratch() sets it when it allocates.
-   */
-  bool m_kdMergeScratchDefined = false;
 
   /**
    * @brief Scratch storage for holding the non-conservative deposition

--- a/Source/ItoDiffusion/CD_ItoSolver.H
+++ b/Source/ItoDiffusion/CD_ItoSolver.H
@@ -998,6 +998,26 @@ public:
                            const bool         a_enableBoundaryCarve);
 
   /**
+   * @brief Allocate the kd merges' per-cell scratch holders, unless they are already current.
+   * @details Called by the kd merge entry points rather than unconditionally from allocate()/regrid(),
+   * for two reasons: an ItoKMC run holds one solver per species, so unconditional holders multiply the
+   * memory by the species count for solvers that may never run a kd merge; and the merge method can be
+   * chosen per call (ItoKMCStepper's regrid merge), so m_mergeMethod does not predict whether a kd
+   * merge will happen. The holders are invalidated at every allocate()/regrid(), so this allocates at
+   * most once per regrid for a solver that does use them.
+   */
+  void
+  defineKDMergeScratch() noexcept;
+
+  /**
+   * @brief Release the kd merges' per-cell scratch holders and mark them stale.
+   * @details Called from allocate()/regrid(), i.e. whenever the grids the holders were sized to have
+   * been replaced. The next kd merge re-allocates them through defineKDMergeScratch().
+   */
+  void
+  invalidateKDMergeScratch() noexcept;
+
+  /**
    * @brief Remap the bulk particle container.
    */
   virtual void
@@ -1492,6 +1512,24 @@ protected:
    * @brief Diffusion-centerer field used for interpolating diffusion coefficients
    */
   EBAMRCellData m_diffusionFunction;
+
+  /**
+   * @brief Per-cell occupancy scratch for the kd merges (see ParticleManagement::mergeKDCarve).
+   * @details Owned here, not by the merge, so the allocation happens once per regrid rather than once
+   * per merge call. Undefined until the first kd merge; see defineKDMergeScratch().
+   */
+  EBAMRFAB m_kdMergeCellHistogram;
+
+  /**
+   * @brief Per-cell merge-quota scratch for the kd merges. Same lifetime as m_kdMergeCellHistogram.
+   */
+  EBAMRFAB m_kdMergeLeafQuota;
+
+  /**
+   * @brief Whether the kd merge scratch holders above match the current grids.
+   * @details Cleared at every allocate()/regrid(); defineKDMergeScratch() sets it when it allocates.
+   */
+  bool m_kdMergeScratchDefined = false;
 
   /**
    * @brief Scratch storage for holding the non-conservative deposition

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -1053,6 +1053,8 @@ ItoSolver::regrid(const int a_lmin, const int a_oldFinestLevel, const int a_newF
 
     m_amr->remapToNewGrids(particles, a_lmin, a_newFinestLevel);
   }
+
+  this->invalidateKDMergeScratch();
 }
 
 void
@@ -1118,6 +1120,43 @@ ItoSolver::allocate()
   for (const auto& which : containers) {
     m_amr->allocate(m_particleContainers[which], m_realm);
   }
+
+  this->invalidateKDMergeScratch();
+}
+
+void
+ItoSolver::invalidateKDMergeScratch() noexcept
+{
+  CH_TIME("ItoSolver::invalidateKDMergeScratch");
+  if (m_verbosity > 5) {
+    pout() << m_name + "::invalidateKDMergeScratch" << endl;
+  }
+
+  // Release the holders rather than merely marking them stale: they are sized to the grids that just
+  // went away, and a solver that never runs a kd merge again should not keep paying for them.
+  m_kdMergeCellHistogram.clear();
+  m_kdMergeLeafQuota.clear();
+
+  m_kdMergeScratchDefined = false;
+}
+
+void
+ItoSolver::defineKDMergeScratch() noexcept
+{
+  CH_TIME("ItoSolver::defineKDMergeScratch");
+  if (m_verbosity > 5) {
+    pout() << m_name + "::defineKDMergeScratch" << endl;
+  }
+
+  if (m_kdMergeScratchDefined) {
+    return;
+  }
+
+  // One component, one ghost cell -- the shape the kd merges document for these holders.
+  m_amr->allocate(m_kdMergeCellHistogram, m_realm, 1, 1);
+  m_amr->allocate(m_kdMergeLeafQuota, m_realm, 1, 1);
+
+  m_kdMergeScratchDefined = true;
 }
 
 #ifdef CH_USE_HDF5
@@ -4234,6 +4273,10 @@ ItoSolver::makeSuperparticlesKDSkinNn(const WhichContainer a_container, const Ve
     pout() << m_name + "::makeSuperparticlesKDSkinNn" << endl;
   }
 
+  // The interior tier below needs the per-cell scratch; allocate it if this is the first kd merge
+  // since the grids last changed.
+  this->defineKDMergeScratch();
+
   // Reduce every over-full cell to a_particlesPerCell superparticles (and refill under-full cells)
   // with a whole-patch kd-tree merge whose boundary tier is the nearest-neighbor pair merge rather
   // than kd_carve's arbitration. The particles are split across TWO containers so the two tiers
@@ -4372,6 +4415,8 @@ ItoSolver::makeSuperparticlesKDSkinNn(const WhichContainer a_container, const Ve
                                                               interior,
                                                               numParticlesPerCellThresh,
                                                               m_kdSplitWeightLeafDx,
+                                                              m_kdMergeCellHistogram,
+                                                              m_kdMergeLeafQuota,
                                                               gather,
                                                               kdCombine,
                                                               kdScatter,
@@ -4507,6 +4552,10 @@ ItoSolver::makeSuperparticlesKDImpl(const WhichContainer a_container,
 {
   CH_TIME("ItoSolver::makeSuperparticlesKDImpl");
 
+  // Both merges below need the per-cell scratch; allocate it if this is the first kd merge since the
+  // grids last changed.
+  this->defineKDMergeScratch();
+
   // Reduce every over-full cell to a_particlesPerCell superparticles (and refill under-full cells)
   // using the whole-patch kd-tree merge (ParticleManagement::mergeKDCarve or mergeKDPatch).
   // Unlike makeSuperparticlesNnPairTree/Hash/OneCell, there is no drain-loop round here -- both
@@ -4611,6 +4660,8 @@ ItoSolver::makeSuperparticlesKDImpl(const WhichContainer a_container,
                                                              merge,
                                                              a_numParticlesPerCellThresh,
                                                              m_kdSplitWeightLeafDx,
+                                                             m_kdMergeCellHistogram,
+                                                             m_kdMergeLeafQuota,
                                                              gather,
                                                              combine,
                                                              scatter,
@@ -4622,6 +4673,8 @@ ItoSolver::makeSuperparticlesKDImpl(const WhichContainer a_container,
                                                              merge,
                                                              a_numParticlesPerCellThresh,
                                                              m_kdSplitWeightLeafDx,
+                                                             m_kdMergeCellHistogram,
+                                                             m_kdMergeLeafQuota,
                                                              gather,
                                                              combine,
                                                              scatter,

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -1029,6 +1029,11 @@ ItoSolver::regrid(const int a_lmin, const int a_oldFinestLevel, const int a_newF
   m_amr->allocate(m_depositionNC, m_realm, m_phase, ncomp);
   m_amr->allocate(m_massDiff, m_realm, m_phase, ncomp);
 
+  // Per-cell scratch for the kd merges (see ParticleManagement::mergeKDCarve). One component, one
+  // ghost cell -- the shape those functions document.
+  m_amr->allocate(m_kdMergeCellHistogram, m_realm, 1, 1);
+  m_amr->allocate(m_kdMergeLeafQuota, m_realm, 1, 1);
+
   // Only allocate memory for velocity if we actually have a mobile solver
   if (m_isMobile) {
     m_amr->allocate(m_mobilityFunction, m_realm, m_phase, ncomp); //
@@ -1053,8 +1058,6 @@ ItoSolver::regrid(const int a_lmin, const int a_oldFinestLevel, const int a_newF
 
     m_amr->remapToNewGrids(particles, a_lmin, a_newFinestLevel);
   }
-
-  this->invalidateKDMergeScratch();
 }
 
 void
@@ -1090,6 +1093,11 @@ ItoSolver::allocate()
   m_amr->allocate(m_depositionNC, m_realm, m_phase, ncomp);
   m_amr->allocate(m_massDiff, m_realm, m_phase, ncomp);
 
+  // Per-cell scratch for the kd merges (see ParticleManagement::mergeKDCarve). One component, one
+  // ghost cell -- the shape those functions document.
+  m_amr->allocate(m_kdMergeCellHistogram, m_realm, 1, 1);
+  m_amr->allocate(m_kdMergeLeafQuota, m_realm, 1, 1);
+
   // Only allocate memory for velocity if we actually have a mobile solver
   if (m_isMobile) {
     m_amr->allocate(m_mobilityFunction, m_realm, m_phase, ncomp); //
@@ -1120,43 +1128,6 @@ ItoSolver::allocate()
   for (const auto& which : containers) {
     m_amr->allocate(m_particleContainers[which], m_realm);
   }
-
-  this->invalidateKDMergeScratch();
-}
-
-void
-ItoSolver::invalidateKDMergeScratch() noexcept
-{
-  CH_TIME("ItoSolver::invalidateKDMergeScratch");
-  if (m_verbosity > 5) {
-    pout() << m_name + "::invalidateKDMergeScratch" << endl;
-  }
-
-  // Release the holders rather than merely marking them stale: they are sized to the grids that just
-  // went away, and a solver that never runs a kd merge again should not keep paying for them.
-  m_kdMergeCellHistogram.clear();
-  m_kdMergeLeafQuota.clear();
-
-  m_kdMergeScratchDefined = false;
-}
-
-void
-ItoSolver::defineKDMergeScratch() noexcept
-{
-  CH_TIME("ItoSolver::defineKDMergeScratch");
-  if (m_verbosity > 5) {
-    pout() << m_name + "::defineKDMergeScratch" << endl;
-  }
-
-  if (m_kdMergeScratchDefined) {
-    return;
-  }
-
-  // One component, one ghost cell -- the shape the kd merges document for these holders.
-  m_amr->allocate(m_kdMergeCellHistogram, m_realm, 1, 1);
-  m_amr->allocate(m_kdMergeLeafQuota, m_realm, 1, 1);
-
-  m_kdMergeScratchDefined = true;
 }
 
 #ifdef CH_USE_HDF5
@@ -2205,6 +2176,8 @@ ItoSolver::preRegrid(const int a_lbase, const int /*a_oldFinestLevel*/)
   m_diffusionFunction.clear();
   m_depositionNC.clear();
   m_massDiff.clear();
+  m_kdMergeCellHistogram.clear();
+  m_kdMergeLeafQuota.clear();
 }
 
 ParticleContainer<ItoParticle>&
@@ -4273,10 +4246,6 @@ ItoSolver::makeSuperparticlesKDSkinNn(const WhichContainer a_container, const Ve
     pout() << m_name + "::makeSuperparticlesKDSkinNn" << endl;
   }
 
-  // The interior tier below needs the per-cell scratch; allocate it if this is the first kd merge
-  // since the grids last changed.
-  this->defineKDMergeScratch();
-
   // Reduce every over-full cell to a_particlesPerCell superparticles (and refill under-full cells)
   // with a whole-patch kd-tree merge whose boundary tier is the nearest-neighbor pair merge rather
   // than kd_carve's arbitration. The particles are split across TWO containers so the two tiers
@@ -4551,10 +4520,6 @@ ItoSolver::makeSuperparticlesKDImpl(const WhichContainer a_container,
                                     const bool           a_enableBoundaryCarve)
 {
   CH_TIME("ItoSolver::makeSuperparticlesKDImpl");
-
-  // Both merges below need the per-cell scratch; allocate it if this is the first kd merge since the
-  // grids last changed.
-  this->defineKDMergeScratch();
 
   // Reduce every over-full cell to a_particlesPerCell superparticles (and refill under-full cells)
   // using the whole-patch kd-tree merge (ParticleManagement::mergeKDCarve or mergeKDPatch).

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -4055,8 +4055,8 @@ ItoSolver::makeSuperparticlesNnPairSearch(const WhichContainer a_container, cons
     // Merge particles -- this is the most expensive part of the merge algorithm. The only line in
     // this whole function that differs between the two backends.
     if constexpr (Backend == NnPairSearchBackend::Hash) {
-      ParticleManagement::mergeNearestNeighborsHash<ItoMergeParticle, Real>(*m_amr,
-                                                                            merge,
+      ParticleManagement::mergeNearestNeighborsHash<ItoMergeParticle, Real>(merge,
+                                                                            *m_amr,
                                                                             a_numParticlesPerCellThresh,
                                                                             gather,
                                                                             combine,
@@ -4069,8 +4069,8 @@ ItoSolver::makeSuperparticlesNnPairSearch(const WhichContainer a_container, cons
                                                                             isPositionValid);
     }
     else {
-      ParticleManagement::mergeNearestNeighborsTree<ItoMergeParticle, Real>(*m_amr,
-                                                                            merge,
+      ParticleManagement::mergeNearestNeighborsTree<ItoMergeParticle, Real>(merge,
+                                                                            *m_amr,
                                                                             a_numParticlesPerCellThresh,
                                                                             gather,
                                                                             combine,
@@ -4221,8 +4221,8 @@ ItoSolver::makeSuperparticlesNnPairOneCell(const WhichContainer a_container, con
                              m_amr->getParticleGhostMaskFineToCoar(m_realm, 1));
 
     // Merge particles -- this is the most expensive part of the merge algorithm.
-    ParticleManagement::mergeNearestNeighborsOneCell<ItoMergeParticle, Real>(*m_amr,
-                                                                             merge,
+    ParticleManagement::mergeNearestNeighborsOneCell<ItoMergeParticle, Real>(merge,
+                                                                             *m_amr,
                                                                              a_numParticlesPerCellThresh,
                                                                              gather,
                                                                              combine,
@@ -4410,13 +4410,13 @@ ItoSolver::makeSuperparticlesKDSkinNn(const WhichContainer a_container, const Ve
   renumber();
   fillWidthOneGhosts(merge);
 
-  ParticleManagement::mergeKDInterior<ItoMergeParticle, Real>(*m_amr,
-                                                              merge,
+  ParticleManagement::mergeKDInterior<ItoMergeParticle, Real>(merge,
                                                               interior,
-                                                              numParticlesPerCellThresh,
-                                                              m_kdSplitWeightLeafDx,
                                                               m_kdMergeCellHistogram,
                                                               m_kdMergeLeafQuota,
+                                                              *m_amr,
+                                                              numParticlesPerCellThresh,
+                                                              m_kdSplitWeightLeafDx,
                                                               gather,
                                                               kdCombine,
                                                               kdScatter,
@@ -4503,8 +4503,8 @@ ItoSolver::makeSuperparticlesKDSkinNn(const WhichContainer a_container, const Ve
     renumber();
     fillWidthOneGhosts(merge);
 
-    ParticleManagement::mergeNearestNeighborsOneCell<ItoMergeParticle, Real>(*m_amr,
-                                                                             merge,
+    ParticleManagement::mergeNearestNeighborsOneCell<ItoMergeParticle, Real>(merge,
+                                                                             *m_amr,
                                                                              cellBudget,
                                                                              gather,
                                                                              nnCombine,
@@ -4656,12 +4656,12 @@ ItoSolver::makeSuperparticlesKDImpl(const WhichContainer a_container,
                              m_amr->getParticleGhostMaskCoarToFine(m_realm, 1),
                              m_amr->getParticleGhostMaskFineToCoar(m_realm, 1));
 
-    ParticleManagement::mergeKDCarve<ItoMergeParticle, Real>(*m_amr,
-                                                             merge,
-                                                             a_numParticlesPerCellThresh,
-                                                             m_kdSplitWeightLeafDx,
+    ParticleManagement::mergeKDCarve<ItoMergeParticle, Real>(merge,
                                                              m_kdMergeCellHistogram,
                                                              m_kdMergeLeafQuota,
+                                                             *m_amr,
+                                                             a_numParticlesPerCellThresh,
+                                                             m_kdSplitWeightLeafDx,
                                                              gather,
                                                              combine,
                                                              scatter,
@@ -4669,12 +4669,12 @@ ItoSolver::makeSuperparticlesKDImpl(const WhichContainer a_container,
                                                              isPositionValid);
   }
   else {
-    ParticleManagement::mergeKDPatch<ItoMergeParticle, Real>(*m_amr,
-                                                             merge,
-                                                             a_numParticlesPerCellThresh,
-                                                             m_kdSplitWeightLeafDx,
+    ParticleManagement::mergeKDPatch<ItoMergeParticle, Real>(merge,
                                                              m_kdMergeCellHistogram,
                                                              m_kdMergeLeafQuota,
+                                                             *m_amr,
+                                                             a_numParticlesPerCellThresh,
+                                                             m_kdSplitWeightLeafDx,
                                                              gather,
                                                              combine,
                                                              scatter,

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -4416,6 +4416,8 @@ ItoSolver::makeSuperparticlesKDSkinNn(const WhichContainer a_container, const Ve
 
     const int nbox = dit.size();
 
+    // Serial (no omp): reservedIDs is a shared set that dedupes a particle seen from several patches,
+    // and cellBudget.reserveOne() accumulates into shared per-cell counts. Both would race.
     for (int mybox = 0; mybox < nbox; mybox++) {
       const ParticleSoA<ItoMergeParticle>& leaf = interior[lvl][dit[mybox]];
 

--- a/Source/Particle/CD_KDParticleMerge.H
+++ b/Source/Particle/CD_KDParticleMerge.H
@@ -190,6 +190,11 @@ kdExchangeByRank(const std::vector<std::vector<T>>& a_sendByRank);
  * @param[in] a_splitWeightLeafDx Leaf size, in cell widths, at or below which the tree build
  * switches from count-median to weight-median splitting -- forwarded verbatim to
  * buildKDQuotaLeaves(). 0 disables the weight median entirely.
+ * @param[in,out] a_cellHistogram Caller-owned per-cell scratch (1 component, >= 1 ghost cell, this
+ * container's realm) holding the cell occupancy. Contents on entry are irrelevant -- it is overwritten
+ * per patch. Owned by the caller so the allocation happens once per regrid rather than once per call.
+ * @param[in,out] a_leafQuota Caller-owned per-cell scratch, same shape and lifetime as
+ * @a a_cellHistogram, holding the live per-cell merge quota.
  * @param[in] a_gather Per-slot gather callback.
  * @param[in] a_combine N-ary opaque-payload combine callback.
  * @param[in] a_scatter Per-merged-particle scatter callback.
@@ -209,6 +214,8 @@ mergeKDCarve(AmrMesh&                      a_amr,
              ParticleContainer<P, Traits>& a_particles,
              const int                     a_ppc,
              const Real                    a_splitWeightLeafDx,
+             EBAMRFAB&                     a_cellHistogram,
+             EBAMRFAB&                     a_leafQuota,
              const Gather&                 a_gather,
              const Combine&                a_combine,
              const Scatter&                a_scatter,
@@ -245,6 +252,8 @@ mergeKDCarve(AmrMesh&                      a_amr,
  * @param[in] a_splitWeightLeafDx Leaf size, in cell widths, at or below which the tree build
  * switches from count-median to weight-median splitting -- forwarded verbatim to
  * buildKDQuotaLeaves(). 0 disables the weight median entirely.
+ * @param[in,out] a_cellHistogram Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
+ * @param[in,out] a_leafQuota Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
  * @param[in] a_gather Per-slot gather callback.
  * @param[in] a_combine N-ary opaque-payload combine callback.
  * @param[in] a_scatter Per-merged-particle scatter callback.
@@ -264,6 +273,8 @@ mergeKDPatch(AmrMesh&                      a_amr,
              ParticleContainer<P, Traits>& a_particles,
              const int                     a_ppc,
              const Real                    a_splitWeightLeafDx,
+             EBAMRFAB&                     a_cellHistogram,
+             EBAMRFAB&                     a_leafQuota,
              const Gather&                 a_gather,
              const Combine&                a_combine,
              const Scatter&                a_scatter,
@@ -308,6 +319,8 @@ mergeKDPatch(AmrMesh&                      a_amr,
  * @param[in] a_splitWeightLeafDx Leaf size, in cell widths, at or below which the tree build
  * switches from count-median to weight-median splitting -- forwarded verbatim to
  * buildKDQuotaLeaves(). 0 disables the weight median entirely.
+ * @param[in,out] a_cellHistogram Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
+ * @param[in,out] a_leafQuota Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
  * @param[in] a_gather Per-slot gather callback.
  * @param[in] a_combine N-ary opaque-payload combine callback.
  * @param[in] a_scatter Per-merged-particle scatter callback.
@@ -328,6 +341,8 @@ mergeKDInterior(AmrMesh&                      a_amr,
                 ParticleContainer<P, Traits>& a_interior,
                 const int                     a_ppc,
                 const Real                    a_splitWeightLeafDx,
+                EBAMRFAB&                     a_cellHistogram,
+                EBAMRFAB&                     a_leafQuota,
                 const Gather&                 a_gather,
                 const Combine&                a_combine,
                 const Scatter&                a_scatter,

--- a/Source/Particle/CD_KDParticleMerge.H
+++ b/Source/Particle/CD_KDParticleMerge.H
@@ -117,30 +117,30 @@ struct KDLeaf
  * be drained by a neighbour's merge.
  * @tparam Packed See MergeParticle.
  * @param[in,out] a_particles Particles to partition; reordered in place.
+ * @param[in,out] a_used Live per-cell leaf quota for this patch, zeroed on entry. Its box must cover
+ * every cell a leaf centroid can fall in, i.e. it needs at least one ghost cell.
+ * @param[out] a_leaves Every resulting leaf, in no particular order.
  * @param[in] a_ppc Target particles per cell, enforced here as a per-cell ceiling on leaf count.
  * @param[in] a_splitWeightLeafDx Leaf size, in cell widths, at or below which the split plane
  * switches from the count median to the weight median. 0 disables the weight median.
  * @param[in] a_dx This patch's own cell spacing.
  * @param[in] a_probLo Physical position of the domain's low corner, for computing cell indices.
- * @param[in,out] a_used Live per-cell leaf quota for this patch, zeroed on entry. Its box must cover
- * every cell a leaf centroid can fall in, i.e. it needs at least one ghost cell.
  * @param[in] a_cellCounts Per-cell TRUE particle-count histogram (see kdFillCellHistogram()). A cell
  * is crowded, and its particles eligible to merge, iff its count exceeds @a a_ppc. A cell outside
  * this box reads as 0 (empty): unlike @a a_used, whose box coverage is a hard precondition, this
  * lookup guards rather than asserts, since a particle's own cell is always in-box but the guard
  * costs nothing and documents the intent.
- * @param[out] a_leaves Every resulting leaf, in no particular order.
  */
 template <typename Packed>
 inline void
 buildKDQuotaLeaves(std::vector<MergeParticle<Packed>>& a_particles,
+                   FArrayBox&                          a_used,
+                   std::vector<KDLeaf>&                a_leaves,
                    const int                           a_ppc,
                    const Real                          a_splitWeightLeafDx,
                    const RealVect&                     a_dx,
                    const RealVect&                     a_probLo,
-                   FArrayBox&                          a_used,
-                   const FArrayBox&                    a_cellCounts,
-                   std::vector<KDLeaf>&                a_leaves) noexcept;
+                   const FArrayBox&                    a_cellCounts) noexcept;
 
 /**
  * @brief Generic Alltoallv-style exchange for a trivially-copyable record type: send a
@@ -184,17 +184,17 @@ kdExchangeByRank(const std::vector<std::vector<T>>& a_sendByRank);
  * @tparam Scatter Callable `(ParticleSoA<P,Traits>&, const MergeParticle<Packed>&) -> void`.
  * @tparam Allocator Callable `() -> ParticleID`, a fresh globally-unique id per committed merge.
  * @tparam PosValid Callable `(const RealVect&) -> bool`; false leaves the group's members untouched.
- * @param[in,out] a_amr AMR mesh -- source of the particle ghost masks and grid layout.
+ * @param[in] a_amr AMR mesh -- source of the particle ghost masks and grid layout.
  * @param[in,out] a_particles The real particle container being merged.
- * @param[in] a_ppc Target particles per cell.
- * @param[in] a_splitWeightLeafDx Leaf size, in cell widths, at or below which the tree build
- * switches from count-median to weight-median splitting -- forwarded verbatim to
- * buildKDQuotaLeaves(). 0 disables the weight median entirely.
  * @param[in,out] a_cellHistogram Caller-owned per-cell scratch (1 component, >= 1 ghost cell, this
  * container's realm) holding the cell occupancy. Contents on entry are irrelevant -- it is overwritten
  * per patch. Owned by the caller so the allocation happens once per regrid rather than once per call.
  * @param[in,out] a_leafQuota Caller-owned per-cell scratch, same shape and lifetime as
  * @a a_cellHistogram, holding the live per-cell merge quota.
+ * @param[in] a_ppc Target particles per cell.
+ * @param[in] a_splitWeightLeafDx Leaf size, in cell widths, at or below which the tree build
+ * switches from count-median to weight-median splitting -- forwarded verbatim to
+ * buildKDQuotaLeaves(). 0 disables the weight median entirely.
  * @param[in] a_gather Per-slot gather callback.
  * @param[in] a_combine N-ary opaque-payload combine callback.
  * @param[in] a_scatter Per-merged-particle scatter callback.
@@ -210,12 +210,12 @@ template <typename P,
           typename Allocator,
           typename PosValid>
 inline void
-mergeKDCarve(AmrMesh&                      a_amr,
-             ParticleContainer<P, Traits>& a_particles,
-             const int                     a_ppc,
-             const Real                    a_splitWeightLeafDx,
+mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
              EBAMRFAB&                     a_cellHistogram,
              EBAMRFAB&                     a_leafQuota,
+             const AmrMesh&                a_amr,
+             const int                     a_ppc,
+             const Real                    a_splitWeightLeafDx,
              const Gather&                 a_gather,
              const Combine&                a_combine,
              const Scatter&                a_scatter,
@@ -246,14 +246,14 @@ mergeKDCarve(AmrMesh&                      a_amr,
  * @tparam Scatter Callable `(ParticleSoA<P,Traits>&, const MergeParticle<Packed>&) -> void`.
  * @tparam Allocator Callable `() -> ParticleID`, a fresh globally-unique id per committed merge.
  * @tparam PosValid Callable `(const RealVect&) -> bool`; false leaves the leaf's members untouched.
- * @param[in,out] a_amr AMR mesh -- source of the grid layout.
  * @param[in,out] a_particles The real particle container being merged.
+ * @param[in,out] a_cellHistogram Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
+ * @param[in,out] a_leafQuota Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
+ * @param[in] a_amr AMR mesh -- source of the grid layout.
  * @param[in] a_ppc Target particles per cell.
  * @param[in] a_splitWeightLeafDx Leaf size, in cell widths, at or below which the tree build
  * switches from count-median to weight-median splitting -- forwarded verbatim to
  * buildKDQuotaLeaves(). 0 disables the weight median entirely.
- * @param[in,out] a_cellHistogram Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
- * @param[in,out] a_leafQuota Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
  * @param[in] a_gather Per-slot gather callback.
  * @param[in] a_combine N-ary opaque-payload combine callback.
  * @param[in] a_scatter Per-merged-particle scatter callback.
@@ -269,12 +269,12 @@ template <typename P,
           typename Allocator,
           typename PosValid>
 inline void
-mergeKDPatch(AmrMesh&                      a_amr,
-             ParticleContainer<P, Traits>& a_particles,
-             const int                     a_ppc,
-             const Real                    a_splitWeightLeafDx,
+mergeKDPatch(ParticleContainer<P, Traits>& a_particles,
              EBAMRFAB&                     a_cellHistogram,
              EBAMRFAB&                     a_leafQuota,
+             const AmrMesh&                a_amr,
+             const int                     a_ppc,
+             const Real                    a_splitWeightLeafDx,
              const Gather&                 a_gather,
              const Combine&                a_combine,
              const Scatter&                a_scatter,
@@ -311,16 +311,16 @@ mergeKDPatch(AmrMesh&                      a_amr,
  * @tparam Scatter Callable `(ParticleSoA<P,Traits>&, const MergeParticle<Packed>&) -> void`.
  * @tparam Allocator Callable `() -> ParticleID`, a fresh globally-unique id per committed merge.
  * @tparam PosValid Callable `(const RealVect&) -> bool`; false leaves the leaf's members untouched.
- * @param[in,out] a_amr AMR mesh -- source of the grid layout.
  * @param[in,out] a_particles Particles to reduce. On return holds only what was not committed.
  * @param[in,out] a_interior Receives one super-particle per committed leaf. Must be allocated on the
  * same realm as @a a_particles, since a leaf is written to the patch it was built on.
+ * @param[in,out] a_cellHistogram Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
+ * @param[in,out] a_leafQuota Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
+ * @param[in] a_amr AMR mesh -- source of the grid layout.
  * @param[in] a_ppc Target particles per cell.
  * @param[in] a_splitWeightLeafDx Leaf size, in cell widths, at or below which the tree build
  * switches from count-median to weight-median splitting -- forwarded verbatim to
  * buildKDQuotaLeaves(). 0 disables the weight median entirely.
- * @param[in,out] a_cellHistogram Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
- * @param[in,out] a_leafQuota Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
  * @param[in] a_gather Per-slot gather callback.
  * @param[in] a_combine N-ary opaque-payload combine callback.
  * @param[in] a_scatter Per-merged-particle scatter callback.
@@ -336,13 +336,13 @@ template <typename P,
           typename Allocator,
           typename PosValid>
 inline void
-mergeKDInterior(AmrMesh&                      a_amr,
-                ParticleContainer<P, Traits>& a_particles,
+mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
                 ParticleContainer<P, Traits>& a_interior,
-                const int                     a_ppc,
-                const Real                    a_splitWeightLeafDx,
                 EBAMRFAB&                     a_cellHistogram,
                 EBAMRFAB&                     a_leafQuota,
+                const AmrMesh&                a_amr,
+                const int                     a_ppc,
+                const Real                    a_splitWeightLeafDx,
                 const Gather&                 a_gather,
                 const Combine&                a_combine,
                 const Scatter&                a_scatter,

--- a/Source/Particle/CD_KDParticleMergeImplem.H
+++ b/Source/Particle/CD_KDParticleMergeImplem.H
@@ -30,7 +30,6 @@
 
 // Our includes
 #include <CD_LevelTiles.H>
-#include <CD_ParticleGhostMask.H>
 #include <CD_KDParticleMerge.H>
 #include <CD_NamespaceHeader.H>
 
@@ -578,17 +577,27 @@ buildKDQuotaLeaves(std::vector<MergeParticle<Packed>>& a_particles,
 }
 
 /**
- * @brief Whether a cell has any outgoing ghost-shipment target -- a duplicate of the nearest-
- * neighbor merge's isBoundaryExposed() (a one-line function, not worth an EBGeometry-pulling
- * dependency to reuse).
- * @param[in] a_cellIndex Cell index in the mask's own frame.
- * @param[in] a_ghostMask Outgoing particle ghost mask.
- * @return True iff the cell has at least one outgoing ghost-shipment target.
+ * @brief Real-space bounds of a box: the half-open region [lo, hi) that its cells cover.
+ * @details Half-open on purpose -- the high corner is the OUTER face of the last cell, so testing
+ * pos >= lo && pos < hi per direction partitions space between abutting boxes with no gap and no
+ * double-cover, which is exactly the "is this particle still in its own patch" test both callers make.
+ * @param[in]  a_box    Box whose bounds are wanted.
+ * @param[in]  a_dx     Grid spacing at the box's level.
+ * @param[in]  a_probLo Lower-left corner of the physical domain.
+ * @param[out] a_boxLo  Low corner (inclusive).
+ * @param[out] a_boxHi  High corner (exclusive).
  */
-inline bool
-kdIsBoundaryExposed(const IntVect& a_cellIndex, const ParticleGhostMask& a_ghostMask) noexcept
+inline void
+kdBoxRealBounds(const Box&      a_box,
+                const RealVect& a_dx,
+                const RealVect& a_probLo,
+                RealVect&       a_boxLo,
+                RealVect&       a_boxHi) noexcept
 {
-  return a_ghostMask.numTargets(a_cellIndex) > 0;
+  for (int dir = 0; dir < SpaceDim; dir++) {
+    a_boxLo[dir] = a_probLo[dir] + a_box.smallEnd(dir) * a_dx[dir];
+    a_boxHi[dir] = a_probLo[dir] + (a_box.bigEnd(dir) + 1) * a_dx[dir];
+  }
 }
 
 /**
@@ -643,6 +652,8 @@ mergeKDCarve(AmrMesh&                      a_amr,
              ParticleContainer<P, Traits>& a_particles,
              const int                     a_ppc,
              const Real                    a_splitWeightLeafDx,
+             EBAMRFAB&                     a_cellHistogram,
+             EBAMRFAB&                     a_leafQuota,
              const Gather&                 a_gather,
              const Combine&                a_combine,
              const Scatter&                a_scatter,
@@ -705,25 +716,23 @@ mergeKDCarve(AmrMesh&                      a_amr,
   CH_TIMER("ParticleManagement::mergeKDCarve::remove_consumed", t_remove);
   CH_TIMER("ParticleManagement::mergeKDCarve::place_results", t_place);
 
-  const std::string   realm       = a_particles.getRealm();
-  const int           finestLevel = a_amr.getFinestLevel();
-  const RealVect      probLo      = a_amr.getProbLo();
-  const Vector<Real>& dxScalar    = a_amr.getDx();
-
-  std::vector<RealVect> dxByLevel(finestLevel + 1);
-
-  for (int lvl = 0; lvl <= finestLevel; lvl++) {
-    dxByLevel[lvl] = dxScalar[lvl] * RealVect::Unit;
-  }
+  const std::string       realm       = a_particles.getRealm();
+  const int               finestLevel = a_amr.getFinestLevel();
+  const RealVect          probLo      = a_amr.getProbLo();
+  const Vector<RealVect>& dxByLevel   = a_amr.getDxAsRealVect();
 
   // Per-cell scratch, as mesh data on this realm rather than per-patch buffers: both quantities are
-  // cell data, and this is what the rest of the code uses for cell data. One ghost cell, which is
-  // what the gathered ghosts and any just-outside leaf centroid need.
-  EBAMRFAB histogram;
-  EBAMRFAB leafQuota;
+  // cell data, and this is what the rest of the code uses for cell data. The caller owns the holders
+  // so they are allocated once per regrid rather than once per call -- AmrMesh::allocate() builds a
+  // Copier per level, which is cheap in isolation but adds up at scale. Their one ghost cell is what
+  // the gathered ghosts and any just-outside leaf centroid need.
+  EBAMRFAB& histogram = a_cellHistogram;
+  EBAMRFAB& leafQuota = a_leafQuota;
 
-  a_amr.allocate(histogram, realm, 1, 1);
-  a_amr.allocate(leafQuota, realm, 1, 1);
+  CH_assert(histogram[0]->nComp() == 1);
+  CH_assert(leafQuota[0]->nComp() == 1);
+  CH_assert(histogram[0]->ghostVect() >= IntVect::Unit);
+  CH_assert(leafQuota[0]->ghostVect() >= IntVect::Unit);
 
   const int myRank   = procID();
   const int numRanks = numProc();
@@ -827,16 +836,16 @@ mergeKDCarve(AmrMesh&                      a_amr,
   std::vector<KDLeaf>   leaves;
   std::vector<KDMember> members;
 
+  // Which cells hold a particle that some other box can also see. Read from the realm, which derives it
+  // from the three ghost masks when they are built; see Realm::m_particleGhostExposure.
+  const AMRMask& exposure = a_amr.getParticleGhostExposure(realm, 1);
+
   // ==== STEP 1: gather + build + classify + commit interior, per patch ====
   CH_START(t_build);
 
   for (int lvl = 0; lvl <= finestLevel; lvl++) {
     const DisjointBoxLayout& dbl = a_amr.getGrids(realm)[lvl];
     const DataIterator&      dit = dbl.dataIterator();
-
-    const AMRParticleGhostMask& maskSame = a_amr.getParticleGhostMask(realm, 1);
-    const AMRParticleGhostMask& maskC2F  = a_amr.getParticleGhostMaskCoarToFine(realm, 1);
-    const AMRParticleGhostMask& maskF2C  = a_amr.getParticleGhostMaskFineToCoar(realm, 1);
 
     const int nbox = dit.size();
 
@@ -845,10 +854,7 @@ mergeKDCarve(AmrMesh&                      a_amr,
 
       ParticleSoA<P, Traits>& leaf = a_particles[lvl][din];
 
-      const ParticleGhostMask* maskSameDin = maskSame[lvl].isNull() ? nullptr : &(*maskSame[lvl])[din];
-      const ParticleGhostMask* maskC2FDin  = (lvl < finestLevel && !maskC2F[lvl].isNull()) ? &(*maskC2F[lvl])[din]
-                                                                                           : nullptr;
-      const ParticleGhostMask* maskF2CDin  = (lvl > 0 && !maskF2C[lvl].isNull()) ? &(*maskF2C[lvl])[din] : nullptr;
+      const BaseFab<bool>& exposureDin = (*exposure[lvl])[din];
 
       std::vector<MergeParticle<Packed>> combined;
       combined.reserve(leaf.size());
@@ -890,36 +896,6 @@ mergeKDCarve(AmrMesh&                      a_amr,
       kdFillCellHistogram(combined, probLo, dxByLevel[lvl], cellCounts);
 
       buildKDQuotaLeaves(combined, a_ppc, a_splitWeightLeafDx, dxByLevel[lvl], probLo, quota, cellCounts, leaves);
-
-      // Per-patch exposure cache. Leaves are about a cell in extent and not grid-aligned, so many
-      // leaves (and many members within one leaf) end up querying the SAME cell's exposure; compute
-      // it (up to 3 mask lookups) once per distinct cell and reuse the cached bit. Tri-state: -1
-      // uncached, 0 not exposed, 1 exposed.
-      //
-      // Held over the patch's OWN box, ungrown: only resident (non-ghost) members are ever queried,
-      // and resident is exactly what it means for a cell to lie in this box. That is why this one
-      // does not need the growth the histogram and the live quota do.
-      BaseFab<signed char> exposureCache(dbl[din], 1);
-      exposureCache.setVal(-1);
-
-      auto isExposedCached = [&](const IntVect& a_iv) -> bool {
-        CH_assert(exposureCache.box().contains(a_iv));
-
-        if (exposureCache(a_iv, 0) < 0) {
-          bool isExposed = (maskSameDin != nullptr) && kdIsBoundaryExposed(a_iv, *maskSameDin);
-
-          if (!isExposed && maskC2FDin != nullptr) {
-            isExposed = kdIsBoundaryExposed(a_iv, *maskC2FDin);
-          }
-          if (!isExposed && maskF2CDin != nullptr) {
-            isExposed = kdIsBoundaryExposed(a_iv, *maskF2CDin);
-          }
-
-          exposureCache(a_iv, 0) = isExposed ? 1 : 0;
-        }
-
-        return exposureCache(a_iv, 0) != 0;
-      };
 
       for (const KDLeaf& bl : leaves) {
         members.clear();
@@ -963,9 +939,8 @@ mergeKDCarve(AmrMesh&                      a_amr,
         // Per-resident-member exposure -- needed either way (leaf-wide OR for the interior/
         // boundary decision below; per-particle for the unmergeable-leaf listen-only case). Ghosts
         // are skipped entirely, not just because they have no standing (above) but because their
-        // position lies outside this patch's own box -- testing a ghost's cell against THIS
-        // patch's own ghost mask would violate ParticleGhostMask::numTargets()'s own precondition
-        // that the cell lie within the mask's box(). Filtering on isGhost (not ownerRank) is what
+        // position lies outside this patch's own box -- the exposure mask carries no ghost cells, so
+        // a ghost's cell is not addressable in it at all. Filtering on isGhost (not ownerRank) is what
         // makes this safe: a particle owned by this rank via a different patch is exactly as much
         // a ghost here, position-wise, as one owned by a different rank entirely.
         std::vector<bool> exposed(bl.hi - bl.lo, false);
@@ -979,8 +954,11 @@ mergeKDCarve(AmrMesh&                      a_amr,
             continue;
           }
 
-          const IntVect cell      = kdCellKeyOf(combined[idx].position, probLo, dxByLevel[lvl]);
-          const bool    isExposed = isExposedCached(cell);
+          const IntVect cell = kdCellKeyOf(combined[idx].position, probLo, dxByLevel[lvl]);
+
+          CH_assert(exposureDin.box().contains(cell));
+
+          const bool isExposed = exposureDin(cell, 0);
 
           exposed[idx - bl.lo] = isExposed;
           anyExposed           = anyExposed || isExposed;
@@ -1511,10 +1489,7 @@ mergeKDCarve(AmrMesh&                      a_amr,
 
     RealVect boxRealLo, boxRealHi;
 
-    for (int dir = 0; dir < SpaceDim; dir++) {
-      boxRealLo[dir] = probLo[dir] + pw.box.smallEnd(dir) * pw.dx[dir];
-      boxRealHi[dir] = probLo[dir] + (pw.box.bigEnd(dir) + 1) * pw.dx[dir];
-    }
+    kdBoxRealBounds(pw.box, pw.dx, probLo, boxRealLo, boxRealHi);
 
     bool inOwnBox = true;
 
@@ -1583,6 +1558,8 @@ mergeKDPatch(AmrMesh&                      a_amr,
              ParticleContainer<P, Traits>& a_particles,
              const int                     a_ppc,
              const Real                    a_splitWeightLeafDx,
+             EBAMRFAB&                     a_cellHistogram,
+             EBAMRFAB&                     a_leafQuota,
              const Gather&                 a_gather,
              const Combine&                a_combine,
              const Scatter&                a_scatter,
@@ -1602,6 +1579,8 @@ mergeKDPatch(AmrMesh&                      a_amr,
                                      a_particles,
                                      a_ppc,
                                      a_splitWeightLeafDx,
+                                     a_cellHistogram,
+                                     a_leafQuota,
                                      a_gather,
                                      a_combine,
                                      a_scatter,
@@ -1623,6 +1602,8 @@ mergeKDInterior(AmrMesh&                      a_amr,
                 ParticleContainer<P, Traits>& a_interior,
                 const int                     a_ppc,
                 const Real                    a_splitWeightLeafDx,
+                EBAMRFAB&                     a_cellHistogram,
+                EBAMRFAB&                     a_leafQuota,
                 const Gather&                 a_gather,
                 const Combine&                a_combine,
                 const Scatter&                a_scatter,
@@ -1636,29 +1617,23 @@ mergeKDInterior(AmrMesh&                      a_amr,
   CH_TIMER("ParticleManagement::mergeKDInterior::commit", t_commit);
   CH_TIMER("ParticleManagement::mergeKDInterior::remove_place", t_place);
 
-  const std::string   realm       = a_particles.getRealm();
-  const int           finestLevel = a_amr.getFinestLevel();
-  const RealVect      probLo      = a_amr.getProbLo();
-  const Vector<Real>& dxScalar    = a_amr.getDx();
+  const std::string       realm       = a_particles.getRealm();
+  const int               finestLevel = a_amr.getFinestLevel();
+  const RealVect          probLo      = a_amr.getProbLo();
+  const Vector<RealVect>& dxByLevel   = a_amr.getDxAsRealVect();
 
   // A leaf committed from patch (lvl,din) is written to the SAME patch of a_interior, which is only
   // meaningful when the two containers share a layout.
   CH_assert(a_interior.getRealm() == realm);
 
-  std::vector<RealVect> dxByLevel(finestLevel + 1);
+  // Caller-owned per-cell scratch; see mergeKDCarve() for why the holders are not allocated here.
+  EBAMRFAB& histogram = a_cellHistogram;
+  EBAMRFAB& leafQuota = a_leafQuota;
 
-  for (int lvl = 0; lvl <= finestLevel; lvl++) {
-    dxByLevel[lvl] = dxScalar[lvl] * RealVect::Unit;
-  }
-
-  // Per-cell scratch, as mesh data on this realm rather than per-patch buffers: both quantities are
-  // cell data, and this is what the rest of the code uses for cell data. One ghost cell, which is
-  // what the gathered ghosts and any just-outside leaf centroid need.
-  EBAMRFAB histogram;
-  EBAMRFAB leafQuota;
-
-  a_amr.allocate(histogram, realm, 1, 1);
-  a_amr.allocate(leafQuota, realm, 1, 1);
+  CH_assert(histogram[0]->nComp() == 1);
+  CH_assert(leafQuota[0]->nComp() == 1);
+  CH_assert(histogram[0]->ghostVect() >= IntVect::Unit);
+  CH_assert(leafQuota[0]->ghostVect() >= IntVect::Unit);
 
   const int myRank = procID();
 
@@ -1823,10 +1798,7 @@ mergeKDInterior(AmrMesh&                      a_amr,
 
       RealVect boxRealLo, boxRealHi;
 
-      for (int dir = 0; dir < SpaceDim; dir++) {
-        boxRealLo[dir] = probLo[dir] + dbl[din].smallEnd(dir) * dxByLevel[lvl][dir];
-        boxRealHi[dir] = probLo[dir] + (dbl[din].bigEnd(dir) + 1) * dxByLevel[lvl][dir];
-      }
+      kdBoxRealBounds(dbl[din], dxByLevel[lvl], probLo, boxRealLo, boxRealHi);
 
       for (const MergeParticle<Packed>& mr : mergedResults) {
         bool inOwnBox = true;

--- a/Source/Particle/CD_KDParticleMergeImplem.H
+++ b/Source/Particle/CD_KDParticleMergeImplem.H
@@ -112,19 +112,19 @@ kdExchangeByRank(const std::vector<std::vector<T>>& a_sendByRank)
 
 /**
  * @brief Axis-aligned bounding box of particles[a_lo, a_hi).
+ * @param[out] a_boxLo Low corner.
+ * @param[out] a_boxHi High corner.
  * @param[in] a_particles Particle buffer.
  * @param[in] a_lo Start of the range (inclusive).
  * @param[in] a_hi End of the range (exclusive).
- * @param[out] a_boxLo Low corner.
- * @param[out] a_boxHi High corner.
  */
 template <typename Packed>
 inline void
-kdBBox(const std::vector<MergeParticle<Packed>>& a_particles,
+kdBBox(RealVect&                                 a_boxLo,
+       RealVect&                                 a_boxHi,
+       const std::vector<MergeParticle<Packed>>& a_particles,
        const std::size_t                         a_lo,
-       const std::size_t                         a_hi,
-       RealVect&                                 a_boxLo,
-       RealVect&                                 a_boxHi) noexcept
+       const std::size_t                         a_hi) noexcept
 {
   CH_assert(a_hi > a_lo);
   CH_assert(a_hi <= a_particles.size());
@@ -233,17 +233,17 @@ kdIntVectLess(const IntVect& a_lhs, const IntVect& a_rhs) noexcept
  * represents every integer exactly up to 2^53, so consumers -- e.g. the crowding test in
  * buildKDQuotaLeaves() -- may @c static_cast<int> it losslessly for any realistic per-cell count.
  * @tparam Packed See MergeParticle.
+ * @param[out] a_counts Per-cell counts, zeroed here before tallying.
  * @param[in] a_particles Gathered particles for this patch.
  * @param[in] a_probLo Physical position of the domain's low corner.
  * @param[in] a_dx This patch's own cell spacing.
- * @param[out] a_counts Per-cell counts, zeroed here before tallying.
  */
 template <typename Packed>
 inline void
-kdFillCellHistogram(const std::vector<MergeParticle<Packed>>& a_particles,
+kdFillCellHistogram(FArrayBox&                                a_counts,
+                    const std::vector<MergeParticle<Packed>>& a_particles,
                     const RealVect&                           a_probLo,
-                    const RealVect&                           a_dx,
-                    FArrayBox&                                a_counts) noexcept
+                    const RealVect&                           a_dx) noexcept
 {
   a_counts.setVal(0);
 
@@ -366,13 +366,13 @@ kdSplitWeightMedian(std::vector<MergeParticle<Packed>>& a_particles,
 template <typename Packed>
 inline void
 buildKDQuotaLeaves(std::vector<MergeParticle<Packed>>& a_particles,
+                   FArrayBox&                          a_used,
+                   std::vector<KDLeaf>&                a_leaves,
                    const int                           a_ppc,
                    const Real                          a_splitWeightLeafDx,
                    const RealVect&                     a_dx,
                    const RealVect&                     a_probLo,
-                   FArrayBox&                          a_used,
-                   const FArrayBox&                    a_cellCounts,
-                   std::vector<KDLeaf>&                a_leaves) noexcept
+                   const FArrayBox&                    a_cellCounts) noexcept
 {
   CH_TIME("ParticleManagement::buildKDQuotaLeaves");
 
@@ -403,7 +403,7 @@ buildKDQuotaLeaves(std::vector<MergeParticle<Packed>>& a_particles,
 
   for (std::size_t idx = numMergeable; idx < a_particles.size(); idx++) {
     RealVect boxLo, boxHi;
-    kdBBox(a_particles, idx, idx + 1, boxLo, boxHi);
+    kdBBox(boxLo, boxHi, a_particles, idx, idx + 1);
 
     a_leaves.push_back(KDLeaf{idx, idx + 1, boxLo, boxHi});
   }
@@ -499,7 +499,7 @@ buildKDQuotaLeaves(std::vector<MergeParticle<Packed>>& a_particles,
 
     if (node.count < 2) {
       RealVect boxLo, boxHi;
-      kdBBox(a_particles, node.lo, node.hi, boxLo, boxHi);
+      kdBBox(boxLo, boxHi, a_particles, node.lo, node.hi);
 
       finalLeaves.push_back(KDLeaf{node.lo, node.hi, boxLo, boxHi});
 
@@ -511,7 +511,7 @@ buildKDQuotaLeaves(std::vector<MergeParticle<Packed>>& a_particles,
     // refused below -- the emitted leaf (formerly re-derived a third time in the emission pass). A
     // split only reorders within [lo,hi), so the box is unchanged by it either way.
     RealVect nodeBoxLo, nodeBoxHi;
-    kdBBox(a_particles, node.lo, node.hi, nodeBoxLo, nodeBoxHi);
+    kdBBox(nodeBoxLo, nodeBoxHi, a_particles, node.lo, node.hi);
 
     const Real nodeSpan  = kdMaxAxisSpan(nodeBoxLo, nodeBoxHi, a_dx);
     const int  splitAxis = (nodeBoxHi - nodeBoxLo).maxDir(true);
@@ -581,18 +581,18 @@ buildKDQuotaLeaves(std::vector<MergeParticle<Packed>>& a_particles,
  * @details Half-open on purpose -- the high corner is the OUTER face of the last cell, so testing
  * pos >= lo && pos < hi per direction partitions space between abutting boxes with no gap and no
  * double-cover, which is exactly the "is this particle still in its own patch" test both callers make.
+ * @param[out] a_boxLo  Low corner (inclusive).
+ * @param[out] a_boxHi  High corner (exclusive).
  * @param[in]  a_box    Box whose bounds are wanted.
  * @param[in]  a_dx     Grid spacing at the box's level.
  * @param[in]  a_probLo Lower-left corner of the physical domain.
- * @param[out] a_boxLo  Low corner (inclusive).
- * @param[out] a_boxHi  High corner (exclusive).
  */
 inline void
-kdBoxRealBounds(const Box&      a_box,
+kdBoxRealBounds(RealVect&       a_boxLo,
+                RealVect&       a_boxHi,
+                const Box&      a_box,
                 const RealVect& a_dx,
-                const RealVect& a_probLo,
-                RealVect&       a_boxLo,
-                RealVect&       a_boxHi) noexcept
+                const RealVect& a_probLo) noexcept
 {
   for (int dir = 0; dir < SpaceDim; dir++) {
     a_boxLo[dir] = a_probLo[dir] + a_box.smallEnd(dir) * a_dx[dir];
@@ -648,12 +648,12 @@ template <typename P,
           typename Allocator,
           typename PosValid>
 inline void
-mergeKDCarve(AmrMesh&                      a_amr,
-             ParticleContainer<P, Traits>& a_particles,
-             const int                     a_ppc,
-             const Real                    a_splitWeightLeafDx,
+mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
              EBAMRFAB&                     a_cellHistogram,
              EBAMRFAB&                     a_leafQuota,
+             const AmrMesh&                a_amr,
+             const int                     a_ppc,
+             const Real                    a_splitWeightLeafDx,
              const Gather&                 a_gather,
              const Combine&                a_combine,
              const Scatter&                a_scatter,
@@ -893,9 +893,9 @@ mergeKDCarve(AmrMesh&                      a_amr,
       FArrayBox& cellCounts = (*histogram[lvl])[din];
       FArrayBox& quota      = (*leafQuota[lvl])[din];
 
-      kdFillCellHistogram(combined, probLo, dxByLevel[lvl], cellCounts);
+      kdFillCellHistogram(cellCounts, combined, probLo, dxByLevel[lvl]);
 
-      buildKDQuotaLeaves(combined, a_ppc, a_splitWeightLeafDx, dxByLevel[lvl], probLo, quota, cellCounts, leaves);
+      buildKDQuotaLeaves(combined, quota, leaves, a_ppc, a_splitWeightLeafDx, dxByLevel[lvl], probLo, cellCounts);
 
       for (const KDLeaf& bl : leaves) {
         members.clear();
@@ -1489,7 +1489,7 @@ mergeKDCarve(AmrMesh&                      a_amr,
 
     RealVect boxRealLo, boxRealHi;
 
-    kdBoxRealBounds(pw.box, pw.dx, probLo, boxRealLo, boxRealHi);
+    kdBoxRealBounds(boxRealLo, boxRealHi, pw.box, pw.dx, probLo);
 
     bool inOwnBox = true;
 
@@ -1554,12 +1554,12 @@ template <typename P,
           typename Allocator,
           typename PosValid>
 inline void
-mergeKDPatch(AmrMesh&                      a_amr,
-             ParticleContainer<P, Traits>& a_particles,
-             const int                     a_ppc,
-             const Real                    a_splitWeightLeafDx,
+mergeKDPatch(ParticleContainer<P, Traits>& a_particles,
              EBAMRFAB&                     a_cellHistogram,
              EBAMRFAB&                     a_leafQuota,
+             const AmrMesh&                a_amr,
+             const int                     a_ppc,
+             const Real                    a_splitWeightLeafDx,
              const Gather&                 a_gather,
              const Combine&                a_combine,
              const Scatter&                a_scatter,
@@ -1574,13 +1574,13 @@ mergeKDPatch(AmrMesh&                      a_amr,
   // so every gathered particle is resident, every leaf is ghost-free, and that test admits them all.
   // Passing a_particles as its own destination puts the super-particles back where the patch merge
   // has always put them.
-  mergeKDInterior<P, Packed, Traits>(a_amr,
+  mergeKDInterior<P, Packed, Traits>(a_particles,
                                      a_particles,
-                                     a_particles,
-                                     a_ppc,
-                                     a_splitWeightLeafDx,
                                      a_cellHistogram,
                                      a_leafQuota,
+                                     a_amr,
+                                     a_ppc,
+                                     a_splitWeightLeafDx,
                                      a_gather,
                                      a_combine,
                                      a_scatter,
@@ -1597,13 +1597,13 @@ template <typename P,
           typename Allocator,
           typename PosValid>
 inline void
-mergeKDInterior(AmrMesh&                      a_amr,
-                ParticleContainer<P, Traits>& a_particles,
+mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
                 ParticleContainer<P, Traits>& a_interior,
-                const int                     a_ppc,
-                const Real                    a_splitWeightLeafDx,
                 EBAMRFAB&                     a_cellHistogram,
                 EBAMRFAB&                     a_leafQuota,
+                const AmrMesh&                a_amr,
+                const int                     a_ppc,
+                const Real                    a_splitWeightLeafDx,
                 const Gather&                 a_gather,
                 const Combine&                a_combine,
                 const Scatter&                a_scatter,
@@ -1686,9 +1686,9 @@ mergeKDInterior(AmrMesh&                      a_amr,
       FArrayBox& cellCounts = (*histogram[lvl])[din];
       FArrayBox& quota      = (*leafQuota[lvl])[din];
 
-      kdFillCellHistogram(combined, probLo, dxByLevel[lvl], cellCounts);
+      kdFillCellHistogram(cellCounts, combined, probLo, dxByLevel[lvl]);
 
-      buildKDQuotaLeaves(combined, a_ppc, a_splitWeightLeafDx, dxByLevel[lvl], probLo, quota, cellCounts, leaves);
+      buildKDQuotaLeaves(combined, quota, leaves, a_ppc, a_splitWeightLeafDx, dxByLevel[lvl], probLo, cellCounts);
 
       CH_STOP(t_build);
       CH_START(t_commit);
@@ -1798,7 +1798,7 @@ mergeKDInterior(AmrMesh&                      a_amr,
 
       RealVect boxRealLo, boxRealHi;
 
-      kdBoxRealBounds(dbl[din], dxByLevel[lvl], probLo, boxRealLo, boxRealHi);
+      kdBoxRealBounds(boxRealLo, boxRealHi, dbl[din], dxByLevel[lvl], probLo);
 
       for (const MergeParticle<Packed>& mr : mergedResults) {
         bool inOwnBox = true;

--- a/Source/Particle/CD_KDParticleMergeImplem.H
+++ b/Source/Particle/CD_KDParticleMergeImplem.H
@@ -716,10 +716,9 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
   CH_TIMER("ParticleManagement::mergeKDCarve::remove_consumed", t_remove);
   CH_TIMER("ParticleManagement::mergeKDCarve::place_results", t_place);
 
-  const std::string       realm       = a_particles.getRealm();
-  const int               finestLevel = a_amr.getFinestLevel();
-  const RealVect          probLo      = a_amr.getProbLo();
-  const Vector<RealVect>& dxByLevel   = a_amr.getDxAsRealVect();
+  const std::string realm       = a_particles.getRealm();
+  const int         finestLevel = a_amr.getFinestLevel();
+  const RealVect    probLo      = a_amr.getProbLo();
 
   // Per-cell scratch, as mesh data on this realm rather than per-patch buffers: both quantities are
   // cell data, and this is what the rest of the code uses for cell data. The caller owns the holders
@@ -847,6 +846,8 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
     const DisjointBoxLayout& dbl = a_amr.getGrids(realm)[lvl];
     const DataIterator&      dit = dbl.dataIterator();
 
+    const RealVect dx = a_amr.getDx()[lvl] * RealVect::Unit;
+
     const int nbox = dit.size();
 
     for (int mybox = 0; mybox < nbox; mybox++) {
@@ -879,7 +880,7 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
         particlesByID.emplace_back(p.globalID, gatheredParticles.size() - 1);
       }
 
-      patchWork.push_back(PatchWork{lvl, din, dxByLevel[lvl], dbl[din]});
+      patchWork.push_back(PatchWork{lvl, din, dx, dbl[din]});
       const int patchIdx = static_cast<int>(patchWork.size()) - 1;
 
       if (combined.empty()) {
@@ -893,9 +894,9 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
       FArrayBox& cellCounts = (*histogram[lvl])[din];
       FArrayBox& quota      = (*leafQuota[lvl])[din];
 
-      kdFillCellHistogram(cellCounts, combined, probLo, dxByLevel[lvl]);
+      kdFillCellHistogram(cellCounts, combined, probLo, dx);
 
-      buildKDQuotaLeaves(combined, quota, leaves, a_ppc, a_splitWeightLeafDx, dxByLevel[lvl], probLo, cellCounts);
+      buildKDQuotaLeaves(combined, quota, leaves, a_ppc, a_splitWeightLeafDx, dx, probLo, cellCounts);
 
       for (const KDLeaf& bl : leaves) {
         members.clear();
@@ -934,7 +935,7 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
         // volume ratio alone cannot be trusted here (a long, thin leaf can have volume <=
         // one cell while still spanning several cells along one axis). leafVolume itself
         // is still needed below, unrelated to this check -- it's the box key's tie-break priority.
-        const bool unmergeable = kdMaxAxisSpan(bl.boxLo, bl.boxHi, dxByLevel[lvl]) > s_kdMaxLeafExtent;
+        const bool unmergeable = kdMaxAxisSpan(bl.boxLo, bl.boxHi, dx) > s_kdMaxLeafExtent;
 
         // Per-resident-member exposure -- needed either way (leaf-wide OR for the interior/
         // boundary decision below; per-particle for the unmergeable-leaf listen-only case). Ghosts
@@ -954,7 +955,7 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
             continue;
           }
 
-          const IntVect cell = kdCellKeyOf(combined[idx].position, probLo, dxByLevel[lvl]);
+          const IntVect cell = kdCellKeyOf(combined[idx].position, probLo, dx);
 
           CH_assert(exposureDin.box().contains(cell));
 
@@ -1617,10 +1618,9 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
   CH_TIMER("ParticleManagement::mergeKDInterior::commit", t_commit);
   CH_TIMER("ParticleManagement::mergeKDInterior::remove_place", t_place);
 
-  const std::string       realm       = a_particles.getRealm();
-  const int               finestLevel = a_amr.getFinestLevel();
-  const RealVect          probLo      = a_amr.getProbLo();
-  const Vector<RealVect>& dxByLevel   = a_amr.getDxAsRealVect();
+  const std::string realm       = a_particles.getRealm();
+  const int         finestLevel = a_amr.getFinestLevel();
+  const RealVect    probLo      = a_amr.getProbLo();
 
   // A leaf committed from patch (lvl,din) is written to the SAME patch of a_interior, which is only
   // meaningful when the two containers share a layout.
@@ -1646,6 +1646,8 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
   for (int lvl = 0; lvl <= finestLevel; lvl++) {
     const DisjointBoxLayout& dbl = a_amr.getGrids(realm)[lvl];
     const DataIterator&      dit = dbl.dataIterator();
+
+    const RealVect dx = a_amr.getDx()[lvl] * RealVect::Unit;
 
     const int nbox = dit.size();
 
@@ -1686,9 +1688,9 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
       FArrayBox& cellCounts = (*histogram[lvl])[din];
       FArrayBox& quota      = (*leafQuota[lvl])[din];
 
-      kdFillCellHistogram(cellCounts, combined, probLo, dxByLevel[lvl]);
+      kdFillCellHistogram(cellCounts, combined, probLo, dx);
 
-      buildKDQuotaLeaves(combined, quota, leaves, a_ppc, a_splitWeightLeafDx, dxByLevel[lvl], probLo, cellCounts);
+      buildKDQuotaLeaves(combined, quota, leaves, a_ppc, a_splitWeightLeafDx, dx, probLo, cellCounts);
 
       CH_STOP(t_build);
       CH_START(t_commit);
@@ -1702,7 +1704,7 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
         }
 
         // Cheap geometric test before the O(members) ghost scan below.
-        if (kdMaxAxisSpan(bl.boxLo, bl.boxHi, dxByLevel[lvl]) > s_kdMaxLeafExtent) {
+        if (kdMaxAxisSpan(bl.boxLo, bl.boxHi, dx) > s_kdMaxLeafExtent) {
           continue;
         }
 
@@ -1798,7 +1800,7 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
 
       RealVect boxRealLo, boxRealHi;
 
-      kdBoxRealBounds(boxRealLo, boxRealHi, dbl[din], dxByLevel[lvl], probLo);
+      kdBoxRealBounds(boxRealLo, boxRealHi, dbl[din], dx, probLo);
 
       for (const MergeParticle<Packed>& mr : mergedResults) {
         bool inOwnBox = true;

--- a/Source/Particle/CD_KDParticleMergeImplem.H
+++ b/Source/Particle/CD_KDParticleMergeImplem.H
@@ -818,6 +818,7 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
     const DataIterator&      dit  = dbl.dataIterator();
     const int                nbox = dit.size();
 
+#pragma omp parallel for schedule(runtime) reduction(+ : combinedCountUpperBound)
     for (int mybox = 0; mybox < nbox; mybox++) {
       combinedCountUpperBound += a_particles[lvl][dit[mybox]].size();
     }
@@ -850,6 +851,10 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
 
     const int nbox = dit.size();
 
+    // Serial (no omp): every patch appends to the same gatheredParticles/particlesByID/patchWork/
+    // selfClaims/consumedIDs buffers, reuses the shared leaves/members scratch declared above, and
+    // draws ids from the single a_allocateID() counter. Parallelising the box loop would race on all
+    // of them, and the id race would mint duplicates.
     for (int mybox = 0; mybox < nbox; mybox++) {
       const DataIndex& din = dit[mybox];
 
@@ -1651,6 +1656,8 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
 
     const int nbox = dit.size();
 
+    // Serial (no omp): the leaves scratch is shared across patches by design, consumedIDs is appended
+    // to from every patch, and a_allocateID() hands out ids from one counter.
     for (int mybox = 0; mybox < nbox; mybox++) {
       const DataIndex& din = dit[mybox];
 

--- a/Source/Particle/CD_NearestNeighborParticleMerge.H
+++ b/Source/Particle/CD_NearestNeighborParticleMerge.H
@@ -40,7 +40,6 @@
 #include <CD_ParticleSoA.H>
 #include <CD_ParticleContainer.H>
 #include <CD_ParticleManagement.H>
-#include <CD_ParticleGhostMask.H>
 #include <CD_NamespaceHeader.H>
 
 class AmrMesh;
@@ -134,8 +133,8 @@ struct NNMergeEdge
   /**
    * @brief True iff the candidate is a locally-valid particle in the SAME patch as the query
    * (i.e. not a ghost). Note this is NOT sufficient on its own to decide trivial-tier
-   * eligibility -- see isBoundaryExposed(): a same-patch candidate can still require the
-   * propose/judge/verdict protocol if either participant is boundary-exposed.
+   * eligibility -- see Realm::m_particleGhostExposure: a same-patch candidate can still require
+   * the propose/judge/verdict protocol if either participant is boundary-exposed.
    */
   bool candidateIsLocal;
 
@@ -561,25 +560,6 @@ buildNNSpatialIndex(const std::vector<MergeParticle<Packed>>& a_localValid,
                     NNSpatialIndex<Packed, Cloud>&            a_index) noexcept;
 
 /**
- * @brief Whether a particle is boundary-exposed -- i.e. would be shipped as a ghost to at
- * least one neighboring patch.
- * @details The eligibility test for the trivial tier (see resolveTrivialTier()). A direct lookup
- * against the patch's own outgoing ghost mask -- whether this particle's cell has any registered
- * destination (@c ParticleGhostMask::numTargets()) -- not "same rank" and not "same ParticleSoA": a
- * particle can be exposed to a different patch owned by the same rank, and can be exposed while its
- * candidate sits in the same ParticleSoA.
- * @param[in] a_cellIndex Cell index (IntVect) of the particle, in this patch's own local frame -- i.e. whatever
- * a_ghostMask itself is keyed by (see ParticleGhostMask::define()/addTarget()).
- * @param[in] a_ghostMask This patch's own OUTGOING particle ghost mask, as returned by
- * AmrMesh::getParticleGhostMask() (or getParticleGhostMaskCoarToFine()/ getParticleGhostMaskFineToCoar() for
- * cross-level exposure -- a particle can be boundary-exposed toward a coarser or finer level too, not just the same
- * level; see mergeNearestNeighborsTree() for how the three mask kinds are combined into one boundary-exposed test).
- * @return True iff the particle's cell has at least one outgoing ghost-shipment target.
- */
-inline bool
-isBoundaryExposed(const IntVect& a_cellIndex, const ParticleGhostMask& a_ghostMask) noexcept;
-
-/**
  * @brief For every over-threshold, currently-alive valid particle in a patch, find its single
  * TRUE nearest neighbor among {this patch's own other valid particles} union {every ghost
  * shipped to this patch}.
@@ -788,7 +768,7 @@ findNearestNeighborCandidatesOneCell(const std::vector<MergeParticle<Packed>>&  
  * coordination, and mark which remaining particles have committed to a non-trivial outgoing
  * proposal.
  * @details An edge is trivial-tier eligible iff NEITHER the query nor the candidate is
- * boundary-exposed (see isBoundaryExposed()) -- this check happens AFTER finding the true nearest
+ * boundary-exposed (see Realm::m_particleGhostExposure) -- this check happens AFTER finding the true nearest
  * neighbor, never as a restriction on the search itself.
  *
  * All eligible edges (across every patch this rank owns) are processed in ONE globally
@@ -834,7 +814,7 @@ findNearestNeighborCandidatesOneCell(const std::vector<MergeParticle<Packed>>&  
  * @param[in] a_particlesByID Full particle data for every currently-alive local valid particle and every ghost across
  * all of this rank's patches, keyed by id. Each value is an NNPooledParticle: the particle (position/weight/id/rank/
  * payload, needed to compute a merge's weighted-centroid position and call a_combine, since an edge only carries
- * ids/distance) plus its cached boundary-exposure flag (isBoundaryExposed(); false for ghosts).
+ * ids/distance) plus its cached boundary-exposure flag (Realm::m_particleGhostExposure; false for ghosts).
  * @param[in] a_combine Opaque-payload combine callback (see PayloadCombine).
  * @param[in,out] a_liveCellCount Live per-cell counts; decremented in place as trivial merges commit, so later edges
  * in the same pass see the up-to-date occupancy.

--- a/Source/Particle/CD_NearestNeighborParticleMerge.H
+++ b/Source/Particle/CD_NearestNeighborParticleMerge.H
@@ -539,6 +539,7 @@ struct NNSpatialIndex
  * function relies on each @c Cloud's own default for whatever third construction parameter it takes (target leaf
  * size for PointCloudBVH, target points per cell for PointCloudHashGrid) -- both defaults are reasonable, general
  * choices, so neither backend needs bespoke construction logic here.
+ * @param[out] a_index The resulting spatial index.
  * @param[in] a_localValid This patch's own full valid-particle set.
  * @param[in] a_ghosts Every ghost shipped to this patch this round.
  * @param[in] a_probLo Physical position of the domain's low corner.
@@ -547,17 +548,16 @@ struct NNSpatialIndex
  * mergeNearestNeighborsTree()'s own a_cellBudget) -- used ONLY for the per-cell pre-filter above.
  * @param[in] a_kNearest k = 1 + a_maxFallbackCandidates -- the neighbor count to precompute per point into
  * NNSpatialIndex::pointCloudGraph.
- * @param[out] a_index The resulting spatial index.
  */
 template <typename Packed, typename Cloud = EBGeometry::PointCloudBVH<Real, ParticleID>>
 inline void
-buildNNSpatialIndex(const std::vector<MergeParticle<Packed>>& a_localValid,
+buildNNSpatialIndex(NNSpatialIndex<Packed, Cloud>&            a_index,
+                    const std::vector<MergeParticle<Packed>>& a_localValid,
                     const std::vector<MergeParticle<Packed>>& a_ghosts,
                     const RealVect&                           a_probLo,
                     const RealVect&                           a_dx,
                     const NNCellBudget&                       a_cellBudget,
-                    const int                                 a_kNearest,
-                    NNSpatialIndex<Packed, Cloud>&            a_index) noexcept;
+                    const int                                 a_kNearest) noexcept;
 
 /**
  * @brief For every over-threshold, currently-alive valid particle in a patch, find its single
@@ -595,6 +595,8 @@ buildNNSpatialIndex(const std::vector<MergeParticle<Packed>>& a_localValid,
  *
  * @tparam Packed See MergeParticle.
  * @tparam Cloud See NNSpatialIndex.
+ * @param[out] a_edges One entry per over-threshold, currently-alive query particle that has at least one candidate
+ * (empty if none found).
  * @param[in] a_localValid This patch's own FULL valid-particle set for this round (query sources AND candidates) --
  * see the contract-change note above; not pre-filtered by a_consumedIDs.
  * @param[in] a_ghosts Every ghost shipped to this patch this round (candidates only; ghosts never initiate a query)
@@ -612,8 +614,6 @@ buildNNSpatialIndex(const std::vector<MergeParticle<Packed>>& a_localValid,
  * function, so a cross-level ghost candidate needs no dx here.
  * @param[in] a_cellBudget Per-cell budget -- a cell is eligible while it holds strictly more
  * than this many particles.
- * @param[out] a_edges One entry per over-threshold, currently-alive query particle that has at least one candidate
- * (empty if none found).
  * @param[in] a_maxFallbackCandidates Forwarded from resolveTrivialTier() (see its docs); 0 (default) means an
  * ordinary single-nearest query and every edge's fallbackCandidates stays empty.
  * @param[in] a_maxCellDistance Same hard cutoff as resolveTrivialTier()'s own a_maxCellDistance (see its docs);
@@ -629,7 +629,8 @@ buildNNSpatialIndex(const std::vector<MergeParticle<Packed>>& a_localValid,
  */
 template <typename Packed, typename Cloud = EBGeometry::PointCloudBVH<Real, ParticleID>>
 inline void
-findNearestNeighborCandidates(const std::vector<MergeParticle<Packed>>&                  a_localValid,
+findNearestNeighborCandidates(std::vector<NNMergeEdge<Packed>>&                          a_edges,
+                              const std::vector<MergeParticle<Packed>>&                  a_localValid,
                               const std::vector<MergeParticle<Packed>>&                  a_ghosts,
                               const std::unordered_set<ParticleID>&                      a_consumedIDs,
                               const NNSpatialIndex<Packed, Cloud>&                       a_spatialIndex,
@@ -637,7 +638,6 @@ findNearestNeighborCandidates(const std::vector<MergeParticle<Packed>>&         
                               const RealVect&                                            a_probLo,
                               const RealVect&                                            a_dx,
                               const NNCellBudget&                                        a_cellBudget,
-                              std::vector<NNMergeEdge<Packed>>&                          a_edges,
                               const int                                                  a_maxFallbackCandidates = 0,
                               const std::optional<int> a_maxCellDistance = std::nullopt) noexcept;
 
@@ -694,22 +694,22 @@ using NNCellSpatialIndex = std::unordered_map<NNWalkCell, std::shared_ptr<NNCell
  * findNearestNeighborCandidatesOneCell()). Uses the same exact per-cell tally as
  * buildNNSpatialIndex() to decide whether to build anything at all for this patch.
  * @tparam Packed See MergeParticle.
+ * @param[out] a_index The resulting one-cell spatial index.
  * @param[in] a_localValid This patch's own full valid-particle set.
  * @param[in] a_ghosts Every ghost shipped to this patch this round.
  * @param[in] a_probLo Physical position of the domain's low corner.
  * @param[in] a_dx Cell spacing of THIS PATCH's own level.
  * @param[in] a_cellBudget The physics-facing per-cell budget used elsewhere this round; used
  * ONLY for the per-cell pre-filter above.
- * @param[out] a_index The resulting one-cell spatial index.
  */
 template <typename Packed>
 inline void
-buildNNCellSpatialIndex(const std::vector<MergeParticle<Packed>>& a_localValid,
+buildNNCellSpatialIndex(NNCellSpatialIndex&                       a_index,
+                        const std::vector<MergeParticle<Packed>>& a_localValid,
                         const std::vector<MergeParticle<Packed>>& a_ghosts,
                         const RealVect&                           a_probLo,
                         const RealVect&                           a_dx,
-                        const NNCellBudget&                       a_cellBudget,
-                        NNCellSpatialIndex&                       a_index) noexcept;
+                        const NNCellBudget&                       a_cellBudget) noexcept;
 
 /**
  * @brief For every over-threshold, currently-alive valid particle in a patch, find its single TRUE
@@ -735,6 +735,7 @@ buildNNCellSpatialIndex(const std::vector<MergeParticle<Packed>>& a_localValid,
  * uses, not merely in the query patch's own frame. Callers MUST still forward that same cap (not
  * std::nullopt) as a_maxCellDistance to resolveTrivialTier()/judgeProposals().
  * @tparam Packed See MergeParticle.
+ * @param[out] a_edges One entry per over-threshold, currently-alive query particle that has at least one candidate.
  * @param[in] a_localValid This patch's own FULL valid-particle set for this round (query sources).
  * @param[in] a_consumedIDs Lazy-deletion skip set: ids already consumed earlier this round.
  * @param[in] a_cellIndex This patch's one-cell spatial index (see NNCellSpatialIndex), built once via
@@ -746,13 +747,13 @@ buildNNCellSpatialIndex(const std::vector<MergeParticle<Packed>>& a_localValid,
  * cross-level re-check described above.
  * @param[in] a_cellBudget Per-cell budget -- a cell is eligible while it holds strictly more
  * than this many particles.
- * @param[out] a_edges One entry per over-threshold, currently-alive query particle that has at least one candidate.
  * @param[in] a_maxFallbackCandidates Same meaning as findNearestNeighborCandidates()'s own parameter; 0 (default)
  * means an ordinary single-nearest query and every edge's fallbackCandidates stays empty.
  */
 template <typename Packed>
 inline void
-findNearestNeighborCandidatesOneCell(const std::vector<MergeParticle<Packed>>&                  a_localValid,
+findNearestNeighborCandidatesOneCell(std::vector<NNMergeEdge<Packed>>&                          a_edges,
+                                     const std::vector<MergeParticle<Packed>>&                  a_localValid,
                                      const std::unordered_set<ParticleID>&                      a_consumedIDs,
                                      const NNCellSpatialIndex&                                  a_cellIndex,
                                      const std::unordered_map<NNCellKey, int, NNCellKeyHasher>& a_liveCellCount,
@@ -760,7 +761,6 @@ findNearestNeighborCandidatesOneCell(const std::vector<MergeParticle<Packed>>&  
                                      const RealVect&                                            a_dx,
                                      const std::vector<RealVect>&                               a_dxByLevel,
                                      const NNCellBudget&                                        a_cellBudget,
-                                     std::vector<NNMergeEdge<Packed>>&                          a_edges,
                                      const int a_maxFallbackCandidates = 0) noexcept;
 
 /**
@@ -809,6 +809,13 @@ findNearestNeighborCandidatesOneCell(const std::vector<MergeParticle<Packed>>&  
  *
  * @tparam Packed See MergeParticle.
  * @tparam Combine See PayloadCombine.
+ * @param[in,out] a_liveCellCount Live per-cell counts; decremented in place as trivial merges commit, so later edges
+ * in the same pass see the up-to-date occupancy.
+ * @param[in,out] a_consumedIDs Ids already consumed this round (by an earlier trivial merge, or found dead for any
+ * other reason); an edge referencing a consumed id is stale and skipped. Updated in place.
+ * @param[out] a_hasOutgoingCommitment Set of query-particle ids that were NOT resolved trivially (excluding the
+ * stale-candidate case, see above) and must go on to generateProposals().
+ * @param[out] a_results One entry per trivial-tier merge actually committed, in the order they were processed.
  * @param[in] a_edges Candidate edges from findNearestNeighborCandidates(), for ALL patches this rank owns (pooled
  * together so the global distance sort spans the whole rank, not just one patch).
  * @param[in] a_particlesByID Full particle data for every currently-alive local valid particle and every ghost across
@@ -816,15 +823,19 @@ findNearestNeighborCandidatesOneCell(const std::vector<MergeParticle<Packed>>&  
  * payload, needed to compute a merge's weighted-centroid position and call a_combine, since an edge only carries
  * ids/distance) plus its cached boundary-exposure flag (Realm::m_particleGhostExposure; false for ghosts).
  * @param[in] a_combine Opaque-payload combine callback (see PayloadCombine).
- * @param[in,out] a_liveCellCount Live per-cell counts; decremented in place as trivial merges commit, so later edges
- * in the same pass see the up-to-date occupancy.
- * @param[in,out] a_consumedIDs Ids already consumed this round (by an earlier trivial merge, or found dead for any
- * other reason); an edge referencing a consumed id is stale and skipped. Updated in place.
  * @param[in] a_cellBudget Per-cell budget, for the dynamic per-cell recheck (same budget used
  * everywhere else this round).
- * @param[out] a_hasOutgoingCommitment Set of query-particle ids that were NOT resolved trivially (excluding the
- * stale-candidate case, see above) and must go on to generateProposals().
- * @param[out] a_results One entry per trivial-tier merge actually committed, in the order they were processed.
+ * @param[in] a_probLo Physical position of the domain's low corner (see cellKeyOf()); needed for the dynamic
+ * crowding recheck and a_maxCellDistance.
+ * @param[in] a_dxByLevel Cell spacing PER AMR LEVEL (index 0 = level 0, etc.) -- see cellKeyOf()'s warning. Each
+ * participant's OWN cell key is computed with a_dxByLevel[participant.level], never a single shared dx: a candidate
+ * can legitimately be a ghost from a coarser or finer level than the query's own patch, and getting this wrong
+ * silently breaks the dynamic crowding recheck for every level but one.
+ * @param[in] a_isPositionValid Position-validity predicate (see PositionValid), called once per otherwise-eligible
+ * pair with the weighted-centroid position already computed. Treated exactly like a_maxCellDistance's "too far" case
+ * on failure: no proposal for the original candidate, a fallback retry if available, otherwise left unmatched with
+ * no side effects.
+ * @param[in] a_allocateID Fresh-id allocator (see IDAllocator), called once per committed trivial-tier merge.
  * @param[in] a_maxFallbackCandidates Default 0 (disabled). When a query particle's chosen candidate is blocked
  * (already consumed, or has its own outgoing commitment, or exposed/a ghost) and the query particle itself is NOT
  * exposed, try the edge's NNMergeEdge::fallbackCandidates in order (pre-fetched by findNearestNeighborCandidates()
@@ -842,17 +853,6 @@ findNearestNeighborCandidatesOneCell(const std::vector<MergeParticle<Packed>>&  
  * NOT proposed to -- this is a physical-validity rule, not a coordination one: the pair is exactly as invalid via
  * judgeProposals() as it would be trivially. If a_maxFallbackCandidates is nonzero the query gets a fallback retry
  * for a closer candidate; otherwise it is left unmatched with no side effects. The cap is inclusive.
- * @param[in] a_probLo Physical position of the domain's low corner (see cellKeyOf()); needed for the dynamic
- * crowding recheck and a_maxCellDistance.
- * @param[in] a_dxByLevel Cell spacing PER AMR LEVEL (index 0 = level 0, etc.) -- see cellKeyOf()'s warning. Each
- * participant's OWN cell key is computed with a_dxByLevel[participant.level], never a single shared dx: a candidate
- * can legitimately be a ghost from a coarser or finer level than the query's own patch, and getting this wrong
- * silently breaks the dynamic crowding recheck for every level but one.
- * @param[in] a_isPositionValid Position-validity predicate (see PositionValid), called once per otherwise-eligible
- * pair with the weighted-centroid position already computed. Treated exactly like a_maxCellDistance's "too far" case
- * on failure: no proposal for the original candidate, a fallback retry if available, otherwise left unmatched with
- * no side effects.
- * @param[in] a_allocateID Fresh-id allocator (see IDAllocator), called once per committed trivial-tier merge.
  * @param[in,out] a_crossLevelMergeCount Optional diagnostic counter (nullptr, the default, disables it entirely --
  * zero cost when not needed): incremented once per committed merge whose two participants were on DIFFERENT AMR
  * levels (query.level != cand.level). NOT reset by this function -- the caller owns its lifetime, so counts can be
@@ -864,14 +864,14 @@ findNearestNeighborCandidatesOneCell(const std::vector<MergeParticle<Packed>>&  
 template <typename Packed, typename Combine, typename PosValid, typename Allocator, typename OnMerge>
 inline void
 resolveTrivialTier(
+  std::unordered_map<NNCellKey, int, NNCellKeyHasher>&            a_liveCellCount,
+  std::unordered_set<ParticleID>&                                 a_consumedIDs,
+  std::unordered_set<ParticleID>&                                 a_hasOutgoingCommitment,
+  std::vector<NNMergeResult<Packed>>&                             a_results,
   const std::vector<NNMergeEdge<Packed>>&                         a_edges,
   const std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
   const Combine&                                                  a_combine,
-  std::unordered_map<NNCellKey, int, NNCellKeyHasher>&            a_liveCellCount,
-  std::unordered_set<ParticleID>&                                 a_consumedIDs,
   const NNCellBudget&                                             a_cellBudget,
-  std::unordered_set<ParticleID>&                                 a_hasOutgoingCommitment,
-  std::vector<NNMergeResult<Packed>>&                             a_results,
   const RealVect&                                                 a_probLo,
   const std::vector<RealVect>&                                    a_dxByLevel,
   const PosValid&                                                 a_isPositionValid,
@@ -896,6 +896,8 @@ resolveTrivialTier(
  * unaware of whether a given proposal arrived locally or over the network -- it still goes through
  * the exact same pooled judge logic, never a shortcut.
  * @tparam Packed See MergeParticle.
+ * @param[out] a_proposalsByDestRank One bucket per rank; a_proposalsByDestRank[r] holds every proposal whose
+ * candidate is owned by rank r (including r == this rank's own).
  * @param[in] a_edges Candidate edges from findNearestNeighborCandidates(), for all of this rank's patches.
  * @param[in] a_hasOutgoingCommitment Query-particle ids that resolveTrivialTier() could not resolve (i.e. exactly
  * the edges this function packages).
@@ -903,16 +905,14 @@ resolveTrivialTier(
  * keyed by id (each value an NNPooledParticle wrapping the particle) -- needed to build the full MergeParticle
  * bundle for each proposal.
  * @param[in] a_numRanks Total MPI rank count (size of the returned bucket vector).
- * @param[out] a_proposalsByDestRank One bucket per rank; a_proposalsByDestRank[r] holds every proposal whose
- * candidate is owned by rank r (including r == this rank's own).
  */
 template <typename Packed>
 inline void
-generateProposals(const std::vector<NNMergeEdge<Packed>>&                         a_edges,
+generateProposals(std::vector<std::vector<NNMergeProposal<Packed>>>&              a_proposalsByDestRank,
+                  const std::vector<NNMergeEdge<Packed>>&                         a_edges,
                   const std::unordered_set<ParticleID>&                           a_hasOutgoingCommitment,
                   const std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
-                  const int                                                       a_numRanks,
-                  std::vector<std::vector<NNMergeProposal<Packed>>>&              a_proposalsByDestRank) noexcept;
+                  const int                                                       a_numRanks) noexcept;
 
 /**
  * @brief Judge every incoming proposal that targets a particle this rank owns, and produce the
@@ -958,6 +958,17 @@ generateProposals(const std::vector<NNMergeEdge<Packed>>&                       
  * @tparam Packed See MergeParticle.
  * @tparam Combine See PayloadCombine.
  * @tparam PosValid See PositionValid.
+ * @param[in,out] a_liveCellCount Live per-cell counts for this rank's own patches; decremented in place as targets
+ * are accepted, in the same distance-sorted processing order (see rule 4 above). Used to dynamically recheck BOTH
+ * the target's AND the source's own cell -- mirrors resolveTrivialTier()'s symmetric recheck exactly; accepting a
+ * proposal whose source's own cell is no longer over threshold (e.g. drained by an earlier merge within this same
+ * round) would silently violate the crowding trigger on the source side. If this rank has no live visibility into
+ * the source's cell (it was never shipped here as a ghost), the source count defaults to 0 -- i.e. rejected -- the
+ * same conservative default already used when a target's own count is unknown.
+ * @param[out] a_results One entry per target actually accepted, in the order processed.
+ * @param[out] a_verdictsByDestRank One bucket per proposer rank (pre-sized to the total rank count by the caller);
+ * every proposal (accepted or not) gets exactly one verdict, addressed back to NNMergeProposal::source's owning
+ * rank.
  * @param[in] a_incomingProposals All proposals targeting a particle this rank owns, pooled from every source rank
  * (including this rank's own in-process bucket).
  * @param[in] a_particlesByID Full particle data for every currently-alive local valid particle and every ghost across
@@ -972,13 +983,6 @@ generateProposals(const std::vector<NNMergeEdge<Packed>>&                       
  * @param[in] a_outgoingTargetOf For an id in a_hasOutgoingCommitment, the id of the particle it is itself proposing
  * to (needed to detect the mutual-match exception in rule 3).
  * @param[in] a_combine Opaque-payload combine callback (see PayloadCombine).
- * @param[in,out] a_liveCellCount Live per-cell counts for this rank's own patches; decremented in place as targets
- * are accepted, in the same distance-sorted processing order (see rule 4 above). Used to dynamically recheck BOTH
- * the target's AND the source's own cell -- mirrors resolveTrivialTier()'s symmetric recheck exactly; accepting a
- * proposal whose source's own cell is no longer over threshold (e.g. drained by an earlier merge within this same
- * round) would silently violate the crowding trigger on the source side. If this rank has no live visibility into
- * the source's cell (it was never shipped here as a ghost), the source count defaults to 0 -- i.e. rejected -- the
- * same conservative default already used when a target's own count is unknown.
  * @param[in] a_cellBudget Per-cell budget (the same budget used everywhere else this round).
  * @param[in] a_probLo Physical position of the domain's low corner (see cellKeyOf()).
  * @param[in] a_dxByLevel Cell spacing PER AMR LEVEL -- see resolveTrivialTier()'s a_dxByLevel docs for why this must
@@ -987,10 +991,6 @@ generateProposals(const std::vector<NNMergeEdge<Packed>>&                       
  * @param[in] a_allocateID Fresh-id allocator (see IDAllocator), called once per accepted target.
  * @param[in] a_maxCellDistance Same physical merge-eligibility cap as resolveTrivialTier()'s (see rule 6 above);
  * std::nullopt (default) disables it.
- * @param[out] a_results One entry per target actually accepted, in the order processed.
- * @param[out] a_verdictsByDestRank One bucket per proposer rank (pre-sized to the total rank count by the caller);
- * every proposal (accepted or not) gets exactly one verdict, addressed back to NNMergeProposal::source's owning
- * rank.
  * @param[in,out] a_crossLevelMergeCount Optional diagnostic counter -- see resolveTrivialTier()'s docs; incremented
  * once per accepted target whose target/source were on different AMR levels.
  * @param[in] a_onMergeCommitted Optional per-merge diagnostic callback -- see resolveTrivialTier()'s docs; called
@@ -999,20 +999,20 @@ generateProposals(const std::vector<NNMergeEdge<Packed>>&                       
 template <typename Packed, typename Combine, typename PosValid, typename Allocator, typename OnMerge>
 inline void
 judgeProposals(
+  std::unordered_map<NNCellKey, int, NNCellKeyHasher>&            a_liveCellCount,
+  std::vector<NNMergeResult<Packed>>&                             a_results,
+  std::vector<std::vector<NNMergeVerdict>>&                       a_verdictsByDestRank,
   const std::vector<NNMergeProposal<Packed>>&                     a_incomingProposals,
   const std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
   const std::unordered_set<ParticleID>&                           a_consumedIDs,
   const std::unordered_set<ParticleID>&                           a_hasOutgoingCommitment,
   const std::map<ParticleID, ParticleID>&                         a_outgoingTargetOf,
   const Combine&                                                  a_combine,
-  std::unordered_map<NNCellKey, int, NNCellKeyHasher>&            a_liveCellCount,
   const NNCellBudget&                                             a_cellBudget,
   const RealVect&                                                 a_probLo,
   const std::vector<RealVect>&                                    a_dxByLevel,
   const PosValid&                                                 a_isPositionValid,
   const Allocator&                                                a_allocateID,
-  std::vector<NNMergeResult<Packed>>&                             a_results,
-  std::vector<std::vector<NNMergeVerdict>>&                       a_verdictsByDestRank,
   const std::optional<int>                                        a_maxCellDistance      = std::nullopt,
   unsigned long long*                                             a_crossLevelMergeCount = nullptr,
   const OnMerge&                                                  a_onMergeCommitted =
@@ -1025,14 +1025,14 @@ judgeProposals(
  * @details Rejected proposals are deliberately a no-op -- the source particle is simply left
  * alone and reconsidered in next round's fresh candidate search. This algorithm never internally
  * retries a rejected proposal against a second-best candidate within the same round.
- * @param[in] a_incomingVerdicts All verdicts addressed to this rank, pooled from every judge rank (including this
- * rank's own in-process verdict for proposals it judged for itself).
  * @param[out] a_consumedIDs Ids of every source particle whose proposal was accepted -- the caller removes these
  * from its own valid particle lists.
+ * @param[in] a_incomingVerdicts All verdicts addressed to this rank, pooled from every judge rank (including this
+ * rank's own in-process verdict for proposals it judged for itself).
  */
 inline void
-applyVerdicts(const std::vector<NNMergeVerdict>& a_incomingVerdicts,
-              std::unordered_set<ParticleID>&    a_consumedIDs) noexcept;
+applyVerdicts(std::unordered_set<ParticleID>&    a_consumedIDs,
+              const std::vector<NNMergeVerdict>& a_incomingVerdicts) noexcept;
 
 /**
  * @brief Locate-by-position callback -- see placeMergedParticles().
@@ -1061,23 +1061,23 @@ using PositionLocator = std::function<LevelTiles::LevelAndBox(const RealVect& a_
  * PositionLocator) -- NEVER a linear scan over every patch, which would turn
  * this function into a real bottleneck at large patch counts.
  * @tparam Packed See MergeParticle.
+ * @param[out] a_localByPatch Results whose merged particle lands in one of this rank's own patches, bucketed by
+ * (level, LevelTiles::LevelAndBox::gridIndex).
+ * @param[out] a_scatterByDestRank Results whose merged particle belongs to a different rank, bucketed by destination
+ * rank (pre-sized to the total rank count by the caller), for one final exchange.
  * @param[in] a_results Every merge result produced this round by resolveTrivialTier() and judgeProposals(), pooled
  * together.
  * @param[in] a_locate Locate-by-position callback (see PositionLocator).
  * @param[in] a_thisRank This rank's own number -- a located box whose rank equals this is what makes a
  * result "local" rather than needing a scatter.
- * @param[out] a_localByPatch Results whose merged particle lands in one of this rank's own patches, bucketed by
- * (level, LevelTiles::LevelAndBox::gridIndex).
- * @param[out] a_scatterByDestRank Results whose merged particle belongs to a different rank, bucketed by destination
- * rank (pre-sized to the total rank count by the caller), for one final exchange.
  */
 template <typename Packed>
 inline void
-placeMergedParticles(const std::vector<NNMergeResult<Packed>>&                                   a_results,
+placeMergedParticles(std::map<std::pair<int, unsigned int>, std::vector<MergeParticle<Packed>>>& a_localByPatch,
+                     std::vector<std::vector<MergeParticle<Packed>>>&                            a_scatterByDestRank,
+                     const std::vector<NNMergeResult<Packed>>&                                   a_results,
                      const PositionLocator&                                                      a_locate,
-                     const int                                                                   a_thisRank,
-                     std::map<std::pair<int, unsigned int>, std::vector<MergeParticle<Packed>>>& a_localByPatch,
-                     std::vector<std::vector<MergeParticle<Packed>>>& a_scatterByDestRank) noexcept;
+                     const int                                                                   a_thisRank) noexcept;
 
 /**
  * @brief One patch's identity for the duration of a merge round: its AMR level, local DataIndex,
@@ -1117,8 +1117,14 @@ struct NNPatchWork
  * @tparam Packed Opaque reconciliation payload type (see MergeParticle).
  * @tparam Traits Column descriptor for P.
  * @tparam Gather Callable `(const ParticleSoA<P,Traits>&, std::size_t) -> Packed`.
- * @param[in,out] a_amr AMR mesh -- source of ghost masks and the patch layout.
  * @param[in,out] a_particles The real particle container being merged.
+ * @param[out] a_patchWork One entry per patch this rank owns.
+ * @param[out] a_patchLocalValid This patch's own local-valid particles, parallel to a_patchWork.
+ * @param[out] a_patchGhosts Every ghost shipped to this patch, parallel to a_patchWork.
+ * @param[out] a_particlesByID Every currently-alive local-valid particle and every ghost, pooled rank-wide by id.
+ * @param[out] a_liveCellCount Live particle count (valid + ghost) per level-qualified cell key, derived from
+ * a_particlesByID.
+ * @param[in] a_amr AMR mesh -- source of ghost masks and the patch layout.
  * @param[in] a_realm Realm name (a_particles.getRealm()).
  * @param[in] a_finestLevel Finest AMR level (a_amr.getFinestLevel()).
  * @param[in] a_probLo Physical position of the domain's low corner.
@@ -1126,28 +1132,22 @@ struct NNPatchWork
  * @param[in] a_ghostWidth Particle ghost halo width already filled by the caller (see
  * mergeNearestNeighborsTree()'s own a_ghostWidth docs).
  * @param[in] a_gather Per-slot gather callback.
- * @param[out] a_patchWork One entry per patch this rank owns.
- * @param[out] a_patchLocalValid This patch's own local-valid particles, parallel to a_patchWork.
- * @param[out] a_patchGhosts Every ghost shipped to this patch, parallel to a_patchWork.
- * @param[out] a_particlesByID Every currently-alive local-valid particle and every ghost, pooled rank-wide by id.
- * @param[out] a_liveCellCount Live particle count (valid + ghost) per level-qualified cell key, derived from
- * a_particlesByID.
  */
 template <typename P, typename Packed, typename Traits, typename Gather>
 inline void
-gatherMergeParticles(AmrMesh&                                                  a_amr,
-                     ParticleContainer<P, Traits>&                             a_particles,
+gatherMergeParticles(ParticleContainer<P, Traits>&                             a_particles,
+                     std::vector<NNPatchWork>&                                 a_patchWork,
+                     std::vector<std::vector<MergeParticle<Packed>>>&          a_patchLocalValid,
+                     std::vector<std::vector<MergeParticle<Packed>>>&          a_patchGhosts,
+                     std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
+                     std::unordered_map<NNCellKey, int, NNCellKeyHasher>&      a_liveCellCount,
+                     const AmrMesh&                                            a_amr,
                      const std::string&                                        a_realm,
                      const int                                                 a_finestLevel,
                      const RealVect&                                           a_probLo,
                      const std::vector<RealVect>&                              a_dxByLevel,
                      const int                                                 a_ghostWidth,
-                     const Gather&                                             a_gather,
-                     std::vector<NNPatchWork>&                                 a_patchWork,
-                     std::vector<std::vector<MergeParticle<Packed>>>&          a_patchLocalValid,
-                     std::vector<std::vector<MergeParticle<Packed>>>&          a_patchGhosts,
-                     std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
-                     std::unordered_map<NNCellKey, int, NNCellKeyHasher>&      a_liveCellCount) noexcept;
+                     const Gather&                                             a_gather) noexcept;
 
 /**
  * @brief Finish a merge round: propose/judge/verdict the edges the local tier could not resolve,
@@ -1166,8 +1166,14 @@ gatherMergeParticles(AmrMesh&                                                  a
  * @tparam PosValid See PositionValid.
  * @tparam Allocator See IDAllocator.
  * @tparam OnMerge See MergeCommittedCallback.
- * @param[in,out] a_amr AMR mesh -- source of the LevelTiles used to place merged particles.
  * @param[in,out] a_particles The real particle container being merged.
+ * @param[in,out] a_particlesByID Every currently-alive local-valid particle and every ghost, pooled rank-wide by id.
+ * @param[in,out] a_consumedIDs Ids already consumed this round; updated in place as judge-side merges commit.
+ * @param[in,out] a_liveCellCount Live per-cell counts; decremented in place as judge-side merges commit.
+ * @param[in,out] a_allResults Every merge result committed this round (trivial-tier results already inside on entry);
+ * judge-side results are appended.
+ * @param[in,out] a_crossLevelMergeCount Optional diagnostic counter (see MergeCommittedCallback's sibling docs).
+ * @param[in] a_amr AMR mesh -- source of the LevelTiles used to place merged particles.
  * @param[in] a_realm Realm name.
  * @param[in] a_cellBudget The count each cell is drained down to -- see NNCellBudget.
  * @param[in] a_combine Opaque-payload combine callback.
@@ -1184,12 +1190,6 @@ gatherMergeParticles(AmrMesh&                                                  a
  * across every patch this rank owns (used to derive outgoingTargetOf; nothing is consumed between the last pass and
  * here, so these are still current).
  * @param[in] a_hasOutgoingCommitment Query ids the local tier could not resolve trivially.
- * @param[in,out] a_particlesByID Every currently-alive local-valid particle and every ghost, pooled rank-wide by id.
- * @param[in,out] a_consumedIDs Ids already consumed this round; updated in place as judge-side merges commit.
- * @param[in,out] a_liveCellCount Live per-cell counts; decremented in place as judge-side merges commit.
- * @param[in,out] a_allResults Every merge result committed this round (trivial-tier results already inside on entry);
- * judge-side results are appended.
- * @param[in,out] a_crossLevelMergeCount Optional diagnostic counter (see MergeCommittedCallback's sibling docs).
  * @param[in] a_onMergeCommitted Optional per-merge diagnostic callback.
  */
 template <typename P,
@@ -1201,8 +1201,13 @@ template <typename P,
           typename Allocator,
           typename OnMerge>
 inline void
-finishMergeRound(AmrMesh&                                                  a_amr,
-                 ParticleContainer<P, Traits>&                             a_particles,
+finishMergeRound(ParticleContainer<P, Traits>&                             a_particles,
+                 std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
+                 std::unordered_set<ParticleID>&                           a_consumedIDs,
+                 std::unordered_map<NNCellKey, int, NNCellKeyHasher>&      a_liveCellCount,
+                 std::vector<NNMergeResult<Packed>>&                       a_allResults,
+                 unsigned long long*                                       a_crossLevelMergeCount,
+                 const AmrMesh&                                            a_amr,
                  const std::string&                                        a_realm,
                  const NNCellBudget&                                       a_cellBudget,
                  const Combine&                                            a_combine,
@@ -1215,11 +1220,6 @@ finishMergeRound(AmrMesh&                                                  a_amr
                  const std::vector<NNPatchWork>&                           a_patchWork,
                  const std::vector<NNMergeEdge<Packed>>&                   a_pooledEdges,
                  const std::unordered_set<ParticleID>&                     a_hasOutgoingCommitment,
-                 std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
-                 std::unordered_set<ParticleID>&                           a_consumedIDs,
-                 std::unordered_map<NNCellKey, int, NNCellKeyHasher>&      a_liveCellCount,
-                 std::vector<NNMergeResult<Packed>>&                       a_allResults,
-                 unsigned long long*                                       a_crossLevelMergeCount,
                  const OnMerge&                                            a_onMergeCommitted) noexcept;
 
 /**
@@ -1249,8 +1249,9 @@ template <typename P,
           typename PosValid,
           typename OnMerge>
 inline void
-mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
-                               ParticleContainer<P, Traits>& a_particles,
+mergeNearestNeighborsRoundImpl(ParticleContainer<P, Traits>& a_particles,
+                               unsigned long long*           a_crossLevelMergeCount,
+                               const AmrMesh&                a_amr,
                                const NNCellBudget&           a_cellBudget,
                                const Gather&                 a_gather,
                                const Combine&                a_combine,
@@ -1261,7 +1262,6 @@ mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
                                const std::optional<int>      a_maxCellDistance,
                                const int                     a_ghostWidth,
                                const PosValid&               a_isPositionValid,
-                               unsigned long long*           a_crossLevelMergeCount,
                                const OnMerge&                a_onMergeCommitted);
 
 } // namespace detail
@@ -1309,13 +1309,20 @@ mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
  * @tparam Combine See PayloadCombine.
  * @tparam Scatter Callable `(ParticleSoA<P,Traits>&, const MergeParticle<Packed>&) -> void` -- appends one
  * surviving/merged particle back into the real SoA container.
- * @param[in,out] a_amr AMR mesh -- source of ghost masks, per-level dx, and the patch layout used to place merged
- * particles.
  * @param[in,out] a_particles The real particle container to merge, for every patch this rank owns.
+ * @param[in,out] a_crossLevelMergeCount Optional diagnostic counter (nullptr, the default, disables it entirely):
+ * incremented once for every merge this call commits (trivial-tier or judge-side) whose two participants were on
+ * DIFFERENT AMR levels. NOT reset by this function -- accumulates across a_iterateLocalTierToConvergence's internal
+ * iterations and across repeated calls if the caller keeps reusing the same counter, so it is safe to use to track
+ * cross-level activity over several rounds.
+ * @param[in] a_amr AMR mesh -- source of ghost masks, per-level dx, and the patch layout used to place merged
+ * particles.
  * @param[in] a_cellBudget The count each cell is drained down to -- see NNCellBudget.
  * @param[in] a_gather Per-slot gather callback (see Gather).
  * @param[in] a_combine Opaque-payload combine callback (see PayloadCombine).
  * @param[in] a_scatter Per-surviving-particle scatter callback (see Scatter).
+ * @param[in] a_allocateID Fresh-id allocator (see IDAllocator). Mandatory -- there is no universally safe default; the
+ * caller must supply a scheme that stays collision-free across every rank and every past/future call.
  * @param[in] a_iterateLocalTierToConvergence Default false. When false, findNearestNeighborCandidates() and
  * resolveTrivialTier() each run once. When true, that candidate-search-plus-trivial-tier pair repeats (reusing the
  * same ghost-fill from step 1; only which local particles are still alive changes) until a full local pass commits
@@ -1341,13 +1348,6 @@ mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
  * @param[in] a_isPositionValid Forwarded to resolveTrivialTier()/judgeProposals() (see PositionValid). Default
  * always-true. Composes with the options above -- e.g. an embedded-boundary point query for an EB-aware caller (see
  * ItoSolver::mergeSuperparticlesNearestNeighbor).
- * @param[in] a_allocateID Fresh-id allocator (see IDAllocator). Mandatory -- there is no universally safe default; the
- * caller must supply a scheme that stays collision-free across every rank and every past/future call.
- * @param[in,out] a_crossLevelMergeCount Optional diagnostic counter (nullptr, the default, disables it entirely):
- * incremented once for every merge this call commits (trivial-tier or judge-side) whose two participants were on
- * DIFFERENT AMR levels. NOT reset by this function -- accumulates across a_iterateLocalTierToConvergence's internal
- * iterations and across repeated calls if the caller keeps reusing the same counter, so it is safe to use to track
- * cross-level activity over several rounds.
  * @param[in] a_onMergeCommitted Optional per-merge diagnostic callback (see MergeCommittedCallback); default is a
  * no-op.
  */
@@ -1363,8 +1363,8 @@ template <typename P,
              void(const MergeParticle<Packed>&, const MergeParticle<Packed>&, const MergeParticle<Packed>&)>>
 inline void
 mergeNearestNeighborsTree(
-  AmrMesh&                      a_amr,
   ParticleContainer<P, Traits>& a_particles,
+  const AmrMesh&                a_amr,
   const NNCellBudget&           a_cellBudget,
   const Gather&                 a_gather,
   const Combine&                a_combine,
@@ -1411,8 +1411,8 @@ template <typename P,
              void(const MergeParticle<Packed>&, const MergeParticle<Packed>&, const MergeParticle<Packed>&)>>
 inline void
 mergeNearestNeighborsHash(
-  AmrMesh&                      a_amr,
   ParticleContainer<P, Traits>& a_particles,
+  const AmrMesh&                a_amr,
   const NNCellBudget&           a_cellBudget,
   const Gather&                 a_gather,
   const Combine&                a_combine,
@@ -1452,8 +1452,8 @@ mergeNearestNeighborsHash(
  * @tparam Gather Callable `(const ParticleSoA<P,Traits>&, std::size_t) -> Packed`.
  * @tparam Combine See PayloadCombine.
  * @tparam Scatter Callable `(ParticleSoA<P,Traits>&, const MergeParticle<Packed>&) -> void`.
- * @param[in,out] a_amr AMR mesh -- source of ghost masks, per-level dx, and the patch layout.
  * @param[in,out] a_particles The real particle container to merge, for every patch this rank owns.
+ * @param[in] a_amr AMR mesh -- source of ghost masks, per-level dx, and the patch layout.
  * @param[in] a_cellBudget The count each cell is drained down to -- see NNCellBudget.
  * @param[in] a_gather Per-slot gather callback (see Gather).
  * @param[in] a_combine Opaque-payload combine callback (see PayloadCombine).
@@ -1482,8 +1482,8 @@ template <typename P,
              void(const MergeParticle<Packed>&, const MergeParticle<Packed>&, const MergeParticle<Packed>&)>>
 inline void
 mergeNearestNeighborsOneCell(
-  AmrMesh&                      a_amr,
   ParticleContainer<P, Traits>& a_particles,
+  const AmrMesh&                a_amr,
   const NNCellBudget&           a_cellBudget,
   const Gather&                 a_gather,
   const Combine&                a_combine,

--- a/Source/Particle/CD_NearestNeighborParticleMergeImplem.H
+++ b/Source/Particle/CD_NearestNeighborParticleMergeImplem.H
@@ -1342,6 +1342,10 @@ gatherMergeParticles(ParticleContainer<P, Traits>&                             a
     const DataIterator& dit  = dbl.dataIterator();
     const int           nbox = dit.size();
 
+    // Serial (no omp): every patch writes into the shared a_particlesByID map and pushes onto the
+    // shared a_patchWork/a_patchLocalValid/a_patchGhosts vectors. The map in particular is the whole
+    // point of this pass -- it deduplicates a particle seen as a ghost by several of this rank's own
+    // patches -- so the sharing cannot be split per thread without changing what it computes.
     for (int mybox = 0; mybox < nbox; mybox++) {
       const DataIndex& din = dit[mybox];
 

--- a/Source/Particle/CD_NearestNeighborParticleMergeImplem.H
+++ b/Source/Particle/CD_NearestNeighborParticleMergeImplem.H
@@ -107,20 +107,20 @@ nnMergeCrossLevelTooFar(const RealVect&              a_posA,
 /**
  * @brief Weighted-centroid merge of two positions/weights -- shared by resolveTrivialTier() and
  * judgeProposals() so the formula is written exactly once.
+ * @param[out] a_mergedPos   Weighted-centroid position.
+ * @param[out] a_mergedWeight Summed weight.
  * @param[in]  a_posA        First particle's position.
  * @param[in]  a_weightA     First particle's weight.
  * @param[in]  a_posB        Second particle's position.
  * @param[in]  a_weightB     Second particle's weight.
- * @param[out] a_mergedPos   Weighted-centroid position.
- * @param[out] a_mergedWeight Summed weight.
  */
 inline void
-nnMergeWeightedCentroid(const RealVect& a_posA,
+nnMergeWeightedCentroid(RealVect&       a_mergedPos,
+                        Real&           a_mergedWeight,
+                        const RealVect& a_posA,
                         const Real      a_weightA,
                         const RealVect& a_posB,
-                        const Real      a_weightB,
-                        RealVect&       a_mergedPos,
-                        Real&           a_mergedWeight) noexcept
+                        const Real      a_weightB) noexcept
 {
   a_mergedWeight = a_weightA + a_weightB;
 
@@ -316,13 +316,13 @@ nnMergeAnyCellCrowded(const std::vector<MergeParticle<Packed>>& a_localValid,
 
 template <typename Packed, typename Cloud>
 inline void
-buildNNSpatialIndex(const std::vector<MergeParticle<Packed>>& a_localValid,
+buildNNSpatialIndex(NNSpatialIndex<Packed, Cloud>&            a_index,
+                    const std::vector<MergeParticle<Packed>>& a_localValid,
                     const std::vector<MergeParticle<Packed>>& a_ghosts,
                     const RealVect&                           a_probLo,
                     const RealVect&                           a_dx,
                     const NNCellBudget&                       a_cellBudget,
-                    const int                                 a_kNearest,
-                    NNSpatialIndex<Packed, Cloud>&            a_index) noexcept
+                    const int                                 a_kNearest) noexcept
 {
   CH_TIME("ParticleManagement::buildNNSpatialIndex");
 
@@ -384,7 +384,8 @@ buildNNSpatialIndex(const std::vector<MergeParticle<Packed>>& a_localValid,
 
 template <typename Packed, typename Cloud>
 inline void
-findNearestNeighborCandidates(const std::vector<MergeParticle<Packed>>&                  a_localValid,
+findNearestNeighborCandidates(std::vector<NNMergeEdge<Packed>>&                          a_edges,
+                              const std::vector<MergeParticle<Packed>>&                  a_localValid,
                               const std::vector<MergeParticle<Packed>>&                  a_ghosts,
                               const std::unordered_set<ParticleID>&                      a_consumedIDs,
                               const NNSpatialIndex<Packed, Cloud>&                       a_spatialIndex,
@@ -392,7 +393,6 @@ findNearestNeighborCandidates(const std::vector<MergeParticle<Packed>>&         
                               const RealVect&                                            a_probLo,
                               const RealVect&                                            a_dx,
                               const NNCellBudget&                                        a_cellBudget,
-                              std::vector<NNMergeEdge<Packed>>&                          a_edges,
                               const int                                                  a_maxFallbackCandidates,
                               const std::optional<int>                                   a_maxCellDistance) noexcept
 {
@@ -533,12 +533,12 @@ findNearestNeighborCandidates(const std::vector<MergeParticle<Packed>>&         
 
 template <typename Packed>
 inline void
-buildNNCellSpatialIndex(const std::vector<MergeParticle<Packed>>& a_localValid,
+buildNNCellSpatialIndex(NNCellSpatialIndex&                       a_index,
+                        const std::vector<MergeParticle<Packed>>& a_localValid,
                         const std::vector<MergeParticle<Packed>>& a_ghosts,
                         const RealVect&                           a_probLo,
                         const RealVect&                           a_dx,
-                        const NNCellBudget&                       a_cellBudget,
-                        NNCellSpatialIndex&                       a_index) noexcept
+                        const NNCellBudget&                       a_cellBudget) noexcept
 {
   CH_TIME("ParticleManagement::buildNNCellSpatialIndex");
 
@@ -596,7 +596,8 @@ buildNNCellSpatialIndex(const std::vector<MergeParticle<Packed>>& a_localValid,
 
 template <typename Packed>
 inline void
-findNearestNeighborCandidatesOneCell(const std::vector<MergeParticle<Packed>>&                  a_localValid,
+findNearestNeighborCandidatesOneCell(std::vector<NNMergeEdge<Packed>>&                          a_edges,
+                                     const std::vector<MergeParticle<Packed>>&                  a_localValid,
                                      const std::unordered_set<ParticleID>&                      a_consumedIDs,
                                      const NNCellSpatialIndex&                                  a_cellIndex,
                                      const std::unordered_map<NNCellKey, int, NNCellKeyHasher>& a_liveCellCount,
@@ -604,7 +605,6 @@ findNearestNeighborCandidatesOneCell(const std::vector<MergeParticle<Packed>>&  
                                      const RealVect&                                            a_dx,
                                      const std::vector<RealVect>&                               a_dxByLevel,
                                      const NNCellBudget&                                        a_cellBudget,
-                                     std::vector<NNMergeEdge<Packed>>&                          a_edges,
                                      const int a_maxFallbackCandidates) noexcept
 {
   CH_TIME("ParticleManagement::findNearestNeighborCandidatesOneCell");
@@ -794,14 +794,14 @@ findNearestNeighborCandidatesOneCell(const std::vector<MergeParticle<Packed>>&  
 
 template <typename Packed, typename Combine, typename PosValid, typename Allocator, typename OnMerge>
 inline void
-resolveTrivialTier(const std::vector<NNMergeEdge<Packed>>&                         a_edges,
-                   const std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
-                   const Combine&                                                  a_combine,
-                   std::unordered_map<NNCellKey, int, NNCellKeyHasher>&            a_liveCellCount,
+resolveTrivialTier(std::unordered_map<NNCellKey, int, NNCellKeyHasher>&            a_liveCellCount,
                    std::unordered_set<ParticleID>&                                 a_consumedIDs,
-                   const NNCellBudget&                                             a_cellBudget,
                    std::unordered_set<ParticleID>&                                 a_hasOutgoingCommitment,
                    std::vector<NNMergeResult<Packed>>&                             a_results,
+                   const std::vector<NNMergeEdge<Packed>>&                         a_edges,
+                   const std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
+                   const Combine&                                                  a_combine,
+                   const NNCellBudget&                                             a_cellBudget,
                    const RealVect&                                                 a_probLo,
                    const std::vector<RealVect>&                                    a_dxByLevel,
                    const PosValid&                                                 a_isPositionValid,
@@ -919,7 +919,7 @@ resolveTrivialTier(const std::vector<NNMergeEdge<Packed>>&                      
         }
 
         if (!tooFar) {
-          nnMergeWeightedCentroid(query.position, query.weight, cand.position, cand.weight, mergedPos, mergedWeight);
+          nnMergeWeightedCentroid(mergedPos, mergedWeight, query.position, query.weight, cand.position, cand.weight);
           invalidPos = !a_isPositionValid(mergedPos);
         }
       }
@@ -1006,11 +1006,11 @@ resolveTrivialTier(const std::vector<NNMergeEdge<Packed>>&                      
 
 template <typename Packed>
 inline void
-generateProposals(const std::vector<NNMergeEdge<Packed>>&                         a_edges,
+generateProposals(std::vector<std::vector<NNMergeProposal<Packed>>>&              a_proposalsByDestRank,
+                  const std::vector<NNMergeEdge<Packed>>&                         a_edges,
                   const std::unordered_set<ParticleID>&                           a_hasOutgoingCommitment,
                   const std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
-                  const int                                                       a_numRanks,
-                  std::vector<std::vector<NNMergeProposal<Packed>>>&              a_proposalsByDestRank) noexcept
+                  const int                                                       a_numRanks) noexcept
 {
   CH_TIME("ParticleManagement::generateProposals");
 
@@ -1045,20 +1045,20 @@ generateProposals(const std::vector<NNMergeEdge<Packed>>&                       
 
 template <typename Packed, typename Combine, typename PosValid, typename Allocator, typename OnMerge>
 inline void
-judgeProposals(const std::vector<NNMergeProposal<Packed>>&                     a_incomingProposals,
+judgeProposals(std::unordered_map<NNCellKey, int, NNCellKeyHasher>&            a_liveCellCount,
+               std::vector<NNMergeResult<Packed>>&                             a_results,
+               std::vector<std::vector<NNMergeVerdict>>&                       a_verdictsByDestRank,
+               const std::vector<NNMergeProposal<Packed>>&                     a_incomingProposals,
                const std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
                const std::unordered_set<ParticleID>&                           a_consumedIDs,
                const std::unordered_set<ParticleID>&                           a_hasOutgoingCommitment,
                const std::map<ParticleID, ParticleID>&                         a_outgoingTargetOf,
                const Combine&                                                  a_combine,
-               std::unordered_map<NNCellKey, int, NNCellKeyHasher>&            a_liveCellCount,
                const NNCellBudget&                                             a_cellBudget,
                const RealVect&                                                 a_probLo,
                const std::vector<RealVect>&                                    a_dxByLevel,
                const PosValid&                                                 a_isPositionValid,
                const Allocator&                                                a_allocateID,
-               std::vector<NNMergeResult<Packed>>&                             a_results,
-               std::vector<std::vector<NNMergeVerdict>>&                       a_verdictsByDestRank,
                const std::optional<int>                                        a_maxCellDistance,
                unsigned long long*                                             a_crossLevelMergeCount,
                const OnMerge&                                                  a_onMergeCommitted) noexcept
@@ -1190,7 +1190,7 @@ judgeProposals(const std::vector<NNMergeProposal<Packed>>&                     a
     RealVect mergedPos(D_DECL(0.0, 0.0, 0.0));
     Real     mergedWeight = 0.0;
 
-    nnMergeWeightedCentroid(target.position, target.weight, source.position, source.weight, mergedPos, mergedWeight);
+    nnMergeWeightedCentroid(mergedPos, mergedWeight, target.position, target.weight, source.position, source.weight);
 
     if (!a_isPositionValid(mergedPos)) {
       a_verdictsByDestRank[sourceDestRank].push_back(NNMergeVerdict{source.globalID, false});
@@ -1258,8 +1258,8 @@ judgeProposals(const std::vector<NNMergeProposal<Packed>>&                     a
 }
 
 inline void
-applyVerdicts(const std::vector<NNMergeVerdict>& a_incomingVerdicts,
-              std::unordered_set<ParticleID>&    a_consumedIDs) noexcept
+applyVerdicts(std::unordered_set<ParticleID>&    a_consumedIDs,
+              const std::vector<NNMergeVerdict>& a_incomingVerdicts) noexcept
 {
   CH_TIME("ParticleManagement::applyVerdicts");
 
@@ -1272,11 +1272,11 @@ applyVerdicts(const std::vector<NNMergeVerdict>& a_incomingVerdicts,
 
 template <typename Packed>
 inline void
-placeMergedParticles(const std::vector<NNMergeResult<Packed>>&                                   a_results,
+placeMergedParticles(std::map<std::pair<int, unsigned int>, std::vector<MergeParticle<Packed>>>& a_localByPatch,
+                     std::vector<std::vector<MergeParticle<Packed>>>&                            a_scatterByDestRank,
+                     const std::vector<NNMergeResult<Packed>>&                                   a_results,
                      const PositionLocator&                                                      a_locate,
-                     const int                                                                   a_thisRank,
-                     std::map<std::pair<int, unsigned int>, std::vector<MergeParticle<Packed>>>& a_localByPatch,
-                     std::vector<std::vector<MergeParticle<Packed>>>& a_scatterByDestRank) noexcept
+                     const int                                                                   a_thisRank) noexcept
 {
   CH_TIME("ParticleManagement::placeMergedParticles");
 
@@ -1307,19 +1307,19 @@ placeMergedParticles(const std::vector<NNMergeResult<Packed>>&                  
 
 template <typename P, typename Packed, typename Traits, typename Gather>
 inline void
-gatherMergeParticles(AmrMesh&                                                  a_amr,
-                     ParticleContainer<P, Traits>&                             a_particles,
+gatherMergeParticles(ParticleContainer<P, Traits>&                             a_particles,
+                     std::vector<NNPatchWork>&                                 a_patchWork,
+                     std::vector<std::vector<MergeParticle<Packed>>>&          a_patchLocalValid,
+                     std::vector<std::vector<MergeParticle<Packed>>>&          a_patchGhosts,
+                     std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
+                     std::unordered_map<NNCellKey, int, NNCellKeyHasher>&      a_liveCellCount,
+                     const AmrMesh&                                            a_amr,
                      const std::string&                                        a_realm,
                      const int                                                 a_finestLevel,
                      const RealVect&                                           a_probLo,
                      const std::vector<RealVect>&                              a_dxByLevel,
                      const int                                                 a_ghostWidth,
-                     const Gather&                                             a_gather,
-                     std::vector<NNPatchWork>&                                 a_patchWork,
-                     std::vector<std::vector<MergeParticle<Packed>>>&          a_patchLocalValid,
-                     std::vector<std::vector<MergeParticle<Packed>>>&          a_patchGhosts,
-                     std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
-                     std::unordered_map<NNCellKey, int, NNCellKeyHasher>&      a_liveCellCount) noexcept
+                     const Gather&                                             a_gather) noexcept
 {
   CH_TIME("ParticleManagement::gatherMergeParticles");
 
@@ -1434,8 +1434,13 @@ template <typename P,
           typename Allocator,
           typename OnMerge>
 inline void
-finishMergeRound(AmrMesh&                                                  a_amr,
-                 ParticleContainer<P, Traits>&                             a_particles,
+finishMergeRound(ParticleContainer<P, Traits>&                             a_particles,
+                 std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
+                 std::unordered_set<ParticleID>&                           a_consumedIDs,
+                 std::unordered_map<NNCellKey, int, NNCellKeyHasher>&      a_liveCellCount,
+                 std::vector<NNMergeResult<Packed>>&                       a_allResults,
+                 unsigned long long*                                       a_crossLevelMergeCount,
+                 const AmrMesh&                                            a_amr,
                  const std::string&                                        a_realm,
                  const NNCellBudget&                                       a_cellBudget,
                  const Combine&                                            a_combine,
@@ -1448,11 +1453,6 @@ finishMergeRound(AmrMesh&                                                  a_amr
                  const std::vector<NNPatchWork>&                           a_patchWork,
                  const std::vector<NNMergeEdge<Packed>>&                   a_pooledEdges,
                  const std::unordered_set<ParticleID>&                     a_hasOutgoingCommitment,
-                 std::unordered_map<ParticleID, NNPooledParticle<Packed>>& a_particlesByID,
-                 std::unordered_set<ParticleID>&                           a_consumedIDs,
-                 std::unordered_map<NNCellKey, int, NNCellKeyHasher>&      a_liveCellCount,
-                 std::vector<NNMergeResult<Packed>>&                       a_allResults,
-                 unsigned long long*                                       a_crossLevelMergeCount,
                  const OnMerge&                                            a_onMergeCommitted) noexcept
 {
   CH_TIME("ParticleManagement::finishMergeRound");
@@ -1472,27 +1472,27 @@ finishMergeRound(AmrMesh&                                                  a_amr
   }
 
   std::vector<std::vector<NNMergeProposal<Packed>>> proposalsByDestRank;
-  generateProposals(a_pooledEdges, a_hasOutgoingCommitment, a_particlesByID, numRanks, proposalsByDestRank);
+  generateProposals(proposalsByDestRank, a_pooledEdges, a_hasOutgoingCommitment, a_particlesByID, numRanks);
 
   const std::vector<NNMergeProposal<Packed>> incomingProposals = nnMergeExchangeByRank(proposalsByDestRank);
 
   std::vector<NNMergeResult<Packed>>       judgeResults;
   std::vector<std::vector<NNMergeVerdict>> verdictsByDestRank(numRanks);
 
-  judgeProposals(incomingProposals,
+  judgeProposals(a_liveCellCount,
+                 judgeResults,
+                 verdictsByDestRank,
+                 incomingProposals,
                  a_particlesByID,
                  a_consumedIDs,
                  a_hasOutgoingCommitment,
                  outgoingTargetOf,
                  a_combine,
-                 a_liveCellCount,
                  a_cellBudget,
                  a_probLo,
                  a_dxByLevel,
                  a_isPositionValid,
                  a_allocateID,
-                 judgeResults,
-                 verdictsByDestRank,
                  a_maxCellDistance,
                  a_crossLevelMergeCount,
                  a_onMergeCommitted);
@@ -1505,7 +1505,7 @@ finishMergeRound(AmrMesh&                                                  a_amr
 
   const std::vector<NNMergeVerdict> incomingVerdicts = nnMergeExchangeByRank(verdictsByDestRank);
 
-  applyVerdicts(incomingVerdicts, a_consumedIDs);
+  applyVerdicts(a_consumedIDs, incomingVerdicts);
 
   // O(1) point->block query. ParticleContainer::findDestination() delegates to the shared
   // LevelTiles::findDestination core, so this is the same mapping remap() routes its own particles
@@ -1517,7 +1517,7 @@ finishMergeRound(AmrMesh&                                                  a_amr
   std::map<std::pair<int, unsigned int>, std::vector<MergeParticle<Packed>>> localByPatch;
   std::vector<std::vector<MergeParticle<Packed>>>                            scatterByDestRank(numRanks);
 
-  placeMergedParticles(a_allResults, locate, myRank, localByPatch, scatterByDestRank);
+  placeMergedParticles(localByPatch, scatterByDestRank, a_allResults, locate, myRank);
 
   const std::vector<MergeParticle<Packed>> incomingScattered = nnMergeExchangeByRank(scatterByDestRank);
 
@@ -1584,8 +1584,9 @@ template <typename P,
           typename PosValid,
           typename OnMerge>
 inline void
-mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
-                               ParticleContainer<P, Traits>& a_particles,
+mergeNearestNeighborsRoundImpl(ParticleContainer<P, Traits>& a_particles,
+                               unsigned long long*           a_crossLevelMergeCount,
+                               const AmrMesh&                a_amr,
                                const NNCellBudget&           a_cellBudget,
                                const Gather&                 a_gather,
                                const Combine&                a_combine,
@@ -1596,7 +1597,6 @@ mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
                                const std::optional<int>      a_maxCellDistance,
                                const int                     a_ghostWidth,
                                const PosValid&               a_isPositionValid,
-                               unsigned long long*           a_crossLevelMergeCount,
                                const OnMerge&                a_onMergeCommitted)
 {
   CH_TIME("ParticleManagement::mergeNearestNeighborsRoundImpl");
@@ -1626,19 +1626,19 @@ mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
   std::unordered_map<ParticleID, NNPooledParticle<Packed>> particlesByID;
   std::unordered_map<NNCellKey, int, NNCellKeyHasher>      liveCellCount;
 
-  gatherMergeParticles<P, Packed, Traits>(a_amr,
-                                          a_particles,
+  gatherMergeParticles<P, Packed, Traits>(a_particles,
+                                          patchWork,
+                                          patchLocalValid,
+                                          patchGhosts,
+                                          particlesByID,
+                                          liveCellCount,
+                                          a_amr,
                                           realm,
                                           finestLevel,
                                           probLo,
                                           dxByLevel,
                                           ghostWidth,
-                                          a_gather,
-                                          patchWork,
-                                          patchLocalValid,
-                                          patchGhosts,
-                                          particlesByID,
-                                          liveCellCount);
+                                          a_gather);
 
   // Backend-specific: one whole-patch point-cloud index (see Cloud) per patch, built once here, per
   // round, over the FULL localValid/ghosts sets, before any consumption this round -- and reused
@@ -1650,13 +1650,13 @@ mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
   for (std::size_t pw = 0; pw < patchWork.size(); pw++) {
     NNSpatialIndex<Packed, Cloud> spatialIndex;
 
-    buildNNSpatialIndex(patchLocalValid[pw],
+    buildNNSpatialIndex(spatialIndex,
+                        patchLocalValid[pw],
                         patchGhosts[pw],
                         probLo,
                         patchWork[pw].dx,
                         a_cellBudget,
-                        1 + a_maxFallbackCandidates,
-                        spatialIndex);
+                        1 + a_maxFallbackCandidates);
 
     patchSpatialIndex.push_back(std::move(spatialIndex));
   }
@@ -1683,7 +1683,8 @@ mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
       // filters against consumedIDs itself (see its docs), so nothing is rebuilt or re-filtered here.
       std::vector<NNMergeEdge<Packed>> patchEdges;
 
-      findNearestNeighborCandidates(patchLocalValid[pw],
+      findNearestNeighborCandidates(patchEdges,
+                                    patchLocalValid[pw],
                                     patchGhosts[pw],
                                     consumedIDs,
                                     patchSpatialIndex[pw],
@@ -1691,7 +1692,6 @@ mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
                                     probLo,
                                     patchWork[pw].dx,
                                     a_cellBudget,
-                                    patchEdges,
                                     a_maxFallbackCandidates,
                                     a_maxCellDistance);
 
@@ -1700,14 +1700,14 @@ mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
 
     std::vector<NNMergeResult<Packed>> passResults;
 
-    resolveTrivialTier(lastPooledEdges,
-                       particlesByID,
-                       a_combine,
-                       liveCellCount,
+    resolveTrivialTier(liveCellCount,
                        consumedIDs,
-                       a_cellBudget,
                        hasOutgoingCommitment,
                        passResults,
+                       lastPooledEdges,
+                       particlesByID,
+                       a_combine,
+                       a_cellBudget,
                        probLo,
                        dxByLevel,
                        a_isPositionValid,
@@ -1741,8 +1741,13 @@ mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
 
   // 3-7. Propose/judge/verdict, placement, and container application -- shared with
   // mergeNearestNeighborsOneCell() (see finishMergeRound()'s own docs).
-  finishMergeRound<P, Packed, Traits>(a_amr,
-                                      a_particles,
+  finishMergeRound<P, Packed, Traits>(a_particles,
+                                      particlesByID,
+                                      consumedIDs,
+                                      liveCellCount,
+                                      allResults,
+                                      a_crossLevelMergeCount,
+                                      a_amr,
                                       realm,
                                       a_cellBudget,
                                       a_combine,
@@ -1755,11 +1760,6 @@ mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
                                       patchWork,
                                       lastPooledEdges,
                                       hasOutgoingCommitment,
-                                      particlesByID,
-                                      consumedIDs,
-                                      liveCellCount,
-                                      allResults,
-                                      a_crossLevelMergeCount,
                                       a_onMergeCommitted);
 }
 
@@ -1775,8 +1775,8 @@ template <typename P,
           typename PosValid,
           typename OnMerge>
 inline void
-mergeNearestNeighborsTree(AmrMesh&                      a_amr,
-                          ParticleContainer<P, Traits>& a_particles,
+mergeNearestNeighborsTree(ParticleContainer<P, Traits>& a_particles,
+                          const AmrMesh&                a_amr,
                           const NNCellBudget&           a_cellBudget,
                           const Gather&                 a_gather,
                           const Combine&                a_combine,
@@ -1793,8 +1793,9 @@ mergeNearestNeighborsTree(AmrMesh&                      a_amr,
   CH_TIME("ParticleManagement::mergeNearestNeighborsTree");
 
   detail::mergeNearestNeighborsRoundImpl<P, Packed, Traits, EBGeometry::PointCloudBVH<Real, ParticleID>>(
-    a_amr,
     a_particles,
+    a_crossLevelMergeCount,
+    a_amr,
     a_cellBudget,
     a_gather,
     a_combine,
@@ -1805,7 +1806,6 @@ mergeNearestNeighborsTree(AmrMesh&                      a_amr,
     a_maxCellDistance,
     a_ghostWidth,
     a_isPositionValid,
-    a_crossLevelMergeCount,
     a_onMergeCommitted);
 }
 
@@ -1819,8 +1819,8 @@ template <typename P,
           typename PosValid,
           typename OnMerge>
 inline void
-mergeNearestNeighborsHash(AmrMesh&                      a_amr,
-                          ParticleContainer<P, Traits>& a_particles,
+mergeNearestNeighborsHash(ParticleContainer<P, Traits>& a_particles,
+                          const AmrMesh&                a_amr,
                           const NNCellBudget&           a_cellBudget,
                           const Gather&                 a_gather,
                           const Combine&                a_combine,
@@ -1837,8 +1837,9 @@ mergeNearestNeighborsHash(AmrMesh&                      a_amr,
   CH_TIME("ParticleManagement::mergeNearestNeighborsHash");
 
   detail::mergeNearestNeighborsRoundImpl<P, Packed, Traits, EBGeometry::PointCloudHashGrid<Real, ParticleID>>(
-    a_amr,
     a_particles,
+    a_crossLevelMergeCount,
+    a_amr,
     a_cellBudget,
     a_gather,
     a_combine,
@@ -1849,7 +1850,6 @@ mergeNearestNeighborsHash(AmrMesh&                      a_amr,
     a_maxCellDistance,
     a_ghostWidth,
     a_isPositionValid,
-    a_crossLevelMergeCount,
     a_onMergeCommitted);
 }
 
@@ -1863,8 +1863,8 @@ template <typename P,
           typename PosValid,
           typename OnMerge>
 inline void
-mergeNearestNeighborsOneCell(AmrMesh&                      a_amr,
-                             ParticleContainer<P, Traits>& a_particles,
+mergeNearestNeighborsOneCell(ParticleContainer<P, Traits>& a_particles,
+                             const AmrMesh&                a_amr,
                              const NNCellBudget&           a_cellBudget,
                              const Gather&                 a_gather,
                              const Combine&                a_combine,
@@ -1900,19 +1900,19 @@ mergeNearestNeighborsOneCell(AmrMesh&                      a_amr,
   std::unordered_map<ParticleID, NNPooledParticle<Packed>> particlesByID;
   std::unordered_map<NNCellKey, int, NNCellKeyHasher>      liveCellCount;
 
-  gatherMergeParticles<P, Packed, Traits>(a_amr,
-                                          a_particles,
+  gatherMergeParticles<P, Packed, Traits>(a_particles,
+                                          patchWork,
+                                          patchLocalValid,
+                                          patchGhosts,
+                                          particlesByID,
+                                          liveCellCount,
+                                          a_amr,
                                           realm,
                                           finestLevel,
                                           probLo,
                                           dxByLevel,
                                           ghostWidth,
-                                          a_gather,
-                                          patchWork,
-                                          patchLocalValid,
-                                          patchGhosts,
-                                          particlesByID,
-                                          liveCellCount);
+                                          a_gather);
 
   // Backend-specific: one PointCloudBVH per OCCUPIED cell (not per patch), built once here, per
   // round, over the FULL localValid/ghosts sets -- see buildNNCellSpatialIndex()'s own docs.
@@ -1922,7 +1922,7 @@ mergeNearestNeighborsOneCell(AmrMesh&                      a_amr,
   for (std::size_t pw = 0; pw < patchWork.size(); pw++) {
     NNCellSpatialIndex cellIndex;
 
-    buildNNCellSpatialIndex(patchLocalValid[pw], patchGhosts[pw], probLo, patchWork[pw].dx, a_cellBudget, cellIndex);
+    buildNNCellSpatialIndex(cellIndex, patchLocalValid[pw], patchGhosts[pw], probLo, patchWork[pw].dx, a_cellBudget);
 
     patchCellSpatialIndex.push_back(std::move(cellIndex));
   }
@@ -1939,7 +1939,8 @@ mergeNearestNeighborsOneCell(AmrMesh&                      a_amr,
     for (std::size_t pw = 0; pw < patchWork.size(); pw++) {
       std::vector<NNMergeEdge<Packed>> patchEdges;
 
-      findNearestNeighborCandidatesOneCell(patchLocalValid[pw],
+      findNearestNeighborCandidatesOneCell(patchEdges,
+                                           patchLocalValid[pw],
                                            consumedIDs,
                                            patchCellSpatialIndex[pw],
                                            liveCellCount,
@@ -1947,7 +1948,6 @@ mergeNearestNeighborsOneCell(AmrMesh&                      a_amr,
                                            patchWork[pw].dx,
                                            dxByLevel,
                                            a_cellBudget,
-                                           patchEdges,
                                            a_maxFallbackCandidates);
 
       lastPooledEdges.insert(lastPooledEdges.end(), patchEdges.begin(), patchEdges.end());
@@ -1955,14 +1955,14 @@ mergeNearestNeighborsOneCell(AmrMesh&                      a_amr,
 
     std::vector<NNMergeResult<Packed>> passResults;
 
-    resolveTrivialTier(lastPooledEdges,
-                       particlesByID,
-                       a_combine,
-                       liveCellCount,
+    resolveTrivialTier(liveCellCount,
                        consumedIDs,
-                       a_cellBudget,
                        hasOutgoingCommitment,
                        passResults,
+                       lastPooledEdges,
+                       particlesByID,
+                       a_combine,
+                       a_cellBudget,
                        probLo,
                        dxByLevel,
                        a_isPositionValid,
@@ -1992,8 +1992,13 @@ mergeNearestNeighborsOneCell(AmrMesh&                      a_amr,
     runLocalTierPass();
   }
 
-  finishMergeRound<P, Packed, Traits>(a_amr,
-                                      a_particles,
+  finishMergeRound<P, Packed, Traits>(a_particles,
+                                      particlesByID,
+                                      consumedIDs,
+                                      liveCellCount,
+                                      allResults,
+                                      a_crossLevelMergeCount,
+                                      a_amr,
                                       realm,
                                       a_cellBudget,
                                       a_combine,
@@ -2006,11 +2011,6 @@ mergeNearestNeighborsOneCell(AmrMesh&                      a_amr,
                                       patchWork,
                                       lastPooledEdges,
                                       hasOutgoingCommitment,
-                                      particlesByID,
-                                      consumedIDs,
-                                      liveCellCount,
-                                      allResults,
-                                      a_crossLevelMergeCount,
                                       a_onMergeCommitted);
 }
 

--- a/Source/Particle/CD_NearestNeighborParticleMergeImplem.H
+++ b/Source/Particle/CD_NearestNeighborParticleMergeImplem.H
@@ -262,12 +262,6 @@ cellKeyOf(const RealVect& a_position, const RealVect& a_probLo, const RealVect& 
   return iv;
 }
 
-inline bool
-isBoundaryExposed(const IntVect& a_cellIndex, const ParticleGhostMask& a_ghostMask) noexcept
-{
-  return a_ghostMask.numTargets(a_cellIndex) > 0;
-}
-
 /**
  * @brief Exact per-cell crowding pre-filter shared by buildNNSpatialIndex()/buildNNCellSpatialIndex(): is any
  * cell in this patch's local+ghost particle set over its a_cellBudget?
@@ -1335,14 +1329,15 @@ gatherMergeParticles(AmrMesh&                                                  a
   a_particlesByID.clear();
   a_liveCellCount.clear();
 
+  // Which cells hold a particle that some other box can also see -- the trivial tier's eligibility test.
+  // Read from the realm, which derives it from the three ghost masks when they are built (see
+  // Realm::m_particleGhostExposure), rather than re-deriving it here per particle per timestep.
+  const AMRMask& exposure = a_amr.getParticleGhostExposure(a_realm, a_ghostWidth);
+
   for (int lvl = 0; lvl <= a_finestLevel; lvl++) {
     const RealVect& dx = a_dxByLevel[lvl];
 
     const DisjointBoxLayout& dbl = a_amr.getGrids(a_realm)[lvl];
-
-    const AMRParticleGhostMask& maskSame = a_amr.getParticleGhostMask(a_realm, a_ghostWidth);
-    const AMRParticleGhostMask& maskC2F  = a_amr.getParticleGhostMaskCoarToFine(a_realm, a_ghostWidth);
-    const AMRParticleGhostMask& maskF2C  = a_amr.getParticleGhostMaskFineToCoar(a_realm, a_ghostWidth);
 
     const DataIterator& dit  = dbl.dataIterator();
     const int           nbox = dit.size();
@@ -1360,10 +1355,7 @@ gatherMergeParticles(AmrMesh&                                                  a
 
       a_particlesByID.reserve(a_particlesByID.size() + leaf.size());
 
-      const ParticleGhostMask* maskSameDin = maskSame[lvl].isNull() ? nullptr : &(*maskSame[lvl])[din];
-      const ParticleGhostMask* maskC2FDin  = (lvl < a_finestLevel && !maskC2F[lvl].isNull()) ? &(*maskC2F[lvl])[din]
-                                                                                             : nullptr;
-      const ParticleGhostMask* maskF2CDin  = (lvl > 0 && !maskF2C[lvl].isNull()) ? &(*maskF2C[lvl])[din] : nullptr;
+      const BaseFab<bool>& exposureDin = (*exposure[lvl])[din];
 
       for (std::size_t i = 0; i < leaf.size(); i++) {
         const bool isGhost = leaf.isGhost(i);
@@ -1405,15 +1397,11 @@ gatherMergeParticles(AmrMesh&                                                  a
           a_particlesByID[p.globalID] = NNPooledParticle<Packed>{p, false};
         }
         else {
-          bool isExposed = (maskSameDin != nullptr) && isBoundaryExposed(cell, *maskSameDin);
+          // A non-ghost particle is resident in this patch, so its cell lies in this box -- which is
+          // exactly the region the exposure mask is defined over (it carries no ghost cells).
+          CH_assert(exposureDin.box().contains(cell));
 
-          if (!isExposed && maskC2FDin != nullptr) {
-            isExposed = isBoundaryExposed(cell, *maskC2FDin);
-          }
-
-          if (!isExposed && maskF2CDin != nullptr) {
-            isExposed = isBoundaryExposed(cell, *maskF2CDin);
-          }
+          const bool isExposed = exposureDin(cell, 0);
 
           localValid.push_back(p);
           a_particlesByID[p.globalID] = NNPooledParticle<Packed>{p, isExposed};
@@ -1613,19 +1601,14 @@ mergeNearestNeighborsRoundImpl(AmrMesh&                      a_amr,
 {
   CH_TIME("ParticleManagement::mergeNearestNeighborsRoundImpl");
 
-  const std::string   realm       = a_particles.getRealm();
-  const int           finestLevel = a_amr.getFinestLevel();
-  const RealVect      probLo      = a_amr.getProbLo();
-  const Vector<Real>& dxScalar    = a_amr.getDx();
+  const std::string realm       = a_particles.getRealm();
+  const int         finestLevel = a_amr.getFinestLevel();
+  const RealVect    probLo      = a_amr.getProbLo();
 
   // Per-level dx, indexed by level -- every cell-key computation below and downstream (in
   // resolveTrivialTier()/judgeProposals()) MUST use the dx of the PARTICLE'S OWN level (see
   // MergeParticle::level's docs), never a single dx shared across levels.
-  std::vector<RealVect> dxByLevel(finestLevel + 1);
-
-  for (int lvl = 0; lvl <= finestLevel; lvl++) {
-    dxByLevel[lvl] = RealVect(D_DECL(dxScalar[lvl], dxScalar[lvl], dxScalar[lvl]));
-  }
+  const std::vector<RealVect>& dxByLevel = a_amr.getDxAsRealVect().constStdVector();
 
   CH_assert(a_ghostWidth >= 1);
   const int ghostWidth = a_ghostWidth;
@@ -1897,16 +1880,13 @@ mergeNearestNeighborsOneCell(AmrMesh&                      a_amr,
 
   using namespace detail;
 
-  const std::string   realm       = a_particles.getRealm();
-  const int           finestLevel = a_amr.getFinestLevel();
-  const RealVect      probLo      = a_amr.getProbLo();
-  const Vector<Real>& dxScalar    = a_amr.getDx();
+  const std::string realm       = a_particles.getRealm();
+  const int         finestLevel = a_amr.getFinestLevel();
+  const RealVect    probLo      = a_amr.getProbLo();
 
-  std::vector<RealVect> dxByLevel(finestLevel + 1);
-
-  for (int lvl = 0; lvl <= finestLevel; lvl++) {
-    dxByLevel[lvl] = RealVect(D_DECL(dxScalar[lvl], dxScalar[lvl], dxScalar[lvl]));
-  }
+  // Per-level dx, indexed by level -- see mergeNearestNeighborsRoundImpl()'s own note on why every cell
+  // key must use the dx of the particle's OWN level.
+  const std::vector<RealVect>& dxByLevel = a_amr.getDxAsRealVect().constStdVector();
 
   // Structurally fixed at 1 -- findNearestNeighborCandidatesOneCell() only ever visits the query's
   // own cell and its Moore neighbors, so a width-1 halo already contains every reachable candidate

--- a/Source/Particle/CD_NearestNeighborParticleMergeImplem.H
+++ b/Source/Particle/CD_NearestNeighborParticleMergeImplem.H
@@ -1607,8 +1607,14 @@ mergeNearestNeighborsRoundImpl(ParticleContainer<P, Traits>& a_particles,
 
   // Per-level dx, indexed by level -- every cell-key computation below and downstream (in
   // resolveTrivialTier()/judgeProposals()) MUST use the dx of the PARTICLE'S OWN level (see
-  // MergeParticle::level's docs), never a single dx shared across levels.
-  const std::vector<RealVect>& dxByLevel = a_amr.getDxAsRealVect().constStdVector();
+  // MergeParticle::level's docs), never a single dx shared across levels. Built here rather than
+  // held by AmrMesh: unlike the kd merges, which only ever want the dx of the level they are looping
+  // over, this one is indexed by each PARTICLE's level, so it genuinely needs the whole vector.
+  std::vector<RealVect> dxByLevel(finestLevel + 1);
+
+  for (int lvl = 0; lvl <= finestLevel; lvl++) {
+    dxByLevel[lvl] = a_amr.getDx()[lvl] * RealVect::Unit;
+  }
 
   CH_assert(a_ghostWidth >= 1);
   const int ghostWidth = a_ghostWidth;
@@ -1885,8 +1891,12 @@ mergeNearestNeighborsOneCell(ParticleContainer<P, Traits>& a_particles,
   const RealVect    probLo      = a_amr.getProbLo();
 
   // Per-level dx, indexed by level -- see mergeNearestNeighborsRoundImpl()'s own note on why every cell
-  // key must use the dx of the particle's OWN level.
-  const std::vector<RealVect>& dxByLevel = a_amr.getDxAsRealVect().constStdVector();
+  // key must use the dx of the particle's OWN level, and why it is built here.
+  std::vector<RealVect> dxByLevel(finestLevel + 1);
+
+  for (int lvl = 0; lvl <= finestLevel; lvl++) {
+    dxByLevel[lvl] = a_amr.getDx()[lvl] * RealVect::Unit;
+  }
 
   // Structurally fixed at 1 -- findNearestNeighborCandidatesOneCell() only ever visits the query's
   // own cell and its Moore neighbors, so a width-1 halo already contains every reachable candidate


### PR DESCRIPTION
# Summary

Closes #685. The particle mergers re-derived, on every call, several quantities that cannot change
between regrids. This moves them to the object whose lifetime already matches -- `Realm`, beside the
particle ghost masks they are derived from -- and removes the duplicated re-derivations.

The branch also carries a signature cleanup across `ParticleManagement`'s merge surface and a
thread-safety audit of the box loops it touches, both described under *Side-effects*, plus merges of
`main` for #689 and #690.

### Background

The substantive item is **boundary exposure per cell**: the test `numTargets(cell) > 0` against the
three particle ghost masks. `mergeKDCarve` allocated and filled a per-patch `BaseFab<signed char>`
exposure cache *every timestep* for data that last changed at the previous regrid, and the
nearest-neighbour gather repeated the same three-mask OR per particle. Alongside it sat smaller
duplications: `dxByLevel` rebuilt in four places, per-patch real-space bounds computed at two sites,
and the kd merges' `EBAMRFAB` scratch holders allocated per call (`AmrMesh::allocate` constructs a
`Copier` per level -- cheap in isolation, non-negligible at scale).

Caching any of this inside the free-function mergers is unsafe: a cache that outlives a regrid it
should not is a silent wrong-answer bug, and free functions have no invalidation hook.
`Realm::defineParticleGhostMasks()` is reached from `regridOperators()` at every regrid and already
owns the masks these quantities are pure functions of, so it is the natural owner -- one definition
point, one invalidation point.

`EBAMRParticleMesh` was considered as the alternative home and rejected: it is owned by `PhaseRealm`
and therefore phase-scoped, while the particle ghost masks and the mergers are realm-scoped and
phase-agnostic. Putting merge state there would key it by an irrelevant phase, duplicate it across
gas/solid, and force it to reach up into `Realm` for data it does not own.

### Solution

`Realm` gains two members, both built inside the existing `defineParticleGhostMasks()` loop over
registered widths and cleared at the top of it alongside the masks:

- `std::map<int, AMRMask> m_particleGhostExposure` -- per level, true in every cell with at least one
  outgoing ghost-shipment target in any direction. Carries **no ghost cells**, deliberately: only
  resident particles are ever tested, and resident means the cell lies in the patch's own box.
- `std::map<int, std::vector<int>> m_particleGhostNeighborRanks` -- for each width, the ranks this rank
  exchanges particle ghosts with, in ascending order, derived with zero MPI. This is the prototype from
  #679, which had no owner; nothing on this branch consumes it yet.

  It is built by flagging ranks in a `std::vector<bool>` and collapsing the flags once, rather than
  inserting into a `std::set`. The masks hold one packed entry per (boundary cell x target) but only a
  handful of distinct ranks, so the set form cost order 10^5-10^6 tree inserts per rank per regrid to
  produce a ~6-element answer. Scanning to collapse the flags yields ascending order for free, which is
  what the eventual point-to-point exchanges need: both sides must walk their shared neighbours in the
  same order for sends and receives to line up. A sorted vector is also what every consumer would
  otherwise copy the set into on each exchange.

`Realm` and `AmrMesh` gain getters for both, modelled on the existing `getParticleGhostMask()`.

Removed as re-derivations of the same invariant data:

- `kdIsBoundaryExposed()` and `isBoundaryExposed()` -- the duplicated one-line mask tests (the former's
  own doc-comment already noted it was a duplicate), plus the per-patch exposure cache.
- The four local `dxByLevel` builds. Two of them disappear outright: every kd use was `dxByLevel[lvl]`
  with `lvl` the enclosing loop variable, so each kd level loop now takes a local `RealVect` and the
  vector is gone from that family entirely. The nearest-neighbour merges genuinely need the whole
  vector -- they index it by each *particle's* level, not the loop's -- so their two entry points build
  it in place. No accessor was added to `AmrMesh` for this: it would have meant a second copy of `m_dx`
  to keep in sync, for something callers can derive.
- The duplicated per-patch real-space bounds, now `detail::kdBoxRealBounds()`.

Finally, the kd merges' per-cell scratch moves to its caller: `mergeKDCarve`/`mergeKDPatch`/
`mergeKDInterior` take the histogram and quota holders as arguments, and `ItoSolver` owns them,
allocating them in `allocate()`/`regrid()` and releasing them in `preRegrid()` exactly like `m_phi` and
the deposition holders.

**New types introduced: none.** Exposure reuses the existing `AMRMask` alias, and the two width-keyed
`std::map`s mirror the three `std::map<int, AMRParticleGhostMask>` members already in `Realm`.

### Side-effects

**Signature cleanup across both merge families.** Adding the scratch parameters interleaved mutable and
non-mutable arguments, which this repository's convention forbids, so the ordering is now
`(<mutables>, <non-mutables>, <optionals>)` throughout `ParticleManagement`'s merge surface -- 22
functions: the three kd entry points, four kd helpers (`buildKDQuotaLeaves`, `kdFillCellHistogram`,
`kdBBox`, `kdBoxRealBounds`), and all sixteen nearest-neighbour functions. Defaulted parameters keep
both their trailing position and their existing relative order, so no call that omits a trailing
optional changes meaning, and no call site gained or lost an argument.

**`AmrMesh` is now passed by const reference.** The mergers call exactly six `AmrMesh` methods --
`getFinestLevel`, `getProbLo`, `getGrids`, `getDx`, `getLevelTiles`, `getParticleGhostExposure` -- and
all six were already `const`. The mutable reference predates this work (even the `a_amr.allocate(...)`
call removed here was itself a `const` member), so this is strictly a tightening.

**Thread-safety audit of the touched box loops.** Six of the seven un-pragma'd `DataIterator` loops in
these files are genuinely unsafe to thread -- shared append buffers, a shared id counter, shared
dedup maps, and (for the neighbour marking) a shared flag array that `std::vector<bool>` packs into
words. Each now records why, instead of leaving the next reader to re-derive it. The one loop that is
safe, summing box sizes for a `reserve()` bound, gains `reduction(+ : combinedCountUpperBound)`.

Other effects:

- The exposure masks cost one `bool` per cell per level per **registered** ghost width. Nothing is
  built unless a width has been registered, so a run that uses no particle ghost masks pays nothing.
- The kd scratch is now held across a timestep rather than allocated and freed within one. It is two
  single-component holders per solver.
- Behaviour is unchanged: particle counts are **identical to `main` across all 24 runs** (six merge
  backends x {2D, 3D} x {serial, 4 ranks}), measured against a baseline built from `main` in a separate
  worktree.
- `main` is merged in twice, for #689 (`ParticleSoA` geometric growth) and #690 (ItoKMC reaction-network
  overhead). Neither overlaps this branch's files.

### Alternative solutions

- **`EBAMRParticleMesh` as the owner** -- rejected for the phase-scoping reason above.
- **A new merge-operator class owning the invariants and the scratch** -- rejected: it would need its
  own `define()`-at-regrid hook duplicating what `Realm` already does, and once the templated state is
  excluded (spatial indices, pooled particle maps, kd partitions -- all particle-dependent and unsafe
  to cache) there are only two non-templated invariants left for it to hold.
- **Leaving the scratch allocated per call** -- rejected because `AmrMesh::allocate()` builds a `Copier`
  per level; cheap at small scale, but it adds up on large runs.
- **Hoisting the scratch above `ItoSolver`** (to `ItoKMCStepper`/`ItoLayout`, one pair instead of one
  per species) -- considered and deferred. It would put two kd-merge buffers into the signature of
  `makeSuperparticles()`, which every merge algorithm shares, including the ones that never touch them.
- **Allocating the scratch lazily**, so a solver that never runs a kd merge pays nothing -- tried and
  dropped. It needed a define/invalidate pair and a state flag to save two single-component holders per
  species; the standard `allocate()`/`preRegrid()` lifecycle is simpler at negligible cost.
- **An `AmrMesh` accessor returning the per-level dx as `RealVect`** -- tried and dropped, see above.
- **Reordering the optional parameters too** (mutable optionals ahead of immutable ones) -- tried and
  reverted: it would have forced call sites that omit a trailing optional to start passing
  `a_crossLevelMergeCount` explicitly, for no benefit.

Verification beyond the 24-run baseline comparison: a temporary DEBUG assertion comparing the cached
exposure bit against the live three-mask OR, for every cell of every patch on every level on every
merge call, ran clean over the whole BrownianWalker merge suite at ghost widths 1 and 2. The neighbour
ranks -- which nothing on this branch reads, so no regression test can exercise them -- were checked by
rebuilding the old `std::set` alongside the new vector and asserting exact equality in order on every
regrid (96 checks over `kd_carve`). Both temporary checks were removed before committing.
`ItoKMC/JSON` runs clean on 4 ranks under `reinitialize`, `kd_carve`, `kd_skin_nn` and `nn_pair_tree`.
The no-MPI build (the CI configuration) and an `OPENMPCC=TRUE` build both compile.

### PR-review checklist

Mandatory:

- [x] I have run the test suite and made sure that it passed.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information.
- [x] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks.
- [ ] I have run clang-tidy and fixed all reported errors.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
