### PR TITLE
Remove per-cell overhead from the ItoKMC reaction-network advance

### DIFF
--- a/Docs/Sphinx/source/Source/Particles.rst
+++ b/Docs/Sphinx/source/Source/Particles.rst
@@ -726,7 +726,7 @@ The recommended pattern for the per-cell family is to cell-sort the leaf, extrac
 ``ParticleSoA<P>::extractCell`` performs the per-cell extraction
 
 .. literalinclude:: ../../../../Source/Particle/CD_ParticleSoA.H
-   :lines: 1506-1528
+   :lines: 1541-1563
    :dedent: 2
    :language: c++
 

--- a/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
@@ -348,8 +348,6 @@ ItoKMCPhysics::advanceKMC(Vector<FPR>&            a_numParticles,
                           const Real              a_dx,
                           const Real              a_kappa) const
 {
-  CH_TIME("ItoKMCPhysics::advanceKMC");
-
   // Note: This is called PER GRID CELL, i.e. within OpenMP parallel regions. For this reason the KMC solver
   //       must be defined through defineKMC() (which must be later killed).
   CH_assert(m_isDefined);
@@ -523,10 +521,6 @@ ItoKMCPhysics::reconcileParticles(Vector<ParticleSoA<ItoParticle>*>& a_particles
                                   const Real                         a_dx,
                                   const Real                         a_kappa) const noexcept
 {
-  CH_TIMERS("ItoKMCPhysics::reconcileParticles");
-  CH_TIMER("ItoKMCPhysics::reconcileParticles::compute_downstream", t1);
-  CH_TIMER("ItoKMCPhysics::reconcileParticles::particle_placement", t2);
-
   CH_assert(m_isDefined);
   CH_assert(a_particles.size() == a_newNumParticles.size());
   CH_assert(a_oldNumParticles.size() == a_newNumParticles.size());
@@ -580,7 +574,6 @@ ItoKMCPhysics::reconcileParticles(Vector<ParticleSoA<ItoParticle>*>& a_particles
                                                   a_dx);
   }
 
-  CH_START(t2);
   for (int i = 0; i < a_particles.size(); i++) {
     const long long diff = static_cast<long long>(a_newNumParticles[i] - a_oldNumParticles[i]);
 
@@ -653,7 +646,6 @@ ItoKMCPhysics::reconcileParticles(Vector<ParticleSoA<ItoParticle>*>& a_particles
       this->removeParticles(*a_particles[i], -diff);
     }
   }
-  CH_STOP(t2);
 }
 
 inline bool
@@ -666,8 +658,6 @@ ItoKMCPhysics::computeUpstreamPosition(RealVect&                       a_pos,
                                        const RealVect&                 a_cellPos,
                                        const Real&                     a_dx) const noexcept
 {
-  CH_TIME("ItoKMCPhysics::computeUpstreamPosition");
-
   CH_assert(a_dx > 0.0);
 
   a_pos = RealVect::Zero;
@@ -712,8 +702,6 @@ ItoKMCPhysics::computeUpstreamPosition(RealVect&                       a_pos,
 inline void
 ItoKMCPhysics::removeParticles(ParticleSoA<ItoParticle>& a_particles, const long long a_numParticlesToRemove) const
 {
-  CH_TIME("ItoKMCPhysics::removeParticles");
-
   constexpr long long zero = 0LL;
 
   CH_assert(m_isDefined);
@@ -786,8 +774,6 @@ ItoKMCPhysics::reconcilePhotons(Vector<ParticleSoA<Photon>*>& a_newPhotons,
                                 const Real                    a_dx,
                                 const Real                    a_kappa) const noexcept
 {
-  CH_TIME("ItoKMCPhysics::reconcilePhotons");
-
   CH_assert(m_isDefined);
 
   for (int i = 0; i < a_newPhotons.size(); i++) {
@@ -818,8 +804,6 @@ ItoKMCPhysics::reconcilePhotoionization(Vector<ParticleSoA<ItoParticle>*>&  a_it
                                         Vector<ParticleSoA<NoPayload>*>&    a_cdrParticles,
                                         const Vector<ParticleSoA<Photon>*>& a_absorbedPhotons) const noexcept
 {
-  CH_TIME("ItoKMCPhysics::reconcilePhotoionization");
-
   CH_assert(m_isDefined);
   CH_assert(a_itoParticles.size() == m_itoSpecies.size());
   CH_assert(a_cdrParticles.size() == m_cdrSpecies.size());

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -3650,18 +3650,19 @@ ItoKMCStepper<I, C, R, F>::computeReactiveItoParticlesPerCell(EBCellFAB&      a_
 
     ParticleContainer<ItoParticle>& particles = solver->getParticles(ItoSolver::WhichContainer::Bulk);
 
-    // SoA per-cell extract: cell-sort this leaf and split it into one ParticleSoA per grid cell.
-    std::vector<ParticleSoA<ItoParticle>> cellParticles;
-    binLeafToCells(cellParticles, particles[a_level][a_din], a_box, dx, probLo);
+    // Cell-sort the leaf and read each cell's particles straight out of its CSR range. This kernel only
+    // sums weights, so there is nothing to extract into per-cell scratch containers.
+    ParticleSoA<ItoParticle>& leaf = particles[a_level][a_din];
+    leaf.sortByCell(a_box, dx * RealVect::Unit, probLo);
 
     // Regular cells kernel.
     auto regularKernel = [&](const IntVect& iv) -> void {
       Real num = 0.0;
 
       if (a_ebisbox.isRegular(iv)) {
-        const ParticleSoA<ItoParticle>& cell = cellParticles[a_box.index(iv)];
-        for (std::size_t i = 0; i < cell.size(); i++) {
-          num += cell.weight(i);
+        const std::pair<std::size_t, std::size_t> range = leaf.cellRange(a_box.index(iv));
+        for (std::size_t i = range.first; i < range.second; i++) {
+          num += leaf.weight(i);
         }
       }
 
@@ -3676,11 +3677,11 @@ ItoKMCStepper<I, C, R, F>::computeReactiveItoParticlesPerCell(EBCellFAB&      a_
 
       Real num = 0.0;
 
-      const ParticleSoA<ItoParticle>& cell = cellParticles[a_box.index(iv)];
-      for (std::size_t i = 0; i < cell.size(); i++) {
-        const RealVect pos = cell.position(i);
+      const std::pair<std::size_t, std::size_t> range = leaf.cellRange(a_box.index(iv));
+      for (std::size_t i = range.first; i < range.second; i++) {
+        const RealVect pos = leaf.position(i);
         if ((pos - physCentroid).dotProduct(normal) >= 0.0) {
-          num += cell.weight(i);
+          num += leaf.weight(i);
         }
       }
 
@@ -3880,9 +3881,10 @@ ItoKMCStepper<I, C, R, F>::computeReactiveMeanEnergiesPerCell(EBCellFAB&      a_
 
     ParticleContainer<ItoParticle>& particles = solver->getParticles(ItoSolver::WhichContainer::Bulk);
 
-    // SoA per-cell extract: cell-sort this leaf and split it into one ParticleSoA per grid cell.
-    std::vector<ParticleSoA<ItoParticle>> cellParticles;
-    binLeafToCells(cellParticles, particles[a_level][a_din], a_box, dx, probLo);
+    // Cell-sort the leaf and read each cell's particles straight out of its CSR range. This kernel only
+    // accumulates weights and energies, so there is nothing to extract into per-cell scratch containers.
+    ParticleSoA<ItoParticle>& leaf = particles[a_level][a_din];
+    leaf.sortByCell(a_box, dx * RealVect::Unit, probLo);
 
     // Regular grid cells.
     auto regularKernel = [&](const IntVect& iv) -> void {
@@ -3890,11 +3892,11 @@ ItoKMCStepper<I, C, R, F>::computeReactiveMeanEnergiesPerCell(EBCellFAB&      a_
         Real totalWeight = 0.0;
         Real totalEnergy = 0.0;
 
-        const ParticleSoA<ItoParticle>& cell = cellParticles[a_box.index(iv)];
-        for (std::size_t i = 0; i < cell.size(); i++) {
-          const Real w = cell.weight(i);
+        const std::pair<std::size_t, std::size_t> range = leaf.cellRange(a_box.index(iv));
+        for (std::size_t i = range.first; i < range.second; i++) {
+          const Real w = leaf.weight(i);
           totalWeight += w;
-          totalEnergy += w * cell.template get<&ItoParticle::energy>(i);
+          totalEnergy += w * leaf.template get<&ItoParticle::energy>(i);
         }
 
         if (totalWeight > 0.0) {
@@ -3915,14 +3917,14 @@ ItoKMCStepper<I, C, R, F>::computeReactiveMeanEnergiesPerCell(EBCellFAB&      a_
       Real totalWeight = 0.0;
       Real totalEnergy = 0.0;
 
-      const ParticleSoA<ItoParticle>& cell = cellParticles[a_box.index(iv)];
-      for (std::size_t i = 0; i < cell.size(); i++) {
-        const RealVect pos = cell.position(i);
+      const std::pair<std::size_t, std::size_t> range = leaf.cellRange(a_box.index(iv));
+      for (std::size_t i = range.first; i < range.second; i++) {
+        const RealVect pos = leaf.position(i);
 
         if ((pos - ebCentroid).dotProduct(normal) >= 0.0) {
-          const Real w = cell.weight(i);
+          const Real w = leaf.weight(i);
           totalWeight += w;
-          totalEnergy += w * cell.template get<&ItoParticle::energy>(i);
+          totalEnergy += w * leaf.template get<&ItoParticle::energy>(i);
         }
       }
 

--- a/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
+++ b/Physics/ItoKMC/PlasmaModels/ItoKMCJSON/CD_ItoKMCJSON.cpp
@@ -3412,7 +3412,6 @@ ItoKMCJSON::parseReactionWildcards(const std::vector<std::string>& a_reactants,
 Real
 ItoKMCJSON::getNeutralDensity(const RealVect& a_pos) const noexcept
 {
-  CH_TIME("ItoKMCJSON::getNeutralDensity");
   if (m_verbose) {
     pout() << m_className + "::getNeutralDensity" << endl;
   }
@@ -3423,7 +3422,6 @@ ItoKMCJSON::getNeutralDensity(const RealVect& a_pos) const noexcept
 Real
 ItoKMCJSON::computeAlpha(const Real a_E, const RealVect& a_pos) const noexcept
 {
-  CH_TIME("ItoKMCJSON::computeAlpha");
   if (m_verbose) {
     pout() << m_className + "::computeAlpha" << endl;
   }
@@ -3434,7 +3432,6 @@ ItoKMCJSON::computeAlpha(const Real a_E, const RealVect& a_pos) const noexcept
 Real
 ItoKMCJSON::computeEta(const Real a_E, const RealVect& a_pos) const noexcept
 {
-  CH_TIME("ItoKMCJSON::computeEta");
   if (m_verbose) {
     pout() << m_className + "::computeEta" << endl;
   }
@@ -3445,7 +3442,6 @@ ItoKMCJSON::computeEta(const Real a_E, const RealVect& a_pos) const noexcept
 Vector<Real>
 ItoKMCJSON::computeMobilities(const Real /*a_time*/, const RealVect& a_pos, const RealVect& a_E) const noexcept
 {
-  CH_TIME("ItoKMCJSON::computeMobilities");
   if (m_verbose) {
     pout() << m_className + "::computeMobilities" << endl;
   }
@@ -3465,7 +3461,6 @@ ItoKMCJSON::computeDiffusionCoefficients(const Real /*a_time*/,
                                          const RealVect& a_pos,
                                          const RealVect& a_E) const noexcept
 {
-  CH_TIME("ItoKMCJSON::computeDiffusionCoefficients");
   if (m_verbose) {
     pout() << m_className + "::computeDiffusionCoefficients" << endl;
   }
@@ -3490,7 +3485,6 @@ ItoKMCJSON::updateReactionRates(std::vector<std::shared_ptr<const KMCReaction>>&
                                 const Real                                       a_dx,
                                 const Real /*a_kappa*/) const noexcept
 {
-  CH_TIME("ItoKMCJSON::updateReactionRates");
   if (m_verbose) {
     pout() << m_className + "::updateReactionRates" << endl;
   }
@@ -3547,7 +3541,6 @@ ItoKMCJSON::secondaryEmissionEB(Vector<ParticleSoA<ItoParticle>>& a_secondaryPar
                                 const bool                              a_isDielectric,
                                 const int /*a_matIndex*/) const noexcept
 {
-  CH_TIME("ItoKMCJSON::secondaryEmissionEB");
   if (m_verbose) {
     pout() << m_className + "::secondaryEmissionEB" << endl;
   }
@@ -3786,7 +3779,6 @@ ItoKMCJSON::getPlotVariables(const RealVect& a_E,
                              const Real /*a_kappa*/) const noexcept
 {
 
-  CH_TIME("ItoKMCJSON::getPlotVariables");
   if (m_verbose) {
     pout() << m_className + "::getPlotVariables" << endl;
   }
@@ -3827,7 +3819,6 @@ ItoKMCJSON::getPlotVariables(const RealVect& a_E,
 std::vector<size_t>
 ItoKMCJSON::multinomial(const size_t N, const std::discrete_distribution<int>& a_distribution) const noexcept
 {
-  CH_TIME("ItoKMCJSON::multinomial");
   if (m_verbose) {
     pout() << m_className + "::multinomial" << endl;
   }

--- a/Source/KineticMonteCarlo/CD_KMCDualStateImplem.H
+++ b/Source/KineticMonteCarlo/CD_KMCDualStateImplem.H
@@ -14,7 +14,7 @@
 #define CD_KMCDUALSTATEIMPLEM_H
 
 // Chombo includes
-#include <CH_Timer.H>
+#include <CH_assert.H>
 
 // Our includes
 #include <CD_KMCDualState.H>
@@ -23,8 +23,6 @@
 template <typename T>
 KMCDualState<T>::KMCDualState(const size_t a_numReactiveSpecies, const size_t a_numNonReactiveSpecies) noexcept
 {
-  CH_TIME("KMCDualState::KMCDualState");
-
   this->define(a_numReactiveSpecies, a_numNonReactiveSpecies);
 
   CH_assert(m_reactiveState.size() > 0);
@@ -38,8 +36,6 @@ template <typename T>
 inline void
 KMCDualState<T>::define(const size_t a_numReactiveSpecies, const size_t a_numNonReactiveSpecies) noexcept
 {
-  CH_TIME("KMCDualState::define");
-
   m_numReactiveSpecies    = a_numReactiveSpecies;
   m_numNonReactiveSpecies = a_numNonReactiveSpecies;
 
@@ -51,8 +47,6 @@ template <typename T>
 inline bool
 KMCDualState<T>::isValidState() const noexcept
 {
-  CH_TIME("KMCDualState::isValidState");
-
   bool isValid = true;
 
   for (const auto& p : m_reactiveState) {

--- a/Source/KineticMonteCarlo/CD_KMCDualStateReactionImplem.H
+++ b/Source/KineticMonteCarlo/CD_KMCDualStateReactionImplem.H
@@ -17,7 +17,7 @@
 #include <limits>
 
 // Chombo includes
-#include <CH_Timer.H>
+#include <CH_assert.H>
 
 // Our includes
 #include <CD_KMCDualStateReaction.H>
@@ -28,8 +28,6 @@ inline KMCDualStateReaction<State, T>::KMCDualStateReaction(const std::list<size
                                                             const std::list<size_t>& a_rhsReactives,
                                                             const std::list<size_t>& a_rhsNonReactives) noexcept
 {
-  CH_TIME("KMCDualStateReaction::KMCDualStateReaction");
-
   m_lhsReactives    = a_lhsReactives;
   m_rhsReactives    = a_rhsReactives;
   m_rhsNonReactives = a_rhsNonReactives;
@@ -41,16 +39,12 @@ inline KMCDualStateReaction<State, T>::KMCDualStateReaction(const std::list<size
 
 template <typename State, typename T>
 inline KMCDualStateReaction<State, T>::~KMCDualStateReaction()
-{
-  CH_TIME("KMCDualStateReaction::~KMCDualStateReaction");
-}
+{}
 
 template <typename State, typename T>
 inline void
 KMCDualStateReaction<State, T>::computeStateChanges() noexcept
 {
-  CH_TIME("KMCDualStateReaction::computeStateChanges");
-
   // Consumed species.
   for (const auto& r : m_lhsReactives) {
     if (m_reactiveStateChange.find(r) == m_reactiveStateChange.end()) {
@@ -133,8 +127,6 @@ template <typename State, typename T>
 inline T
 KMCDualStateReaction<State, T>::population(const size_t& a_reactant, const State& a_state) noexcept
 {
-  CH_TIME("KMCDualStateReaction::population");
-
   const auto& reactiveState = a_state.getReactiveState();
 
   CH_assert(reactiveState.size() > a_reactant);
@@ -146,7 +138,6 @@ template <typename State, typename T>
 inline Real
 KMCDualStateReaction<State, T>::propensity(const State& a_state) const noexcept
 {
-  CH_TIME("KMCDualStateReaction::propensity");
 #ifndef NDEBUG
   this->sanityCheck(a_state);
 #endif
@@ -168,8 +159,6 @@ template <typename State, typename T>
 inline T
 KMCDualStateReaction<State, T>::computeCriticalNumberOfReactions(const State& a_state) const noexcept
 {
-  CH_TIME("KMCDualStateReaction::computeCriticalNumberOfReactions");
-
 #ifndef NDEBUG
   this->sanityCheck(a_state);
 #endif
@@ -216,8 +205,6 @@ template <typename State, typename T>
 inline T
 KMCDualStateReaction<State, T>::getStateChange(const size_t a_particleReactant) const noexcept
 {
-  CH_TIME("KMCDualStateReaction::getStateChange");
-
   T nuIJ = 0;
 
   if (m_reactiveStateChange.find(a_particleReactant) != m_reactiveStateChange.end()) {
@@ -231,8 +218,6 @@ template <typename State, typename T>
 inline void
 KMCDualStateReaction<State, T>::advanceState(State& a_state, const T& a_numReactions) const noexcept
 {
-  CH_TIME("KMCDualStateReaction::advanceState");
-
 #ifndef NDEBUG
   this->sanityCheck(a_state);
 #endif
@@ -256,8 +241,6 @@ template <typename State, typename T>
 inline void
 KMCDualStateReaction<State, T>::sanityCheck(const State& a_state) const noexcept
 {
-  CH_TIME("KMCDualStateReaction::sanityCheck");
-
   const auto& reactiveState = a_state.getReactiveState();
   const auto& photonState   = a_state.getNonReactiveState();
 

--- a/Source/KineticMonteCarlo/CD_KMCSingleStateImplem.H
+++ b/Source/KineticMonteCarlo/CD_KMCSingleStateImplem.H
@@ -14,7 +14,7 @@
 #define CD_KMCSINGLESTATEIMPLEM_H
 
 // Chombo includes
-#include <CH_Timer.H>
+#include <CH_assert.H>
 
 // Our includes
 #include <CD_KMCSingleState.H>
@@ -23,23 +23,17 @@
 template <typename T>
 KMCSingleState<T>::KMCSingleState(const size_t a_numSpecies) noexcept
 {
-  CH_TIME("KMCSingleState::KMCSingleState");
-
   m_state.resize(a_numSpecies);
 }
 
 template <typename T>
 inline KMCSingleState<T>::~KMCSingleState()
-{
-  CH_TIME("KMCSingleState::~KMCSingleState");
-}
+{}
 
 template <typename T>
 inline bool
 KMCSingleState<T>::isValidState() const noexcept
 {
-  CH_TIME("KMCSingleState::isValidState");
-
   bool isValid = true;
 
   for (const auto& p : m_state) {

--- a/Source/KineticMonteCarlo/CD_KMCSingleStateReactionImplem.H
+++ b/Source/KineticMonteCarlo/CD_KMCSingleStateReactionImplem.H
@@ -13,9 +13,6 @@
 #ifndef CD_KMCSINGLESTATEREACTIONIMPLEM_H
 #define CD_KMCSINGLESTATEREACTIONIMPLEM_H
 
-// Chombo includes
-#include <CH_Timer.H>
-
 // Our includes
 #include <CD_KMCSingleStateReaction.H>
 #include <CD_NamespaceHeader.H>
@@ -25,23 +22,17 @@ inline KMCSingleStateReaction<State, T>::KMCSingleStateReaction(const std::list<
                                                                 const std::list<size_t>& a_products) noexcept
   : m_reactants(a_reactants), m_products(a_products)
 {
-  CH_TIME("KMCSingleStateReaction::KMCSingleStateReaction");
-
   this->computeStateChanges();
 }
 
 template <typename State, typename T>
 inline KMCSingleStateReaction<State, T>::~KMCSingleStateReaction()
-{
-  CH_TIME("KMCSingleStateReaction::~KMCSingleStateReaction");
-}
+{}
 
 template <typename State, typename T>
 inline void
 KMCSingleStateReaction<State, T>::computeStateChanges() noexcept
 {
-  CH_TIME("KMCSingleStateReaction::computeStateChanges");
-
   // Consumed particles.
   for (const auto& r : m_reactants) {
     if (m_stateChange.find(r) == m_stateChange.end()) {
@@ -111,8 +102,6 @@ template <typename State, typename T>
 inline Real
 KMCSingleStateReaction<State, T>::propensity(const State& a_state) const noexcept
 {
-  CH_TIME("KMCSingleStateReaction::propensity");
-
   Real A = m_rate * m_propensityFactor;
 
   State tmp = a_state;
@@ -130,8 +119,6 @@ template <typename State, typename T>
 inline T
 KMCSingleStateReaction<State, T>::computeCriticalNumberOfReactions(const State& a_state) const noexcept
 {
-  CH_TIME("KMCSingleStateReaction::computeCriticalNumberOfReactions");
-
   T Lj = std::numeric_limits<T>::max();
 
   for (const auto& s : m_stateChange) {
@@ -158,8 +145,6 @@ template <typename State, typename T>
 inline T
 KMCSingleStateReaction<State, T>::getStateChange(const size_t a_particleReactant) const noexcept
 {
-  CH_TIME("KMCSingleStateReaction::getStateChange");
-
   T nuIJ = 0;
 
   if (m_stateChange.find(a_particleReactant) != m_stateChange.end()) {
@@ -173,8 +158,6 @@ template <typename State, typename T>
 inline void
 KMCSingleStateReaction<State, T>::advanceState(State& a_state, const T& a_numReactions) const noexcept
 {
-  CH_TIME("KMCSingleStateReaction::advanceState");
-
   for (const auto& s : m_stateChange) {
     a_state[s.first] += a_numReactions * s.second;
   }

--- a/Source/KineticMonteCarlo/CD_KMCSolverImplem.H
+++ b/Source/KineticMonteCarlo/CD_KMCSolverImplem.H
@@ -18,7 +18,9 @@
 #include <unordered_set>
 
 // Chombo includes
-#include <CH_Timer.H>
+#include <CH_assert.H>
+#include <MayDay.H>
+#include <parstream.H>
 
 // Our includes
 #include <CD_Random.H>
@@ -29,31 +31,23 @@
 template <typename R, typename State, typename T>
 inline KMCSolver<R, State, T>::KMCSolver() noexcept
 {
-  CH_TIME("KMCSolver::KMCSolver");
-
   this->setSolverParameters(0, 0, 100, std::numeric_limits<Real>::max(), 0.0, 1.E-6);
 }
 
 template <typename R, typename State, typename T>
 inline KMCSolver<R, State, T>::KMCSolver(const ReactionList& a_reactions) noexcept
 {
-  CH_TIME("KMCSolver::KMCSolver");
-
   this->define(a_reactions);
 }
 
 template <typename R, typename State, typename T>
 inline KMCSolver<R, State, T>::~KMCSolver() noexcept
-{
-  CH_TIME("KMCSolver::~KMCSolver");
-}
+{}
 
 template <typename R, typename State, typename T>
 inline void
 KMCSolver<R, State, T>::define(const ReactionList& a_reactions) noexcept
 {
-  CH_TIME("KMCSolver::define");
-
   m_reactions = a_reactions;
 
   // Default settings. These are equivalent to ALWAYS using tau-leaping.
@@ -69,8 +63,6 @@ KMCSolver<R, State, T>::setSolverParameters(const T    a_numCrit,
                                             const Real a_SSAlim,
                                             const Real a_exitTol) noexcept
 {
-  CH_TIME("KMCSolver::setSolverParameters");
-
   m_Ncrit   = a_numCrit;
   m_numSSA  = a_numSSA;
   m_maxIter = a_maxIter;
@@ -83,8 +75,6 @@ template <typename R, typename State, typename T>
 inline std::vector<std::vector<T>>
 KMCSolver<R, State, T>::getNu(const State& a_state, const ReactionList& a_reactions) const noexcept
 {
-  CH_TIME("KMCSolver::getNu(State)");
-
   std::vector<std::vector<T>> ret(a_reactions.size());
 
   for (int j = 0; j < a_reactions.size(); j++) {
@@ -118,8 +108,6 @@ template <typename R, typename State, typename T>
 inline std::vector<Real>
 KMCSolver<R, State, T>::propensities(const State& a_state) const noexcept
 {
-  CH_TIME("KMCSolver::propensities(State)");
-
   return this->propensities(a_state, m_reactions);
 }
 
@@ -127,8 +115,6 @@ template <typename R, typename State, typename T>
 inline std::vector<Real>
 KMCSolver<R, State, T>::propensities(const State& a_state, const ReactionList& a_reactions) const noexcept
 {
-  CH_TIME("KMCSolver::propensities(State, ReactionList)");
-
   std::vector<Real> A(a_reactions.size());
 
   const size_t numReactions = a_reactions.size();
@@ -144,8 +130,6 @@ template <typename R, typename State, typename T>
 inline Real
 KMCSolver<R, State, T>::totalPropensity(const State& a_state) const noexcept
 {
-  CH_TIME("KMCSolver::totalPropensity(State)");
-
   return this->totalPropensity(a_state, m_reactions);
 }
 
@@ -153,8 +137,6 @@ template <typename R, typename State, typename T>
 inline Real
 KMCSolver<R, State, T>::totalPropensity(const State& a_state, const ReactionList& a_reactions) const noexcept
 {
-  CH_TIME("KMCSolver::totalPropensity(State, ReactionList)");
-
   Real A = 0.0;
 
   const size_t numReactions = a_reactions.size();
@@ -170,8 +152,6 @@ template <typename R, typename State, typename T>
 inline std::pair<typename KMCSolver<R, State, T>::ReactionList, typename KMCSolver<R, State, T>::ReactionList>
 KMCSolver<R, State, T>::partitionReactions(const State& a_state) const noexcept
 {
-  CH_TIME("KMCSolver::partitionReactions(State)");
-
   return this->partitionReactions(a_state, m_reactions);
 }
 
@@ -179,8 +159,6 @@ template <typename R, typename State, typename T>
 inline std::pair<typename KMCSolver<R, State, T>::ReactionList, typename KMCSolver<R, State, T>::ReactionList>
 KMCSolver<R, State, T>::partitionReactions(const State& a_state, const ReactionList& a_reactions) const noexcept
 {
-  CH_TIME("KMCSolver::partitionReactions(State, ReactionList)");
-
   ReactionList criticalReactions;
   ReactionList nonCriticalReactions;
 
@@ -202,7 +180,9 @@ KMCSolver<R, State, T>::partitionReactions(const State& a_state, const ReactionL
     }
   }
 
-  return std::make_pair(criticalReactions, nonCriticalReactions);
+  // Move rather than copy: this runs once per substep per grid cell, and copying the two lists would
+  // duplicate both allocations and bump the refcount of every reaction twice more.
+  return std::make_pair(std::move(criticalReactions), std::move(nonCriticalReactions));
 }
 
 template <typename R, typename State, typename T>
@@ -218,8 +198,6 @@ inline Real
 KMCSolver<R, State, T>::getCriticalTimeStep(const State&        a_state,
                                             const ReactionList& a_criticalReactions) const noexcept
 {
-  CH_TIME("KMCSolver::getCriticalTimeStep");
-
   // TLDR: This computes the time until the firing of the next critical reaction.
 
   Real dt = std::numeric_limits<Real>::max();
@@ -238,8 +216,6 @@ template <typename R, typename State, typename T>
 inline Real
 KMCSolver<R, State, T>::getCriticalTimeStep(const std::vector<Real>& a_propensities) const noexcept
 {
-  CH_TIME("KineticMonteCarlo::getCriticalTimeStep(std::vector<Real>)");
-
   // To avoid division by zero later on.
   Real A = std::numeric_limits<Real>::min();
 
@@ -254,8 +230,6 @@ template <typename R, typename State, typename T>
 inline Real
 KMCSolver<R, State, T>::getCriticalTimeStep(const Real& a_totalPropensity) const noexcept
 {
-  CH_TIME("KineticMonteCarlo::getCriticalTimeStep(Real)");
-
   const Real u = std::numeric_limits<Real>::min() + Random::getUniformReal01();
 
   return log(1.0 / u) / a_totalPropensity;
@@ -265,8 +239,6 @@ template <typename R, typename State, typename T>
 inline Real
 KMCSolver<R, State, T>::getNonCriticalTimeStep(const State& a_state) const noexcept
 {
-  CH_TIME("KMCSolver::getNonCriticalTimeStep(State");
-
   const auto& partitionedReactions = this->partitionReactions(a_state, m_reactions);
 
   return this->getNonCriticalTimeStep(a_state, partitionedReactions.second);
@@ -276,8 +248,6 @@ template <typename R, typename State, typename T>
 inline Real
 KMCSolver<R, State, T>::getNonCriticalTimeStep(const State& a_state, const ReactionList& a_reactions) const noexcept
 {
-  CH_TIME("KMCSolver::getNonCriticalTimeStep(State, ReactionList");
-
   const std::vector<Real> propensities = this->propensities(a_state, a_reactions);
 
   return this->getNonCriticalTimeStep(a_state, a_reactions, propensities);
@@ -289,8 +259,6 @@ KMCSolver<R, State, T>::getNonCriticalTimeStep(const State&             a_state,
                                                const ReactionList&      a_nonCriticalReactions,
                                                const std::vector<Real>& a_nonCriticalPropensities) const noexcept
 {
-  CH_TIME("KMCSolver::getNonCriticalTimeStep(State, ReactionList, std::vector<Real>");
-
   CH_assert(a_nonCriticalReactions.size() == a_nonCriticalPropensities.size());
 
   constexpr Real one = 1.0;
@@ -371,8 +339,6 @@ KMCSolver<R, State, T>::computeDt(const State&             a_state,
                                   const std::vector<Real>& a_propensities,
                                   const Real               a_epsilon) const noexcept
 {
-  CH_TIME("KMCSolver::computeDt(State, ReactionList, std::vector<Real>, Real");
-
   CH_assert(a_reactions.size() == a_propensities.size());
 
   constexpr Real one = 1.0;
@@ -439,8 +405,6 @@ template <typename R, typename State, typename T>
 inline void
 KMCSolver<R, State, T>::stepSSA(State& a_state) const noexcept
 {
-  CH_TIME("KMCSolver::stepSSA(State, Real)");
-
   this->stepSSA(a_state, m_reactions);
 }
 
@@ -448,8 +412,6 @@ template <typename R, typename State, typename T>
 inline void
 KMCSolver<R, State, T>::stepSSA(State& a_state, const ReactionList& a_reactions) const noexcept
 {
-  CH_TIME("KMCSolver::stepSSA(State, ReactionList, Real)");
-
   if (a_reactions.size() > 0) {
 
     // Compute all propensities.
@@ -465,8 +427,6 @@ KMCSolver<R, State, T>::stepSSA(State&                   a_state,
                                 const ReactionList&      a_reactions,
                                 const std::vector<Real>& a_propensities) const noexcept
 {
-  CH_TIME("KMCSolver::stepSSA(State, ReactionList, std::vector<Real>)");
-
   CH_assert(a_reactions.size() == a_propensities.size());
 
   const size_t numReactions = a_reactions.size();
@@ -506,8 +466,6 @@ template <typename R, typename State, typename T>
 inline void
 KMCSolver<R, State, T>::advanceSSA(State& a_state, const Real a_dt) const noexcept
 {
-  CH_TIME("KMCSolver::advanceSSA(State, Real)");
-
   this->advanceSSA(a_state, m_reactions, a_dt);
 }
 
@@ -515,8 +473,6 @@ template <typename R, typename State, typename T>
 inline void
 KMCSolver<R, State, T>::advanceSSA(State& a_state, const ReactionList& a_reactions, const Real a_dt) const noexcept
 {
-  CH_TIME("KMCSolver::advanceSSA(State, ReactionList, Real)");
-
   const size_t numReactions = a_reactions.size();
 
   if (numReactions > 0) {
@@ -545,8 +501,6 @@ template <typename R, typename State, typename T>
 inline void
 KMCSolver<R, State, T>::stepExplicitEuler(State& a_state, const Real a_dt) const noexcept
 {
-  CH_TIME("KMCSolver::stepExplicitEuler(State, Real)");
-
   this->stepExplicitEuler(a_state, m_reactions, a_dt);
 }
 
@@ -556,8 +510,6 @@ KMCSolver<R, State, T>::stepExplicitEuler(State&              a_state,
                                           const ReactionList& a_reactions,
                                           const Real          a_dt) const noexcept
 {
-  CH_TIME("KMCSolver::stepExplicitEuler(State, ReactionList, std::vector<Real>, Real)");
-
   CH_assert(a_dt > 0.0);
 
   if (a_reactions.size() > 0) {
@@ -578,8 +530,6 @@ template <typename R, typename State, typename T>
 inline void
 KMCSolver<R, State, T>::stepMidpoint(State& a_state, const Real a_dt) const noexcept
 {
-  CH_TIME("KMCSolver::stepMidpoint(State&, const Real)");
-
   this->stepMidpoint(a_state, m_reactions, a_dt);
 }
 
@@ -587,10 +537,6 @@ template <typename R, typename State, typename T>
 inline void
 KMCSolver<R, State, T>::stepMidpoint(State& a_state, const ReactionList& a_reactions, const Real a_dt) const noexcept
 {
-  CH_TIMERS("KMCSolver::stepMidpoint(State&, const ReactionList&, const Real)");
-  CH_TIMER("KMCSolver::stepTauMidPoint::first_loop", t1);
-  CH_TIMER("KMCSolver::stepTauMidPoint::second_loop", t2);
-
   const int numReactions = a_reactions.size();
 
   if (numReactions > 0) {
@@ -599,23 +545,19 @@ KMCSolver<R, State, T>::stepMidpoint(State& a_state, const ReactionList& a_react
 
     State Xdagger = a_state;
 
-    CH_START(t1);
     for (size_t i = 0; i < numReactions; i++) {
       // TLDR: Predict a midpoint state -- unfortunately this means that as a_dt->0 we end up with plain
       //       tau-leaping. I don't know of a way to fix this without introducing double fluctuations (yet).
       a_reactions[i]->advanceState(Xdagger, (T)std::round(0.5 * propensities[i] * a_dt));
     }
-    CH_STOP(t1);
 
     propensities = this->propensities(Xdagger, a_reactions);
 
-    CH_START(t2);
     for (size_t i = 0; i < numReactions; i++) {
       const T curReactions = (T)Random::getPoisson<long long>(propensities[i] * a_dt);
 
       a_reactions[i]->advanceState(a_state, curReactions);
     }
-    CH_STOP(t2);
   }
 }
 
@@ -623,8 +565,6 @@ template <typename R, typename State, typename T>
 inline void
 KMCSolver<R, State, T>::stepPRC(State& a_state, const Real a_dt) const noexcept
 {
-  CH_TIME("KMCSolver::stepPRC(State&, const Real)");
-
   this->stepPRC(a_state, m_reactions, a_dt);
 }
 
@@ -632,10 +572,6 @@ template <typename R, typename State, typename T>
 inline void
 KMCSolver<R, State, T>::stepPRC(State& a_state, const ReactionList& a_reactions, const Real a_dt) const noexcept
 {
-  CH_TIMERS("KMCSolver::stepPRC(State&, const ReactionList&, const Real)");
-  CH_TIMER("KMCSolver::stepPRC::first_loop", t1);
-  CH_TIMER("KMCSolver::stepPRC::second_loop", t2);
-
   const int numReactions = a_reactions.size();
 
   if (numReactions > 0) {
@@ -644,7 +580,6 @@ KMCSolver<R, State, T>::stepPRC(State& a_state, const ReactionList& a_reactions,
 
     const std::vector<Real> ak = aj;
 
-    CH_START(t1);
     for (int j = 0; j < numReactions; j++) {
       for (int k = 0; k < numReactions; k++) {
         State x = a_state;
@@ -656,15 +591,12 @@ KMCSolver<R, State, T>::stepPRC(State& a_state, const ReactionList& a_reactions,
         aj[j] += 0.5 * a_dt * ak[k] * etajk;
       }
     }
-    CH_STOP(t1);
 
-    CH_START(t2);
     for (size_t i = 0; i < numReactions; i++) {
       const T nr = (T)Random::getPoisson<long long>(aj[i] * a_dt);
 
       a_reactions[i]->advanceState(a_state, nr);
     }
-    CH_STOP(t2);
   }
 }
 
@@ -672,8 +604,6 @@ template <typename R, typename State, typename T>
 inline void
 KMCSolver<R, State, T>::stepImplicitEuler(State& a_state, const Real a_dt) const noexcept
 {
-  CH_TIME("KMCSolver::stepImplicitEuler(State, a_dt)");
-
   this->stepImplicitEuler(a_state, m_reactions, a_dt);
 }
 
@@ -683,8 +613,6 @@ KMCSolver<R, State, T>::stepImplicitEuler(State&              a_state,
                                           const ReactionList& a_reactions,
                                           const Real          a_dt) const noexcept
 {
-  CH_TIME("KMCSolver::stepImplicitEuler(State, ReactionList, a_dt)");
-
   // TLDR: The implicit Euler tau-leaping scheme is equivalent to the solution of
   //
   // F(X) = X - (x + sum_j (nu_j * (P(a(x)*dt) - a(x)*dt)]) - dt*sum_j nu_j a_j(X)
@@ -877,8 +805,6 @@ KMCSolver<R, State, T>::advanceTau(State&                   a_state,
                                    const Real&              a_dt,
                                    const KMCLeapPropagator& a_leapPropagator) const noexcept
 {
-  CH_TIME("KMCSolver::advanceTau(State, ReactionList, Real, KMCLeapPropagator)");
-
   this->advanceTau(a_state, m_reactions, a_dt, a_leapPropagator);
 }
 
@@ -889,8 +815,6 @@ KMCSolver<R, State, T>::advanceTau(State&                   a_state,
                                    const Real&              a_dt,
                                    const KMCLeapPropagator& a_leapPropagator) const noexcept
 {
-  CH_TIME("KMCSolver::advanceTau(State, ReactionList, Real, KMCLeapPropagator)");
-
   if (a_reactions.size() > 0) {
     Real curTime = 0.0;
     Real curDt   = a_dt;
@@ -956,8 +880,6 @@ KMCSolver<R, State, T>::advanceHybrid(State&                   a_state,
                                       const Real               a_dt,
                                       const KMCLeapPropagator& a_leapPropagator) const noexcept
 {
-  CH_TIME("KMCSolver::advanceHybrid(State, Real, KMCLeapPropagator)");
-
   this->advanceHybrid(a_state, m_reactions, a_dt, a_leapPropagator);
 }
 
@@ -968,8 +890,6 @@ KMCSolver<R, State, T>::advanceHybrid(State&                   a_state,
                                       const Real               a_dt,
                                       const KMCLeapPropagator& a_leapPropagator) const noexcept
 {
-  CH_TIME("KMCSolver::advanceHybrid(State, ReactionList, Real, KMCLeapPropagator)");
-
   switch (a_leapPropagator) {
   case KMCLeapPropagator::ExplicitEuler: {
     this->advanceHybrid(a_state, a_reactions, a_dt, [this](State& s, const ReactionList& r, const Real dt) {
@@ -1013,8 +933,6 @@ KMCSolver<R, State, T>::advanceHybrid(
   const Real                                                                           a_dt,
   const std::function<void(State&, const ReactionList& a_reactions, const Real a_dt)>& a_propagator) const noexcept
 {
-  CH_TIME("KMCSolver::advanceHybrid(State, ReactionList, Real, std::function)");
-
   constexpr T one = (T)1;
 
   // Simulated time within the advancement algorithm.

--- a/Source/Particle/CD_ParticleSoA.H
+++ b/Source/Particle/CD_ParticleSoA.H
@@ -856,6 +856,9 @@ public:
     std::swap(m_sorted, a_other.m_sorted);
     std::swap(m_colPtrs, a_other.m_colPtrs);
     m_cellStart.swap(a_other.m_cellStart);
+    std::swap(m_sortBox, a_other.m_sortBox);
+    std::swap(m_sortDx, a_other.m_sortDx);
+    std::swap(m_sortProbLo, a_other.m_sortProbLo);
   }
 
   ///@}
@@ -1117,12 +1120,18 @@ public:
 
   /**
    * @brief Raw position component column dir (double*, for SIMD kernels).
+   * @details Handing out a writable position column invalidates the cell sort: the caller may move
+   * particles across cell boundaries, and the container cannot observe that. The sort flag is therefore
+   * cleared here rather than on the (unobservable) write, which is what lets sortByCell() trust the flag
+   * and skip a re-sort. Use the const overload for read-only kernels to keep the sort.
    * @param[in] a_dir Spatial direction in [0, SpaceDim).
    * @return Base pointer of the position component column for direction a_dir.
    */
   double*
   positionColumn(const int a_dir) noexcept
   {
+    m_sorted = false;
+
     return reinterpret_cast<double*>(m_colPtrs[a_dir]);
   }
 
@@ -1183,6 +1192,7 @@ public:
 
   /**
    * @brief Set the position of particle i.
+   * @details Invalidates the cell sort -- the new position may lie in a different cell.
    * @param[in] a_index    Particle index.
    * @param[in] a_position New position.
    */
@@ -1191,6 +1201,7 @@ public:
   {
     CH_assert(a_index < m_size);
 
+    // Writes through the non-const positionColumn(), which clears m_sorted.
     for (int dir = 0; dir < SpaceDim; dir++) {
       this->positionColumn(dir)[a_index] = a_position[dir];
     }
@@ -1432,6 +1443,15 @@ public:
    * @brief Counting-sort the columns into Fortran cell order and build CSR cell offsets.
    * @details After this, cell c owns the contiguous particle range [cellStart(c), cellStart(c+1)).
    * Particles must lie within a_box; out-of-range positions are clamped to the boundary cells.
+   *
+   * This is idempotent: a container already sorted against the same (box, dx, probLo) returns
+   * immediately, because the sort it would produce is the one it already has. Callers that establish
+   * the sort defensively therefore cost nothing when an earlier caller already did it, which is the
+   * common case -- the ItoKMC reaction path sorts the same leaves at three separate call sites. Any
+   * operation that can move a particle between cells (append, remove, resize, setPosition, or handing
+   * out a writable positionColumn()) clears the flag, so the early-out only fires when the CSR mapping
+   * is still the one this container computed. In debug builds the mapping is re-verified on every
+   * early-out; see checkCellSort().
    * @param[in] a_box    Patch box defining the cells.
    * @param[in] a_dx     Grid spacing per direction.
    * @param[in] a_probLo Physical coordinate of the lower domain corner.
@@ -1447,6 +1467,21 @@ public:
   isSorted() const noexcept
   {
     return m_sorted;
+  }
+
+  /**
+   * @brief Whether the container is cell-sorted against exactly this cell domain.
+   * @details isSorted() only says that some CSR mapping is valid; this says it is the mapping the
+   * caller is about to index with. sortByCell() early-outs on precisely this condition.
+   * @param[in] a_box    Patch box defining the cells.
+   * @param[in] a_dx     Grid spacing per direction.
+   * @param[in] a_probLo Physical coordinate of the lower domain corner.
+   * @return True iff the container is sorted against (a_box, a_dx, a_probLo).
+   */
+  bool
+  isSortedAgainst(const Box& a_box, const RealVect& a_dx, const RealVect& a_probLo) const noexcept
+  {
+    return m_sorted && m_sortBox == a_box && m_sortDx == a_dx && m_sortProbLo == a_probLo;
   }
 
   /**
@@ -1561,6 +1596,94 @@ protected:
   std::vector<std::size_t> m_cellStart;
 
   /**
+   * @brief Patch box the CSR mapping in m_cellStart was built against (meaningful only when m_sorted).
+   */
+  Box m_sortBox;
+
+  /**
+   * @brief Grid spacing the CSR mapping was built against (meaningful only when m_sorted).
+   */
+  RealVect m_sortDx = RealVect::Zero;
+
+  /**
+   * @brief Lower domain corner the CSR mapping was built against (meaningful only when m_sorted).
+   */
+  RealVect m_sortProbLo = RealVect::Zero;
+
+  /**
+   * @brief Compute the Fortran (x-fastest) cell index of particle i within the sort domain.
+   * @details Shared by sortByCell() and its debug-mode verifier so the two can never disagree about
+   * the mapping. Positions outside the box are clamped to the boundary cells.
+   * @param[in] a_index   Particle index.
+   * @param[in] a_box     Patch box defining the cells.
+   * @param[in] a_dx      Grid spacing per direction.
+   * @param[in] a_probLo  Physical coordinate of the lower domain corner.
+   * @return Linearized cell index in [0, a_box.numPts()).
+   */
+  std::size_t
+  cellKey(const std::size_t a_index, const Box& a_box, const RealVect& a_dx, const RealVect& a_probLo) const noexcept
+  {
+    const IntVect  loEnd   = a_box.smallEnd();
+    const IntVect  boxSize = a_box.size();
+    const RealVect x       = this->position(a_index);
+
+    std::size_t lin    = 0;
+    std::size_t stride = 1;
+    for (int d = 0; d < SpaceDim; d++) {
+      int c = static_cast<int>(std::floor((x[d] - a_probLo[d]) / a_dx[d])) - loEnd[d];
+      if (c < 0) {
+        c = 0;
+      }
+      if (c >= boxSize[d]) {
+        c = boxSize[d] - 1;
+      }
+      lin += static_cast<std::size_t>(c) * stride;
+      stride *= static_cast<std::size_t>(boxSize[d]);
+    }
+
+    return lin;
+  }
+
+  /**
+   * @brief Verify that the CSR mapping really does describe the current particle positions.
+   * @details The sort flag is only as good as the invalidation of every mutating path, so sortByCell()
+   * asserts on this whenever it takes its early-out: it recomputes each particle's cell key and checks
+   * that the particle sits in that cell's CSR range. O(N), and compiled out with the assertion in
+   * optimized builds. A failure here means some path moved particles without clearing m_sorted.
+   * @param[in] a_box    Patch box defining the cells.
+   * @param[in] a_dx     Grid spacing per direction.
+   * @param[in] a_probLo Physical coordinate of the lower domain corner.
+   * @return True iff the CSR mapping is consistent with the current positions.
+   */
+  bool
+  checkCellSort(const Box& a_box, const RealVect& a_dx, const RealVect& a_probLo) const noexcept
+  {
+    if (!m_sorted) {
+      return false;
+    }
+    if (m_cellStart.size() != static_cast<std::size_t>(a_box.numPts()) + 1) {
+      return false;
+    }
+    if (m_cellStart.back() != m_size) {
+      return false;
+    }
+
+    for (std::size_t c = 0; c < this->numCells(); c++) {
+      if (m_cellStart[c] > m_cellStart[c + 1]) {
+        return false;
+      }
+
+      for (std::size_t i = m_cellStart[c]; i < m_cellStart[c + 1]; i++) {
+        if (this->cellKey(i, a_box, a_dx, a_probLo) != c) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /**
    * @brief Round a_x up to the next multiple of s_align.
    * @param[in] a_x Value to round up.
    * @return a_x rounded up to a multiple of s_align.
@@ -1582,6 +1705,9 @@ protected:
     m_capacity     = a_o.m_capacity;
     m_size         = a_o.m_size;
     m_sorted       = a_o.m_sorted;
+    m_sortBox      = a_o.m_sortBox;
+    m_sortDx       = a_o.m_sortDx;
+    m_sortProbLo   = a_o.m_sortProbLo;
     m_colPtrs      = a_o.m_colPtrs;
     m_cellStart    = std::move(a_o.m_cellStart);
     a_o.m_buffer   = nullptr;

--- a/Source/Particle/CD_ParticleSoAImplem.H
+++ b/Source/Particle/CD_ParticleSoAImplem.H
@@ -29,17 +29,23 @@ inline void
 ParticleSoA<P, Traits>::reallocate(const std::size_t a_capacity)
 {
   std::array<std::size_t, s_numColumns> off{};
-  const std::size_t total  = this->computeOffsets(a_capacity, off, std::make_index_sequence<s_numColumns>{});
-  void* const       newBuf = std::aligned_alloc(s_align, alignUp(total));
+  const std::size_t total = this->computeOffsets(a_capacity, off, std::make_index_sequence<s_numColumns>{});
+
+  void* const newBuf = std::aligned_alloc(s_align, alignUp(total));
+
   if (newBuf == nullptr) {
     MayDay::Abort("ParticleSoA::reallocate - std::aligned_alloc returned null (out of memory)");
   }
+
   if (m_size > 0) {
     this->moveColumns(newBuf, off, std::make_index_sequence<s_numColumns>{});
   }
+
   std::free(m_buffer);
+
   m_buffer   = newBuf;
   m_capacity = a_capacity;
+
   this->setColPtrs(off, std::make_index_sequence<s_numColumns>{});
 }
 
@@ -48,14 +54,20 @@ inline void
 ParticleSoA<P, Traits>::permute(const std::vector<std::size_t>& a_dest)
 {
   std::array<std::size_t, s_numColumns> off{};
-  const std::size_t total  = this->computeOffsets(m_capacity, off, std::make_index_sequence<s_numColumns>{});
-  void* const       newBuf = std::aligned_alloc(s_align, alignUp(total));
+  const std::size_t total = this->computeOffsets(m_capacity, off, std::make_index_sequence<s_numColumns>{});
+
+  void* const newBuf = std::aligned_alloc(s_align, alignUp(total));
+
   if (newBuf == nullptr) {
     MayDay::Abort("ParticleSoA::permute - std::aligned_alloc returned null (out of memory)");
   }
+
   this->scatterColumns(newBuf, off, a_dest, std::make_index_sequence<s_numColumns>{});
+
   std::free(m_buffer);
+
   m_buffer = newBuf;
+
   this->setColPtrs(off, std::make_index_sequence<s_numColumns>{});
 }
 
@@ -66,6 +78,7 @@ ParticleSoA<P, Traits>::reserve(const std::size_t a_capacity)
   if (a_capacity <= m_capacity) {
     return;
   }
+
   this->reallocate(a_capacity);
 }
 
@@ -74,6 +87,7 @@ inline void
 ParticleSoA<P, Traits>::resize(const std::size_t a_count)
 {
   this->reserve(a_count);
+
   m_size   = a_count;
   m_sorted = false;
 }
@@ -84,15 +98,18 @@ ParticleSoA<P, Traits>::deepCopy() const
 {
   ParticleSoA<P, Traits> dst;
   dst.reserve(m_capacity); // identical arena layout: reallocate() sets the capacity exactly
+
   if (m_size > 0) {
     std::memcpy(dst.m_buffer, m_buffer, this->byteSpan()); // one contiguous copy of the live region
   }
+
   dst.m_size       = m_size;
   dst.m_sorted     = m_sorted;
   dst.m_cellStart  = m_cellStart;
   dst.m_sortBox    = m_sortBox;
   dst.m_sortDx     = m_sortDx;
   dst.m_sortProbLo = m_sortProbLo;
+
   return dst;
 }
 
@@ -106,9 +123,11 @@ ParticleSoA<P, Traits>::deepCopyTo(ParticleSoA<P, Traits>& a_dst) const
 
   a_dst.clear();         // drop a_dst's particles (keeps its arena) so the grow below moves nothing
   a_dst.reserve(m_size); // reuse a_dst's allocation if it is already large enough; grow only if not
+
   if (m_size > 0) {
     this->copyLiveColumnsTo(a_dst, std::make_index_sequence<s_numColumns>{});
   }
+
   a_dst.m_size       = m_size;
   a_dst.m_sorted     = m_sorted;
   a_dst.m_cellStart  = m_cellStart;
@@ -122,12 +141,16 @@ inline void
 ParticleSoA<P, Traits>::append(const ParticleSoA<P, Traits>& a_other)
 {
   const std::size_t n = a_other.m_size;
+
   if (n == 0) {
     return;
   }
+
   const std::size_t oldSize = m_size;
+
   this->growTo(oldSize + n); // may reallocate this (and a_other, when a_other == this); pointers refreshed below
   this->appendColumnsFrom(a_other, oldSize, std::make_index_sequence<s_numColumns>{});
+
   m_size   = oldSize + n;
   m_sorted = false;
 }
@@ -139,8 +162,10 @@ ParticleSoA<P, Traits>::appendParticle(const ParticleSoA<P, Traits>& a_src, cons
   CH_assert(a_index < a_src.m_size);
 
   const std::size_t at = m_size;
+
   this->growTo(m_size + 1); // may reallocate this (and a_src, when a_src == this); pointers refreshed below
   this->copyParticleColumns(a_src, a_index, at, std::make_index_sequence<s_numColumns>{});
+
   m_size   = at + 1;
   m_sorted = false;
 }
@@ -152,11 +177,15 @@ ParticleSoA<P, Traits>::shrinkToFit()
   if (m_capacity <= m_size) {
     return; // already compact
   }
+
   if (m_size == 0) {
     std::free(m_buffer);
+
     m_buffer   = nullptr;
     m_capacity = 0;
+
     m_colPtrs.fill(nullptr);
+
     return;
   }
   this->reallocate(m_size);
@@ -167,15 +196,19 @@ inline void
 ParticleSoA<P, Traits>::append(const RealVect& a_position, const double a_weight, const P& a_payload)
 {
   this->growIfFull();
+
   for (int dir = 0; dir < SpaceDim; dir++) {
     this->positionColumn(dir)[m_size] = a_position[dir]; // write the reserved slot directly (m_size not yet bumped)
   }
+
   this->template columnByIndex<s_weightCol>()[m_size] = a_weight;
   this->template columnByIndex<s_idCol>()[m_size]     = s_invalidID;
   this->template columnByIndex<s_rankCol>()[m_size]   = static_cast<RankID>(-1);
   this->template columnByIndex<s_ghostCol>()[m_size]  = GhostType::Valid;
   this->writePayload(a_payload, std::make_index_sequence<s_numPayloadColumns>{});
+
   m_size++;
+
   m_sorted = false;
 }
 
@@ -186,6 +219,7 @@ ParticleSoA<P, Traits>::linearizeParticle(void* a_buffer, const std::size_t a_in
   CH_assert(a_index < m_size);
 
   auto* p = static_cast<unsigned char*>(a_buffer);
+
   this->linearizeImpl(p, a_index, std::make_index_sequence<s_numColumns>{});
 }
 
@@ -194,9 +228,13 @@ inline void
 ParticleSoA<P, Traits>::delinearizeAndAppend(const void* a_buffer)
 {
   this->growIfFull();
+
   const auto* p = static_cast<const unsigned char*>(a_buffer);
+
   this->delinearizeImpl(p, std::make_index_sequence<s_numColumns>{});
+
   m_size++;
+
   m_sorted = false;
 }
 
@@ -207,10 +245,13 @@ ParticleSoA<P, Traits>::h5LinearizeParticle(void* a_buffer, const std::size_t a_
   CH_assert(a_index < m_size);
 
   auto* p = static_cast<unsigned char*>(a_buffer);
+
   for (int dir = 0; dir < SpaceDim; dir++) {
     detail::pushBytes(p, this->positionColumn(dir)[a_index]);
   }
+
   detail::pushBytes(p, this->template columnByIndex<s_weightCol>()[a_index]);
+
   this->h5LinearizePayload(p, a_index, H5PayloadColumns{});
 }
 
@@ -219,17 +260,22 @@ inline void
 ParticleSoA<P, Traits>::h5DelinearizeAndAppend(const void* a_buffer)
 {
   this->growIfFull();
+
   const auto* p = static_cast<const unsigned char*>(a_buffer);
+
   for (int dir = 0; dir < SpaceDim; dir++) {
     detail::pullBytes(p, this->positionColumn(dir)[m_size]);
   }
+
   detail::pullBytes(p, this->template columnByIndex<s_weightCol>()[m_size]);
+
   this->template columnByIndex<s_idCol>()[m_size]    = s_invalidID;
   this->template columnByIndex<s_rankCol>()[m_size]  = static_cast<RankID>(-1);
   this->template columnByIndex<s_ghostCol>()[m_size] = GhostType::Valid;
 
   // Non-checkpointed payload columns default-construct; then overwrite the checkpointed subset.
   const P def{};
+
   this->writePayload(def, std::make_index_sequence<s_numPayloadColumns>{});
   this->h5DelinearizePayload(p, H5PayloadColumns{});
 
@@ -282,9 +328,11 @@ ParticleSoA<P, Traits>::sortByCell(const Box& a_box, const RealVect& a_dx, const
   // Pass 2: stable destination slot per particle, then physically reorder all columns.
   std::vector<std::size_t> cursor(m_cellStart.begin(), m_cellStart.begin() + nCells);
   std::vector<std::size_t> dest(m_size);
+
   for (std::size_t i = 0; i < m_size; i++) {
     dest[i] = cursor[key[i]]++;
   }
+
   this->permute(dest);
 
   m_sorted = true;

--- a/Source/Particle/CD_ParticleSoAImplem.H
+++ b/Source/Particle/CD_ParticleSoAImplem.H
@@ -87,9 +87,12 @@ ParticleSoA<P, Traits>::deepCopy() const
   if (m_size > 0) {
     std::memcpy(dst.m_buffer, m_buffer, this->byteSpan()); // one contiguous copy of the live region
   }
-  dst.m_size      = m_size;
-  dst.m_sorted    = m_sorted;
-  dst.m_cellStart = m_cellStart;
+  dst.m_size       = m_size;
+  dst.m_sorted     = m_sorted;
+  dst.m_cellStart  = m_cellStart;
+  dst.m_sortBox    = m_sortBox;
+  dst.m_sortDx     = m_sortDx;
+  dst.m_sortProbLo = m_sortProbLo;
   return dst;
 }
 
@@ -106,9 +109,12 @@ ParticleSoA<P, Traits>::deepCopyTo(ParticleSoA<P, Traits>& a_dst) const
   if (m_size > 0) {
     this->copyLiveColumnsTo(a_dst, std::make_index_sequence<s_numColumns>{});
   }
-  a_dst.m_size      = m_size;
-  a_dst.m_sorted    = m_sorted;
-  a_dst.m_cellStart = m_cellStart;
+  a_dst.m_size       = m_size;
+  a_dst.m_sorted     = m_sorted;
+  a_dst.m_cellStart  = m_cellStart;
+  a_dst.m_sortBox    = m_sortBox;
+  a_dst.m_sortDx     = m_sortDx;
+  a_dst.m_sortProbLo = m_sortProbLo;
 }
 
 template <typename P, typename Traits>
@@ -237,9 +243,21 @@ ParticleSoA<P, Traits>::sortByCell(const Box& a_box, const RealVect& a_dx, const
 {
   // No CH_TIME here: this leaf container is the per-particle hot path; timing of bulk
   // operations like this one is done by the container/mesh drivers above.
-  const std::size_t nCells  = a_box.numPts();
-  const IntVect     loEnd   = a_box.smallEnd();
-  const IntVect     boxSize = a_box.size();
+
+  // Already sorted against exactly this cell domain -- the sort below would reproduce the CSR mapping
+  // the container already holds. Callers establish this precondition defensively at several call sites
+  // (see sortByCell's documentation), so this is the common path, not a rare one.
+  if (this->isSortedAgainst(a_box, a_dx, a_probLo)) {
+    CH_assert(this->checkCellSort(a_box, a_dx, a_probLo));
+
+    return;
+  }
+
+  const std::size_t nCells = a_box.numPts();
+
+  m_sortBox    = a_box;
+  m_sortDx     = a_dx;
+  m_sortProbLo = a_probLo;
 
   m_cellStart.assign(nCells + 1, 0);
   if (m_size == 0) {
@@ -250,20 +268,8 @@ ParticleSoA<P, Traits>::sortByCell(const Box& a_box, const RealVect& a_dx, const
   // Pass 1: compute each particle's Fortran cell key and tally per-cell counts.
   std::vector<std::size_t> key(m_size);
   for (std::size_t i = 0; i < m_size; i++) {
-    const RealVect x      = this->position(i);
-    std::size_t    lin    = 0;
-    std::size_t    stride = 1;
-    for (int d = 0; d < SpaceDim; d++) {
-      int c = static_cast<int>(std::floor((x[d] - a_probLo[d]) / a_dx[d])) - loEnd[d];
-      if (c < 0) {
-        c = 0;
-      }
-      if (c >= boxSize[d]) {
-        c = boxSize[d] - 1;
-      }
-      lin += static_cast<std::size_t>(c) * stride;
-      stride *= static_cast<std::size_t>(boxSize[d]);
-    }
+    const std::size_t lin = this->cellKey(i, a_box, a_dx, a_probLo);
+
     key[i] = lin;
     m_cellStart[lin + 1]++;
   }


### PR DESCRIPTION
# Summary

Removes three sources of avoidable per-cell overhead from `ItoKMCGodunovStepper`'s `advanceReactionNetwork` call: Chombo timers on per-cell and per-reaction functions, redundant cell-sorts and per-cell particle copies, and a copied reaction partition. Static analysis only drove the changes; no algorithm or result changes.

### Background

Profiling `advanceReactionNetwork` statically turned up several costs that are per grid cell, and in places per reaction within a cell.

**Timers on per-cell functions.** All 63 timer sites in `Source/KineticMonteCarlo` sit on functions that are only ever entered per cell — including `KMCSolver::propensities`/`computeDt` and `KMCDualStateReaction::propensity`/`computeCriticalNumberOfReactions`/`getStateChange`, which run once per reaction per cell. With the 8–23 reactions in the shipped chemistries that is on the order of 2000 `CH_TIME` sites entered per grid cell. The same applies to `ItoKMCPhysics::advanceKMC` and the `ItoKMCJSON` per-cell hooks.

These are not compiled out by an optimized build. `CH_TIME` is disabled by `CH_NTIMER`, which the build system emits from exactly one place — `$(subst FALSE,-DCH_NTIMER,$(subst TRUE,,$(USE_TIMER)))` in `Make.rules:277` — so it follows `USE_TIMER` (default `TRUE`, and never overridden in `Lib/Local/` or the Betzy/Fram configs) and is independent of `DEBUG`/`OPT`/`NDEBUG`. A `DEBUG=FALSE OPT=HIGH` build gets `-DNDEBUG` but no `-DCH_NTIMER`.

At runtime, with `CH_TIMER` absent from the environment, `TraceTimer::initializer()` prunes the root timer, so each site returns early. It is *not* free, though: the pruning is a runtime early-out, so every site still costs three out-of-line `TraceTimer` calls (`getTimer`, `start`, `stop`) plus several `omp_get_thread_num()` calls under OpenMP, none of which an optimized build can inline away. That is irrelevant at ordinary call sites — which is why this PR leaves timers alone everywhere else — and is not irrelevant at ~2000 sites per cell.

The residual cost is also asymmetric: the macro only does its work when `omp_get_thread_num() == 0`, so thread 0 carries it alone while the rest of the team waits at the enclosing `omp for` barrier. And with `CH_TIMER=1` — exactly when one is profiling this code — the per-cell sites go fully live and distort the loop being measured, while giving nothing actionable at per-cell granularity.

**Repeated cell-sorting.** The reaction path cell-sorted the same Ito bulk leaves at three separate call sites per step: `ItoKMCGodunovStepper::advance` before the reaction network, `computeReactiveItoParticlesPerCell`, and `reconcileParticles` via `binLeafToCells`. Nothing between them mutates those leaves — the KMC integration works on mesh data (`m_fluidPPC`/`m_fluidYPC`) — so the second and third reproduced a CSR mapping the container already held. Each is a counting sort plus `permute()`, which `aligned_alloc()`s a fresh arena and scatters every column across it (15 columns per `ItoParticle` in 2D, 19 in 3D).

The precondition was in fact already satisfied at every call site in the repo — both callers of `computeReactiveItoParticlesPerCell` sort immediately beforehand. It simply was not expressible, so each helper re-established it defensively.

**Per-cell copies that bought nothing.** `computeReactiveItoParticlesPerCell` and `computeReactiveMeanEnergiesPerCell` went through `binLeafToCells`, copying every particle into per-cell scratch containers, then only accumulated weights and energies out of them.

**A copied partition.** `KMCSolver::partitionReactions` returned its two lists through `std::make_pair` on lvalues, duplicating both allocations and bumping the refcount of every reaction twice more, once per substep per cell.

### Solution

Three commits.

1. **Timers.** Every timer removed from `Source/KineticMonteCarlo` and from the ItoKMC functions that run per cell (`advanceKMC`, `reconcileParticles`, `reconcilePhotons`, `reconcilePhotoionization`, `computeUpstreamPosition`, `removeParticles`, and the `ItoKMCJSON` rate/coefficient hooks). Stepper-level timers are untouched, so the `compute_ppc` / `integrate_network` / `copies` / `reconcile_particles` / `reconcile_cdr` split reports as before. `CH_Timer.H` includes are replaced with the headers actually used. Also moves rather than copies in `partitionReactions`.

2. **Read in place.** The two per-cell-count kernels index the leaf's CSR ranges via `cellRange(c)` instead of extracting copies. `binLeafToCells` stays for `reconcileParticles` and the secondary-emission path, which need mutable per-cell containers to hand to the physics interface.

3. **Idempotent sort.** `ParticleSoA` records the `(box, dx, probLo)` its CSR mapping was built against and `sortByCell` returns early when asked for the same domain, exposed as `isSortedAgainst()`. This collapses the chain to **one** real sort per step for the whole-patch mergers (`kd_patch`, `kd_carve`, `kd_skin_nn`, `nn_pair_*`), and to two for the per-cell mergers, which sort again inside `applyCellMerger` after `reconcileParticles` has rebuilt the leaves.

An early-out is only as sound as the invalidation of every mutating path, and two paths moved particles without clearing `m_sorted`: `setPosition`, and the non-const `positionColumn()`, whose raw `double*` the transport kernels write through. That was harmless while `sortByCell` was unconditional but would have become a silent wrong-answer bug here, so the flag is now cleared when the writable column pointer is handed out — the write itself is not observable to the container, the handout is. Read-only kernels keep the sort by taking the existing const overload.

To keep the invariant checkable rather than merely asserted, `sortByCell` verifies the mapping against the current positions on every early-out via `checkCellSort()`, which recomputes each particle's cell key and confirms it lies in that cell's range. It shares `cellKey()` with the sort itself so the two cannot disagree, is O(N), and compiles out with the assertion in optimized builds.

### Side-effects

- **No new types.** The change adds three data members to `ParticleSoA` (`m_sortBox`, `m_sortDx`, `m_sortProbLo`) and two member functions (`isSortedAgainst`, public, 1 use in `sortByCell` plus external callers; `checkCellSort`, protected, 1 use). No new class, struct, or container.
- **`positionColumn()`'s non-const overload now has a side effect** — it clears the sort flag. Callers that only read through it (e.g. `ItoKMCGodunovStepperImplem.H:829`, which copies position into `old_x`) now drop the sort unnecessarily. That site runs during transport, before the sort, so it costs nothing today, but the pattern is worth a later sweep toward the const overload.
- `checkCellSort` makes DEBUG builds do O(N) verification work per skipped sort. Compiled out in optimized builds.
- `Particles.rst`'s `extractCell` literalinclude range updated for the shifted line numbers; `sphinx -W --keep-going` is clean.

### Alternative solutions

- **A bare `if (isSorted()) return;` guard** would have been the same speedup for far less code, but `m_sorted` records only *that* some mapping is valid, not *which* domain it was built against. That makes the invariant less checkable than it is today, and would silently misbehave the first time a leaf is sorted against a different box.
- **Making `rebuildLeafFromCells` mark the rebuilt leaf sorted** would remove the last sort for the per-cell mergers. `reconcileParticles` concatenates its per-cell scratch in `Box::index` order, so the output is already physically CSR-ordered, and the offsets are a running sum in a loop that already runs — nearly free. Rejected for now: it buys **zero** for `kd_patch` and the other whole-patch mergers (which never sort the bulk leaf — only the per-cell family routes through `applyCellMerger`), applies only on `merge_interval` steps, and promotes three undocumented facts to load-bearing invariants (photoionization products inherit the absorbed photon's position; those photons were binned to the same cell; `cellKey` clamps identically in the sort and the verifier). `ItoKMCStepper::reconcilePhotoionization()` appends products to the leaf tail and would violate it outright — it is currently dead code, but it is a loaded gun next to the invariant.
- **Replacing `ReactionList`'s `std::shared_ptr` with a non-owning pointer** would remove the remaining 2R atomic refcount operations per substep per cell. Rejected: the refcounts are per-thread and uncontended, so this is roughly 1–5% of what the per-cell KMC work costs, and it would break the `updateReactionRates` signature — a public extension point that `ItoKMCJSON` overrides.

### Not addressed here

The dominant per-cell cost found during this analysis is untouched and is 1–2 orders of magnitude larger than anything in this PR: the time-step-limiting tail of `ItoKMCPhysics::advanceKMC` is O(R²) heap allocations and O(R²·U) `std::map` lookups per cell, and runs unconditionally in cells with zero particles. Specifically — `auto S = m_kmcState` is copied above the `N < max` test that is its only consumer; `KMCSolver::computeDt` rebuilds a run-invariant reactant set (concatenating by-value `std::list`s, then sort + unique) on every call and looks up a fixed stoichiometry matrix through `std::map::find` + `at`; and `KMCDualStateReaction::propensity` copies the whole state vector because `auto` drops the reference from `const State&`. Worth a follow-up PR.

### Testing

- Compile-checked in 2D and 3D, DEBUG and OPT, across `ItoKMCJSON.cpp`, `ItoKMCPhysics.cpp`, both standalone KMC test drivers, and `Exec/Tests/ItoKMC/JSON`.
- `Exec/Tests/ItoKMC/JSON` regression run in a DEBUG build (assertions live, so `checkCellSort` verifies every early-out): 26 steps with regrids every 5, particle count 189 decaying to 1, clean exit, no assertion failures and no NaNs.
- `pre-commit run` clean on all changed files (clang-format, reuse, codespell, cppcheck, doxygen).
- `python3 -m sphinx -W --keep-going` clean.

### PR-review checklist

Mandatory:

- [x] I have run the test suite and made sure that it passed.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information.
- [x] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks.
- [ ] I have run clang-tidy and fixed all reported errors.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
