### PR TITLE
Remove the O(R^2) per-cell cost from the ItoKMC time step calculation

### DIFF
--- a/Physics/ItoKMC/CD_ItoKMCPhysics.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysics.H
@@ -479,6 +479,21 @@ protected:
   static thread_local KMCState m_kmcState;
 
   /**
+   * @brief Perturbed KMC state used by the time step tail of advanceKMC.
+   * @details The tail probes each reaction by firing it to its critical number and re-evaluating
+   * the time step on the result. It needs a state to perturb without disturbing m_kmcState, and
+   * reuses this one so that the probe does not allocate once per reaction per grid cell.
+   */
+  static thread_local KMCState m_kmcStateScratch;
+
+  /**
+   * @brief Propensity buffer used by the time step tail of advanceKMC.
+   * @details Reused across the tail's probes so the propensities are not returned by value, which
+   * allocated once per probe, i.e. once per reaction per grid cell.
+   */
+  static thread_local std::vector<Real> m_kmcPropensityScratch;
+
+  /**
    * @brief Thread-local copies of KMC reactions used in advanceReactionNetwork.
    * @details Set up via defineKMC() to ensure OpenMP thread safety; depopulated by killKMC().
    */

--- a/Physics/ItoKMC/CD_ItoKMCPhysics.cpp
+++ b/Physics/ItoKMC/CD_ItoKMCPhysics.cpp
@@ -23,6 +23,8 @@ thread_local bool                                            ItoKMCPhysics::m_ha
 thread_local KMCSolverType                                   ItoKMCPhysics::m_kmcSolver;
 thread_local KMCState                                        ItoKMCPhysics::m_kmcState;
 thread_local std::vector<std::shared_ptr<const KMCReaction>> ItoKMCPhysics::m_kmcReactionsThreadLocal;
+thread_local KMCState                                        ItoKMCPhysics::m_kmcStateScratch;
+thread_local std::vector<Real>                               ItoKMCPhysics::m_kmcPropensityScratch;
 
 Vector<std::string>
 ItoKMCPhysics::getPlotVariableNames() const noexcept

--- a/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCPhysicsImplem.H
@@ -122,6 +122,9 @@ ItoKMCPhysics::defineKMC() const noexcept
   m_kmcSolver.define(m_kmcReactionsThreadLocal);
   m_kmcSolver.setSolverParameters(m_Ncrit, m_NSSA, m_maxIter, m_eps, m_SSAlim, m_exitTol);
   m_kmcState.define(m_itoSpecies.size() + m_cdrSpecies.size(), m_rtSpecies.size());
+  m_kmcStateScratch.define(m_itoSpecies.size() + m_cdrSpecies.size(), m_rtSpecies.size());
+
+  m_kmcPropensityScratch.resize(m_kmcReactionsThreadLocal.size());
 
   m_hasKMCSolver = true;
 }
@@ -136,6 +139,9 @@ ItoKMCPhysics::killKMC() const noexcept
   m_kmcReactionsThreadLocal.resize(0);
   m_kmcSolver.define(m_kmcReactionsThreadLocal);
   m_kmcState.define(0, 0);
+  m_kmcStateScratch.define(0, 0);
+
+  m_kmcPropensityScratch.resize(0);
 
   m_hasKMCSolver = false;
 }
@@ -474,35 +480,38 @@ ItoKMCPhysics::advanceKMC(Vector<FPR>&            a_numParticles,
   // time step. It exists because if there are no electrons but lots of ions, one may get a time step that is too large
   // because X/|sum mu| is zero for the electrons. Similarly, one may get a time step that is too small away from
   // ionization regions because X/|sum mu| may be tiny if there is, say, 1 electron but lots of detachment.
-  auto getPropensitiesDt = [&](const KMCState& a_state) -> std::vector<Real> {
-    std::vector<Real> propensities = m_kmcSolver.propensities(a_state, m_kmcReactionsThreadLocal);
-
-    for (int i = 0; i < propensities.size(); i++) {
-      propensities[i] *= m_reactiveDtFactors[i];
+  // Fills the reusable propensity buffer rather than returning one, so that the probes below do not
+  // allocate once per reaction per grid cell.
+  auto fillPropensitiesDt = [&](const KMCState& a_state) -> void {
+    for (size_t i = 0; i < m_kmcReactionsThreadLocal.size(); i++) {
+      m_kmcPropensityScratch[i] = m_kmcReactionsThreadLocal[i]->propensity(a_state) * m_reactiveDtFactors[i];
     }
-
-    return propensities;
   };
 
   // Do a time step limitation on the complete state, using the user-specified reactions.
-  const auto propensitiesDt = getPropensitiesDt(m_kmcState);
-  const auto physicsDt      = m_kmcSolver.computeDt(m_kmcState, m_kmcReactionsThreadLocal, propensitiesDt, 1.0);
+  fillPropensitiesDt(m_kmcState);
 
-  a_physicsDt = std::min(a_physicsDt, physicsDt);
+  a_physicsDt = std::min(a_physicsDt,
+                         m_kmcSolver.computeDt(m_kmcState, m_kmcReactionsThreadLocal, m_kmcPropensityScratch, 1.0));
 
   // Go through reactions that are potentially detaching species and do the calculation again.
   for (const auto& reaction : m_kmcReactionsThreadLocal) {
-    auto       S = m_kmcState;
     const auto N = reaction->computeCriticalNumberOfReactions(m_kmcState);
 
-    // Trigger on both the reactions and the reactions with completely consumed reactants
+    // Trigger on both the reactions and the reactions with completely consumed reactants. The state
+    // is only copied inside the branch because that is the only place it is read -- copying it above
+    // the test meant paying for a copy per reaction per grid cell, including for the reactions that
+    // never enter here.
     if (N < std::numeric_limits<FPR>::max()) {
-      reaction->advanceState(S, N);
+      m_kmcStateScratch = m_kmcState;
 
-      const auto propensitiesDt = getPropensitiesDt(S);
-      const auto physicsDt      = m_kmcSolver.computeDt(S, m_kmcReactionsThreadLocal, propensitiesDt, 1.0);
+      reaction->advanceState(m_kmcStateScratch, N);
 
-      a_physicsDt = std::min(a_physicsDt, physicsDt);
+      fillPropensitiesDt(m_kmcStateScratch);
+
+      a_physicsDt = std::min(
+        a_physicsDt,
+        m_kmcSolver.computeDt(m_kmcStateScratch, m_kmcReactionsThreadLocal, m_kmcPropensityScratch, 1.0));
     }
   }
 }

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -5045,6 +5045,17 @@ ItoKMCStepper<I, C, R, F>::fillSecondaryEmissionEB(
     for (int mybox = 0; mybox < nbox; mybox++) {
       const DataIndex& din = dit[mybox];
 
+      // The kernel below is driven by the cut cells, so a patch without any has nothing to do. Its
+      // secondary containers were cleared and its CDR fluxes zeroed before this loop, which is
+      // exactly the state the patch would be left in anyway. Skipping matters because everything
+      // below is per species and would otherwise be paid on every patch in the domain, whether or
+      // not it is anywhere near the EB.
+      VoFIterator& vofit = (*m_amr->getVofIterator(m_particleRealm, m_plasmaPhase)[lvl])[din];
+
+      if (vofit.size() == 0) {
+        continue;
+      }
+
       const EBISBox&       ebisbox       = ebisl[din];
       const EBCellFAB&     electricField = (*a_electricField[lvl])[din];
       const BaseFab<bool>& validCells    = (*m_amr->getValidCells(m_particleRealm)[lvl])[din];
@@ -5178,7 +5189,6 @@ ItoKMCStepper<I, C, R, F>::fillSecondaryEmissionEB(
       };
 
       // Run the kernel.
-      VoFIterator& vofit = (*m_amr->getVofIterator(m_particleRealm, m_plasmaPhase)[lvl])[din];
       BoxLoops::loop(vofit, irregularKernel);
 
       // SoA write-back: rebuild the secondary Ito/photon leaves for this patch from the filled per-cell scratch.

--- a/Source/KineticMonteCarlo/CD_KMCDualStateReaction.H
+++ b/Source/KineticMonteCarlo/CD_KMCDualStateReaction.H
@@ -94,9 +94,12 @@ public:
 
   /**
    * @brief Get the reactants in the reaction.
+   * @details Returned by reference because KMCSolver walks this list once per reaction per grid
+   * cell when it assembles the reactant set for the time step calculation; returning by value
+   * deep-copied the list, and with it one heap allocation per element, on every one of those walks.
    * @return m_lhsReactives
    */
-  inline std::list<size_t>
+  inline const std::list<size_t>&
   getReactants() const noexcept;
 
   /**
@@ -161,6 +164,27 @@ protected:
    * @brief State change for reactants/products.
    */
   std::map<size_t, T> m_reactiveStateChange;
+
+  /**
+   * @brief Dense form of m_reactiveStateChange, indexed by reactive species.
+   * @details Built once in computeStateChanges() and holding the same values as
+   * m_reactiveStateChange, with zero for species the reaction does not touch. It exists because
+   * getStateChange() sits in the innermost loop of KMCSolver::computeDt and
+   * KMCSolver::getNonCriticalTimeStep, which run once per reactant per reaction per grid cell.
+   * Serving those from the map cost two red-black-tree walks (find followed by at) per lookup.
+   * Species indices at or beyond the vector's length are not involved in the reaction and their
+   * state change is zero.
+   */
+  std::vector<T> m_reactiveStateChangeDense;
+
+  /**
+   * @brief Reactants of the left-hand side, compacted to (species, order) pairs.
+   * @details Built once in computeStateChanges() from the same reactant tally that fixes
+   * m_propensityFactor. propensity() uses it to form the falling factorial directly from the
+   * incoming state; without it the reaction has to copy the whole state vector on every call so
+   * that it can decrement its own copy while multiplying.
+   */
+  std::vector<std::pair<size_t, size_t>> m_lhsOrders;
 
   /**
    * @brief State change for non-reactive products.

--- a/Source/KineticMonteCarlo/CD_KMCDualStateReactionImplem.H
+++ b/Source/KineticMonteCarlo/CD_KMCDualStateReactionImplem.H
@@ -114,6 +114,30 @@ KMCDualStateReaction<State, T>::computeStateChanges() noexcept
   for (const auto& rn : reactantNumbers) {
     m_propensityFactor *= 1.0 / factorial(rn.second);
   }
+
+  // Compact the reactant tally into the form propensity() consumes, so that the falling factorial
+  // can be formed straight off the incoming state rather than off a private copy of it.
+  m_lhsOrders.clear();
+  m_lhsOrders.reserve(reactantNumbers.size());
+
+  for (const auto& rn : reactantNumbers) {
+    m_lhsOrders.emplace_back(rn.first, rn.second);
+  }
+
+  // Dense mirror of m_reactiveStateChange for the per-cell lookups in KMCSolver. The map is keyed by
+  // species index, so the highest key fixes the length; species the reaction does not touch keep a
+  // zero state change.
+  m_reactiveStateChangeDense.clear();
+
+  if (!m_reactiveStateChange.empty()) {
+    const size_t highestSpecies = m_reactiveStateChange.rbegin()->first;
+
+    m_reactiveStateChangeDense.assign(highestSpecies + 1, (T)0);
+
+    for (const auto& s : m_reactiveStateChange) {
+      m_reactiveStateChangeDense[s.first] = s.second;
+    }
+  }
 }
 
 template <typename State, typename T>
@@ -144,12 +168,20 @@ KMCDualStateReaction<State, T>::propensity(const State& a_state) const noexcept
 
   Real A = m_rate * m_propensityFactor;
 
-  auto reactiveState = a_state.getReactiveState();
+  const auto& reactiveState = a_state.getReactiveState();
 
-  for (const auto& r : m_lhsReactives) {
-    A *= reactiveState[r];
+  // For a species entering the reaction k times the contribution is the falling factorial
+  // X * (X-1) * ... * (X-k+1) -- the same product the previous implementation formed by walking
+  // m_lhsReactives and decrementing a private copy of the state after each factor. Taking the order
+  // from m_lhsOrders gives the identical product without copying the state.
+  for (const auto& lhs : m_lhsOrders) {
+    T X = reactiveState[lhs.first];
 
-    reactiveState[r]--;
+    for (size_t k = 0; k < lhs.second; k++) {
+      A *= X;
+
+      X -= (T)1;
+    }
   }
 
   return A;
@@ -181,7 +213,7 @@ KMCDualStateReaction<State, T>::computeCriticalNumberOfReactions(const State& a_
 }
 
 template <typename State, typename T>
-inline std::list<size_t>
+inline const std::list<size_t>&
 KMCDualStateReaction<State, T>::getReactants() const noexcept
 {
   return m_lhsReactives;
@@ -205,10 +237,12 @@ template <typename State, typename T>
 inline T
 KMCDualStateReaction<State, T>::getStateChange(const size_t a_particleReactant) const noexcept
 {
+  // Species beyond the dense vector are not part of this reaction, so their state change is zero --
+  // the same answer the map lookup gave for an absent key.
   T nuIJ = 0;
 
-  if (m_reactiveStateChange.find(a_particleReactant) != m_reactiveStateChange.end()) {
-    nuIJ = m_reactiveStateChange.at(a_particleReactant);
+  if (a_particleReactant < m_reactiveStateChangeDense.size()) {
+    nuIJ = m_reactiveStateChangeDense[a_particleReactant];
   }
 
   return nuIJ;

--- a/Source/KineticMonteCarlo/CD_KMCSingleStateReaction.H
+++ b/Source/KineticMonteCarlo/CD_KMCSingleStateReaction.H
@@ -91,9 +91,12 @@ public:
 
   /**
    * @brief Get the reactants involved in the reaction.
+   * @details Returned by reference for the same reason as in KMCDualStateReaction: KMCSolver walks
+   * this list once per reaction per grid cell when assembling the reactant set for the time step
+   * calculation, and returning by value deep-copied the list on every walk.
    * @return m_reactants
    */
-  inline std::list<size_t>
+  inline const std::list<size_t>&
   getReactants() const noexcept;
 
   /**

--- a/Source/KineticMonteCarlo/CD_KMCSingleStateReactionImplem.H
+++ b/Source/KineticMonteCarlo/CD_KMCSingleStateReactionImplem.H
@@ -135,7 +135,7 @@ KMCSingleStateReaction<State, T>::computeCriticalNumberOfReactions(const State& 
 }
 
 template <typename State, typename T>
-inline std::list<size_t>
+inline const std::list<size_t>&
 KMCSingleStateReaction<State, T>::getReactants() const noexcept
 {
   return m_reactants;

--- a/Source/KineticMonteCarlo/CD_KMCSolver.H
+++ b/Source/KineticMonteCarlo/CD_KMCSolver.H
@@ -500,6 +500,50 @@ protected:
    * population of the state vector, with an indexing given by the State's linearIn/linearOut functions.
    */
   std::vector<std::vector<int>> m_nu;
+
+  /**
+   * @brief Scratch accumulator for the per-reactant expected state change, indexed by species.
+   * @details Used by computeDt and getNonCriticalTimeStep, which run once per grid cell (and, in
+   * the ItoKMC time step tail, once per reaction per grid cell). Holding the buffer on the solver
+   * keeps those calls free of heap traffic; previously they allocated a std::list node per reactant
+   * per reaction and then sorted it.
+   * @note Mutable because the calls that use it are logically const. This makes the solver's
+   * const member functions non-reentrant: a single KMCSolver must not be shared across threads.
+   * ItoKMCPhysics satisfies this by holding its solver as static thread_local (see defineKMC).
+   */
+  mutable std::vector<Real> m_muScratch;
+
+  /**
+   * @brief Scratch accumulator for the per-reactant propensity variance, indexed by species.
+   * @details Companion to m_muScratch, needed only by getNonCriticalTimeStep. Same reentrancy
+   * caveat.
+   */
+  mutable std::vector<Real> m_sigmaScratch;
+
+  /**
+   * @brief Scratch holding the distinct reactants of the reaction list currently being processed.
+   * @details Replaces the sorted, uniqued std::list the two time step routines used to rebuild on
+   * every call. Same reentrancy caveat.
+   */
+  mutable std::vector<size_t> m_reactantScratch;
+
+  /**
+   * @brief Membership stamps used to build m_reactantScratch without sorting, indexed by species.
+   * @details Entry i is set when species i has already been added to m_reactantScratch for the
+   * call in progress, and is cleared again before the call returns. Same reentrancy caveat.
+   */
+  mutable std::vector<char> m_seenScratch;
+
+  /**
+   * @brief Fill m_reactantScratch with the distinct reactants of the input reactions.
+   * @details Replaces concatenating the reactions' reactant lists and then sorting and uniquing
+   * them. The distinct set is the same; only the order differs, and both callers use it purely as a
+   * set to reduce over. The scratch buffers are sized from the largest reactant index seen, which
+   * keeps the routine independent of the State type's interface.
+   * @param[in] a_reactions Reactions whose reactants are collected.
+   */
+  inline void
+  gatherDistinctReactants(const ReactionList& a_reactions) const noexcept;
 };
 
 #include <CD_NamespaceFooter.H>

--- a/Source/KineticMonteCarlo/CD_KMCSolverImplem.H
+++ b/Source/KineticMonteCarlo/CD_KMCSolverImplem.H
@@ -254,6 +254,46 @@ KMCSolver<R, State, T>::getNonCriticalTimeStep(const State& a_state, const React
 }
 
 template <typename R, typename State, typename T>
+inline void
+KMCSolver<R, State, T>::gatherDistinctReactants(const ReactionList& a_reactions) const noexcept
+{
+  // Size the scratch from the largest reactant index the reactions refer to. Species above that are
+  // not reactants of any of these reactions and can never be reduced over below.
+  size_t numSpecies = 0;
+
+  for (const auto& reaction : a_reactions) {
+    for (const size_t reactant : reaction->getReactants()) {
+      numSpecies = std::max(numSpecies, reactant + 1);
+    }
+  }
+
+  if (m_seenScratch.size() < numSpecies) {
+    m_seenScratch.resize(numSpecies, 0);
+    m_muScratch.resize(numSpecies, 0.0);
+    m_sigmaScratch.resize(numSpecies, 0.0);
+  }
+
+  // Collect the distinct reactants. The stamps make this a single pass with no sort: a reactant is
+  // appended the first time it is seen and skipped afterwards.
+  m_reactantScratch.clear();
+
+  for (const auto& reaction : a_reactions) {
+    for (const size_t reactant : reaction->getReactants()) {
+      if (!m_seenScratch[reactant]) {
+        m_seenScratch[reactant] = 1;
+
+        m_reactantScratch.push_back(reactant);
+      }
+    }
+  }
+
+  // Leave the stamps clear for the next call.
+  for (const size_t reactant : m_reactantScratch) {
+    m_seenScratch[reactant] = 0;
+  }
+}
+
+template <typename R, typename State, typename T>
 inline Real
 KMCSolver<R, State, T>::getNonCriticalTimeStep(const State&             a_state,
                                                const ReactionList&      a_nonCriticalReactions,
@@ -269,22 +309,30 @@ KMCSolver<R, State, T>::getNonCriticalTimeStep(const State&             a_state,
 
   if (numReactions > 0) {
 
-    // 1. Gather a list of all reactants involved in the non-critical reactions.
-    auto allReactants = a_nonCriticalReactions[0]->getReactants();
-    for (size_t i = 1; i < numReactions; i++) {
-      const auto& curReactants = a_nonCriticalReactions[i]->getReactants();
+    // 1. Gather the distinct reactants involved in the non-critical reactions.
+    this->gatherDistinctReactants(a_nonCriticalReactions);
 
-      allReactants.insert(allReactants.end(), curReactants.begin(), curReactants.end());
+    for (const size_t reactant : m_reactantScratch) {
+      m_muScratch[reactant]    = 0.0;
+      m_sigmaScratch[reactant] = 0.0;
     }
 
-    // Only do unique reactants. Sorting before the unique() collapses ALL duplicates (std::list::unique only removes
-    // consecutive equal elements), so each distinct reactant is processed exactly once. This does not change the
-    // result: each reactant's contribution is independent and only feeds into a min-reduction.
-    allReactants.sort();
-    allReactants.unique();
+    // 2. Accumulate the expected change and variance per reactant. The loops are ordered reaction-
+    // major so that each reaction's state change is fetched once per reactant from its dense table
+    // rather than through a map lookup; the sums are the same as reactant-major.
+    for (size_t i = 0; i < numReactions; i++) {
+      const Real& p = a_nonCriticalPropensities[i];
 
-    // 2. Iterate through all reactants and compute deviations.
-    for (const auto& reactant : allReactants) {
+      for (const size_t reactant : m_reactantScratch) {
+        const auto muIJ = a_nonCriticalReactions[i]->getStateChange(reactant);
+
+        m_muScratch[reactant] += muIJ * p;
+        m_sigmaScratch[reactant] += muIJ * muIJ * p;
+      }
+    }
+
+    // 3. Reduce over the reactants.
+    for (const size_t reactant : m_reactantScratch) {
 
       // Xi is the population of the current reactant. It might seem weird that we are indexing this
       // through the reactions rather then through the state. Which it is, but the reason for that is
@@ -294,28 +342,18 @@ KMCSolver<R, State, T>::getNonCriticalTimeStep(const State&             a_state,
       const T Xi = a_nonCriticalReactions[0]->population(reactant, a_state);
 
       if (Xi > (T)0) {
-        Real mu     = 0.0;
-        Real sigma2 = 0.0;
 
         // Set gi to 1 for now. A more complex version would parse this through an input parameter
         // where the user has inspected the highest-order-reaction.
         constexpr Real gi = 1.0;
-
-        for (size_t i = 0; i < numReactions; i++) {
-          const Real& p    = a_nonCriticalPropensities[i];
-          const auto& muIJ = a_nonCriticalReactions[i]->getStateChange(reactant);
-
-          mu += muIJ * p;
-          sigma2 += muIJ * muIJ * p;
-        }
 
         Real dt1 = std::numeric_limits<Real>::max();
         Real dt2 = std::numeric_limits<Real>::max();
 
         const Real f = std::max(m_eps * Xi / gi, one);
 
-        mu     = std::abs(mu);
-        sigma2 = std::abs(sigma2);
+        const Real mu     = std::abs(m_muScratch[reactant]);
+        const Real sigma2 = std::abs(m_sigmaScratch[reactant]);
 
         if (mu > std::numeric_limits<Real>::min()) {
           dt1 = f / mu;
@@ -349,22 +387,28 @@ KMCSolver<R, State, T>::computeDt(const State&             a_state,
 
   if (numReactions > 0) {
 
-    // 1. Gather a list of all reactants involved in the input reactions
-    auto allReactants = a_reactions[0]->getReactants();
-    for (size_t i = 1; i < numReactions; i++) {
-      const auto& curReactants = a_reactions[i]->getReactants();
+    // 1. Gather the distinct reactants involved in the input reactions.
+    this->gatherDistinctReactants(a_reactions);
 
-      allReactants.insert(allReactants.end(), curReactants.begin(), curReactants.end());
+    for (const size_t reactant : m_reactantScratch) {
+      m_muScratch[reactant] = 0.0;
     }
 
-    // Only do unique reactants. Sorting before the unique() collapses ALL duplicates (std::list::unique only removes
-    // consecutive equal elements), so each distinct reactant is processed exactly once. This does not change the
-    // result: each reactant's contribution is independent and only feeds into a min-reduction.
-    allReactants.sort();
-    allReactants.unique();
+    // 2. Accumulate the expected change per reactant. The loops are ordered reaction-major so that
+    // each reaction's state change is fetched once per reactant from its dense table rather than
+    // through a map lookup; the sums are the same as reactant-major.
+    for (size_t i = 0; i < numReactions; i++) {
+      const Real& p = a_propensities[i];
 
-    // 2. Iterate through all reactants and compute deviations.
-    for (const auto& reactant : allReactants) {
+      for (const size_t reactant : m_reactantScratch) {
+        const auto muIJ = a_reactions[i]->getStateChange(reactant);
+
+        m_muScratch[reactant] += muIJ * p;
+      }
+    }
+
+    // 3. Reduce over the reactants.
+    for (const size_t reactant : m_reactantScratch) {
 
       // Xi is the population of the current reactant. It might seem weird that we are indexing this
       // through the reactions rather then through the state. Which it is, but the reason for that is
@@ -374,22 +418,13 @@ KMCSolver<R, State, T>::computeDt(const State&             a_state,
       const T Xi = R::population(reactant, a_state);
 
       if (Xi > (T)0) {
-        Real mu = 0.0;
 
         // Set gi to 1 for now. A more complex version would parse this through an input parameter
         // where the user has inspected the highest-order-reaction.
         constexpr Real gi = 1.0;
 
-        for (size_t i = 0; i < numReactions; i++) {
-          const Real& p    = a_propensities[i];
-          const auto& muIJ = a_reactions[i]->getStateChange(reactant);
-
-          mu += muIJ * p;
-        }
-
-        const Real f = std::max(a_epsilon * Xi / gi, one);
-
-        mu = std::abs(mu);
+        const Real f  = std::max(a_epsilon * Xi / gi, one);
+        const Real mu = std::abs(m_muScratch[reactant]);
 
         if (mu > std::numeric_limits<Real>::min()) {
           dt = std::min(dt, f / mu);


### PR DESCRIPTION
# Summary

Removes the O(R²) per-cell cost from the ItoKMC time step calculation, where R is the number of reactions. This is the follow-up #690 named in its "Not addressed here" section. Per-cell cost drops 2.5×–5.8× depending on chemistry size, and the scaling in R changes from ~R^1.8 to ~R^1.25. Results are unchanged.

Also skips whole patches with no cut cells in `fillSecondaryEmissionEB`.

### Background

#690 removed per-cell timer and sort overhead from `advanceReactionNetwork` and recorded what it left behind:

> The dominant per-cell cost found during this analysis is untouched and is 1–2 orders of magnitude larger than anything in this PR: the time-step-limiting tail of `ItoKMCPhysics::advanceKMC` is O(R²) heap allocations and O(R²·U) `std::map` lookups per cell, and runs unconditionally in cells with zero particles.

Profiling confirms it. A driver built on the `Exec/Tests/KineticMonteCarlo/Avalanche` pattern — using the types `ItoKMCPhysics` actually instantiates (`KMCDualState`/`KMCDualStateReaction` with `FPR = Real`), driving the real `KMCSolver::advanceHybrid` with `hybrid_midpoint` and the solver parameters from `regression2d.inputs` — attributes the per-cell cost as follows, for the 20-reaction air chemistry in `Exec/Tests/CdrPlasma/JSON` with its wildcards expanded:

| | µs/cell | share |
|---|---|---|
| `KMCSolver::computeDt` | 17.3 | **74%** |
| `propensities` | 3.4 | 15% |
| `computeCriticalNumberOfReactions` | 0.45 | 2% |
| state copies in the tail | 0.39 | 2% |
| the KMC advance itself | 1.1 | 5% |

`computeDt` is entered 16 times per cell for a 20-reaction set: once for the cell state, then once per reaction that can fire.

Three structures are rebuilt on every one of those calls even though none of them depends on the state:

- **The distinct reactant set.** `computeDt` and `getNonCriticalTimeStep` assembled it by concatenating each reaction's `getReactants()` — which returned a `std::list<size_t>` **by value**, so one heap node per reactant per reaction per call — then `sort()`ing and `unique()`ing the resulting linked list.
- **The stoichiometry.** The innermost loop called `getStateChange(reactant)`, which did `std::map::find` followed by `std::map::at`: two red-black-tree walks per lookup, |U|·R times per call.
- **The propensity's working state.** `KMCDualStateReaction::propensity` did `auto reactiveState = a_state.getReactiveState()` — `auto` drops the reference from the `const State&` — copying the whole state vector on every call, purely so it could decrement its own copy while forming the falling factorial.

The `advanceKMC` tail additionally copied `m_kmcState` above the `N < max` test that is its only consumer, so the copy was paid for every reaction including those that never enter the branch, and returned its propensities by value.

`getNonCriticalTimeStep` carries the same reactant-set and stoichiometry pattern and is called once per reactive substep from inside `advanceHybrid`, so this is not confined to the time step tail.

### Solution

- `KMCSolver` gains four `mutable` scratch buffers and `gatherDistinctReactants()`. The distinct reactant set is collected in a single pass using membership stamps — no sort, no allocation — and `computeDt`/`getNonCriticalTimeStep` accumulate reaction-major into per-species scratch before reducing. The sums are the same as reactant-major; only the loop order differs.
- `KMCDualStateReaction` gains `m_reactiveStateChangeDense` (a dense mirror of `m_reactiveStateChange`, built once in `computeStateChanges()`) so `getStateChange` is an indexed read, and `m_lhsOrders` (the reactant tally that already fixes `m_propensityFactor`, compacted to `(species, order)` pairs) so `propensity` forms the falling factorial straight off the incoming state.
- `getReactants()` returns by const reference in both `KMCDualStateReaction` and `KMCSingleStateReaction`.
- The `advanceKMC` tail reuses a thread-local propensity buffer and a thread-local perturbed state, and copies the state only inside the branch that reads it.
- `fillSecondaryEmissionEB` fetches its `VoFIterator` first and skips the patch when it is empty.

Measured against the parent commit, same machine, `OPT=HIGH`:

| chemistry | reactions | before | after | speedup |
|---|---|---|---|---|
| `simple_air` (`Exec/Tests/ItoKMC/JSON`) | 4 | 1.174 µs/cell | 0.468 | **2.5×** |
| AirBasic (`Exec/Examples/ItoKMC/AirBasic`) | 5 | 1.719 µs/cell | 0.614 | **2.8×** |
| air (`Exec/Tests/CdrPlasma/JSON`, `@` expanded) | 20 | 29.191 µs/cell | 5.026 | **5.8×** |

Cost against reaction count, 8 reactive species:

| reactions | before µs/cell | after |
|---|---|---|
| 4 | 1.43 | 0.44 |
| 8 | 4.55 | 0.90 |
| 20 | 24.21 | 2.78 |
| 40 | 87.85 | 7.86 |

~R^1.8 before, ~R^1.25 after.

### Side-effects

- **`KMCSolver`'s `const` member functions are no longer reentrant.** The scratch is `mutable`, so a single `KMCSolver` must not be shared across threads. `ItoKMCPhysics` satisfies this by holding its solver as `static thread_local` (see `defineKMC`), and the constraint is documented on each member. This is the one deliberate trade in the PR: it is what makes the hot path allocation-free.
- **`getReactants()`'s return type changed** from `std::list<size_t>` to `const std::list<size_t>&` in both reaction classes. Source-compatible for every use in the repo (`auto x = r->getReactants()` still copies); it would affect out-of-tree code only if something bound the result in a way that relied on it being a temporary.
- **`m_reactiveStateChange` is now mirrored, not replaced.** The map remains the authoritative store and is still iterated by `advanceState` and `computeCriticalNumberOfReactions`, which are sparse walks and measured at ~2% each. Keeping both means the dense table must be rebuilt whenever the map changes; `computeStateChanges()` is the only place that writes it.
- The `fillSecondaryEmissionEB` skip changes nothing inside a processed patch — the body is unchanged, so the consume-once/overwrite behaviour in multi-valued cells (where several VoFs share one `IntVect`, and the per-cell scratch is keyed by `IntVect`) is preserved exactly.
- No new types, classes, or containers. The change adds two data members to `KMCDualStateReaction`, four scratch members plus one protected helper to `KMCSolver`, and two `static thread_local` members to `ItoKMCPhysics`.

### Alternative solutions

- **Caching the reactant set and stoichiometry on the solver at `define()` time** would remove even the single gathering pass. Rejected because both routines are handed a *sub*-list: `getNonCriticalTimeStep` receives the non-critical partition, which changes per cell and per substep, so a table keyed on the full reaction list would not serve it. Hanging the dense stoichiometry off each reaction works for any sub-list.
- **A scratch workspace passed in by the caller** would keep `KMCSolver` reentrant with no allocation. Rejected because it changes the signatures of `computeDt` and `getNonCriticalTimeStep`, which are public and called directly by the standalone drivers and by user code.
- **Local `std::vector` scratch** would also keep the class reentrant, at two small allocations per call (~32 per cell at R=20). Rejected as the worst of both: it keeps allocation in the hot path while still being slower than the mutable-member form, for a reentrancy guarantee nothing in the repo uses.
- **An early-out for cells whose reactive state is entirely zero.** Rejected: it is only sound while every reaction has at least one reactant. A zero-order reaction such as `<nothing> -> e + O2+` (background ionisation) has a non-zero propensity in an empty cell, so the guard would be a latent trap the first time such a reaction is added. After the hoists an empty cell costs little enough that it is not worth the risk.
- **Rewriting `fillSecondaryEmissionEB` to size its scratch by cut cells rather than by `box.numPts()`.** Deferred: it changes behaviour in multi-valued cells (`extractCell` copies rather than consumes, so every VoF sees the cell's particles, and appending accumulates rather than overwrites). Both the old and new semantics are arbitrary — the cell-sort keys on `IntVect` and cannot say which VoF a particle belongs to — so this belongs in its own change with that question settled deliberately. The patch skip captures most of the win because EB-touching patches are a small minority.

### Testing

Both suites were run against a build of the parent commit in a separate tree, with identical inputs and `Random.seed` pinned, and compared line for line after filtering wall-clock timings, OS memory readouts, and the working-directory banner.

- `Exec/Tests/ItoKMC/JSON`, 4 MPI ranks, 16 time steps: **539 physics lines identical on all 4 ranks**.
- `Exec/Examples/ItoKMC/PartialDischarge`, 4 MPI ranks, 25 time steps: **1199 physics lines identical on all 4 ranks**. This configuration is the one whose chemistry has a `dielectric emission` block; `Qsurf` grows monotonically across the run (24 distinct values), confirming the secondary-emission path is exercised rather than merely compiled.
- The profiling driver additionally cross-checks `dt` against an independent implementation over 61,440 cell evaluations spanning three chemistries and both empty and populated cells: **0 differ, maximum relative difference 0**.
- Compile-checked in 2-D and 3-D: `CD_ItoKMCPhysics.cpp`, `CD_ItoKMCJSON.cpp`, `Exec/Tests/ItoKMC/JSON/main.cpp`, and both standalone KMC drivers (`Avalanche`, `Schlogl`), which exercise the `KMCSingleStateReaction` path.
- `pre-commit run` clean on all changed files (clang-format, reuse, codespell, cppcheck, doxygen).

Not done: no Sphinx documentation covers these internals, so none was updated; no `.rst` `literalinclude` references the changed line ranges.

### PR-review checklist

Mandatory:

- [x] I have run the test suite and made sure that it passed.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information.
- [x] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks.
- [ ] I have run clang-tidy and fixed all reported errors.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
