### PR TITLE
Grow ParticleSoA geometrically on the bulk append paths

### DIFF
--- a/Docs/Sphinx/source/Source/Particles.rst
+++ b/Docs/Sphinx/source/Source/Particles.rst
@@ -726,7 +726,7 @@ The recommended pattern for the per-cell family is to cell-sort the leaf, extrac
 ``ParticleSoA<P>::extractCell`` performs the per-cell extraction
 
 .. literalinclude:: ../../../../Source/Particle/CD_ParticleSoA.H
-   :lines: 1505-1527
+   :lines: 1506-1528
    :dedent: 2
    :language: c++
 

--- a/Source/Particle/CD_ParticleSoA.H
+++ b/Source/Particle/CD_ParticleSoA.H
@@ -1594,11 +1594,18 @@ protected:
   /**
    * @brief Grow the arena to hold at least @a a_needed particles, geometrically.
    * @details The growth policy for every append path, and deliberately NOT folded into reserve():
-   * reserve() sets the capacity EXACTLY, which deepCopy() depends on to reproduce a source
-   * container's arena layout byte for byte. An append that called reserve(m_size + n) directly would
-   * leave capacity == size on return, so the very next append would reallocate and recopy the whole
-   * arena again -- turning the documented extract->mutate->accumulate idiom (see extractCell()) into
-   * O(N^2) copying, since the accumulating container is grown one cell at a time.
+   * reserve() sets the capacity EXACTLY, and exactly one caller needs that for correctness.
+   * deepCopy() sizes the destination to the SOURCE's capacity and then flat-memcpy()s byteSpan()
+   * across in one go, which is only valid while both arenas compute the same per-column offsets --
+   * and those offsets are derived from the capacity. Rounding the capacity up there would silently
+   * copy the columns to the wrong places. The remaining exact-sizing callers do not depend on the
+   * layout: resize() and deepCopyTo() simply want the capacity they asked for rather than a doubled
+   * one, deepCopyTo() copying column by column and so needing only capacity >= m_size.
+   *
+   * An append that called reserve(m_size + n) directly would leave capacity == size on return, so
+   * the very next append would reallocate and recopy the whole arena -- turning the
+   * extract->mutate->accumulate idiom extractCell() documents as canonical into O(N^2) copying,
+   * since the accumulating container is grown one cell at a time.
    * @param[in] a_needed Number of particles the arena must be able to hold.
    */
   void

--- a/Source/Particle/CD_ParticleSoA.H
+++ b/Source/Particle/CD_ParticleSoA.H
@@ -117,6 +117,7 @@
 #define CD_PARTICLESOA_H
 
 // Std includes
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -1590,18 +1591,41 @@ protected:
     a_o.m_colPtrs  = {};
   }
 
-  /** @brief Grow geometrically if the container is full (called before writing slot m_size). */
+  /**
+   * @brief Grow the arena to hold at least @a a_needed particles, geometrically.
+   * @details The growth policy for every append path, and deliberately NOT folded into reserve():
+   * reserve() sets the capacity EXACTLY, which deepCopy() depends on to reproduce a source
+   * container's arena layout byte for byte. An append that called reserve(m_size + n) directly would
+   * leave capacity == size on return, so the very next append would reallocate and recopy the whole
+   * arena again -- turning the documented extract->mutate->accumulate idiom (see extractCell()) into
+   * O(N^2) copying, since the accumulating container is grown one cell at a time.
+   * @param[in] a_needed Number of particles the arena must be able to hold.
+   */
+  void
+  growTo(const std::size_t a_needed)
+  {
+    if (a_needed <= m_capacity) {
+      return;
+    }
+
+    // Saturating geometric growth: 2 * m_capacity overflows std::size_t once m_capacity exceeds
+    // SIZE_MAX/2, and reserve()'s "a_capacity <= m_capacity" guard would then silently no-op.
+    const std::size_t doubled = (m_capacity == 0) ? 16
+                                                  : (m_capacity <= std::numeric_limits<std::size_t>::max() / 2
+                                                       ? 2 * m_capacity
+                                                       : std::numeric_limits<std::size_t>::max());
+
+    this->reserve(std::max(a_needed, doubled));
+  }
+
+  /**
+   * @brief Grow geometrically if the container is full (called before writing slot m_size).
+   */
   void
   growIfFull()
   {
     if (m_size == m_capacity) {
-      // Saturating geometric growth: 2 * m_capacity overflows std::size_t once m_capacity exceeds
-      // SIZE_MAX/2, and reserve()'s "a_capacity <= m_capacity" guard would then silently no-op.
-      const std::size_t newCap = (m_capacity == 0) ? 16
-                                                   : (m_capacity <= std::numeric_limits<std::size_t>::max() / 2
-                                                        ? 2 * m_capacity
-                                                        : std::numeric_limits<std::size_t>::max());
-      this->reserve(newCap);
+      this->growTo(m_size + 1);
     }
   }
 

--- a/Source/Particle/CD_ParticleSoAImplem.H
+++ b/Source/Particle/CD_ParticleSoAImplem.H
@@ -120,7 +120,7 @@ ParticleSoA<P, Traits>::append(const ParticleSoA<P, Traits>& a_other)
     return;
   }
   const std::size_t oldSize = m_size;
-  this->reserve(oldSize + n); // may reallocate this (and a_other, when a_other == this); pointers refreshed below
+  this->growTo(oldSize + n); // may reallocate this (and a_other, when a_other == this); pointers refreshed below
   this->appendColumnsFrom(a_other, oldSize, std::make_index_sequence<s_numColumns>{});
   m_size   = oldSize + n;
   m_sorted = false;
@@ -133,7 +133,7 @@ ParticleSoA<P, Traits>::appendParticle(const ParticleSoA<P, Traits>& a_src, cons
   CH_assert(a_index < a_src.m_size);
 
   const std::size_t at = m_size;
-  this->reserve(m_size + 1); // may reallocate this (and a_src, when a_src == this); pointers refreshed below
+  this->growTo(m_size + 1); // may reallocate this (and a_src, when a_src == this); pointers refreshed below
   this->copyParticleColumns(a_src, a_index, at, std::make_index_sequence<s_numColumns>{});
   m_size   = at + 1;
   m_sorted = false;


### PR DESCRIPTION
# Summary

`ParticleSoA`'s two bulk append paths grew the arena to exactly the size they needed, so every
subsequent append reallocated and recopied the whole container. This makes the documented
extract → mutate → accumulate idiom quadratic in the accumulating container. Routing both paths
through a geometric `growTo()` fixes it.

### Background

`reserve()` sets the capacity *exactly* — `reallocate()` ends with `m_capacity = a_capacity`. Both
bulk append paths called it with precisely the number of particles they were about to write:

- `append(const ParticleSoA&)` → `reserve(oldSize + n)`
- `appendParticle(const ParticleSoA&, std::size_t)` → `reserve(m_size + 1)`

Capacity therefore equalled size on return, so the *next* append always exceeded capacity and
reallocated and recopied the entire arena. Appending `k` blocks into a container that starts empty
copies `O(k²)` particles rather than `O(k)`. The single-particle
`append(const RealVect&, double, const P&)` overload was never affected — it grows geometrically
through `growIfFull()` — which is why only the accumulation step showed the cost.

This is exactly the pattern `extractCell()`'s own documentation recommends ("extract a cell into a
reusable scratch container, mutate it, accumulate it into an output container via
`append(const ParticleSoA&)`, and finally `swap()`"), so every caller that followed the documented
idiom paid for it.

`ItoSolver::splitAndRebuildFromMergeContainer()` is the worst case: it accumulates one cell at a
time into an initially empty container. For a 16³ patch reaching 65 536 particles that is 4096
reallocations recopying roughly 7.6 GB. A standalone reproduction of just the allocation pattern
(4096 blocks of 16, ~61 B/particle) measures **1650.9 ms** against **1.5 ms** for geometric growth.
In a 3-D `ItoKMCGodunovStepper` run this accounted for about 90% of the "Make superparticles" timer
— the kd-tree build it wraps is ~55 ms per patch by comparison.

Other call sites hitting the same path include `ItoSolver`'s per-cell merger accumulation,
`ItoKMCStepper`'s cell rebuild, the `appendParticle` loops in `AmrMesh`'s ghost and remap helpers,
and several in `DischargeInceptionStepper`.

### Solution

Add a private `growTo(a_needed)` that holds the geometric policy — grow to
`max(a_needed, 2 * m_capacity)`, with the existing saturation guard against `2 * m_capacity`
overflowing `std::size_t` — and route `append(const ParticleSoA&)` and `appendParticle()` through
it. `growIfFull()` now delegates to it as well and keeps its previous behaviour exactly.

`reserve()` is deliberately left exact rather than made geometric: `deepCopy()` and `deepCopyTo()`
depend on it to reproduce a source container's arena layout byte for byte, so the growth policy
belongs in a separate helper.

### Side-effects

Containers grown through a bulk append now carry up to 2× their size in capacity, matching what the
single-particle `append()` overload has always done. `shrinkToFit()` reclaims it where that matters.

No behavioural change otherwise: only `m_capacity` is affected, never `m_size`, the particle data,
or the ordering. No caller anywhere in `Source`, `Physics` or `Exec` reads `capacity()`.

Verified with a 3-D `OPT=HIGH MPI=TRUE` build and six particle regression tests on 4 ranks — the
`BrownianWalker` `KDPatch`, `KDCarve`, `KDSkinNn`, `NNMergeTree`, `Reinitialize` and
`DriftDiffusion` cases — all running to completion. `pre-commit` passes on the changed files.

No new types are introduced; `growTo()` is a private member function alongside the `growIfFull()` it
generalises.

### Alternative solutions

- **Make `reserve()` itself geometric.** Rejected: `deepCopy()`/`deepCopyTo()` rely on it setting an
  exact capacity, and callers asking for a specific capacity should get that capacity.
- **Fix the call sites instead**, e.g. one up-front `split.reserve(...)` in
  `splitAndRebuildFromMergeContainer()`. Rejected: it leaves the trap in place for every other
  caller, including the loops in `AmrMesh` and `DischargeInceptionStepper`, and the idiom that
  triggers it is the one the header documents as canonical.
- **Have `appendParticle()` take a count**, so callers can size the growth themselves. Rejected as
  an API change that pushes an allocation concern onto callers for no gain over a growth policy.

### PR-review checklist

Mandatory:

- [x] I have run the test suite and made sure that it passed.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information.
- [x] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks.
- [ ] I have run clang-tidy and fixed all reported errors.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
