### PR TITLE
Remove the particle ghost neighbour-rank facility

### DIFF
--- a/Docs/Sphinx/source/Source/Particles.rst
+++ b/Docs/Sphinx/source/Source/Particles.rst
@@ -391,7 +391,7 @@ For each source cell a mask lists the destination boxes (grid index and receivin
 There is one mask per direction, and the collection type is
 
 .. literalinclude:: ../../../../Source/AmrMesh/CD_ParticleGhostMask.H
-   :lines: 224
+   :lines: 210
    :language: c++
 
 The masks live on the :ref:`Chap:Realm` and are rebuilt at every regrid.

--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -1891,17 +1891,6 @@ public:
   getParticleGhostExposure(const std::string& a_realm, const int a_width) const;
 
   /**
-   * @brief Get the particle ghost neighbor ranks on a realm for a registered width.
-   * @details Every rank this rank exchanges particle ghosts with, in either direction, at a_width. Lets a
-   * consumer restrict a would-be all-to-all exchange to this set instead.
-   * @param[in] a_realm Realm name
-   * @param[in] a_width Registered ghost width.
-   * @return The neighbor ranks, in ascending order.
-   */
-  const std::vector<int>&
-  getParticleGhostNeighborRanks(const std::string& a_realm, const int a_width) const;
-
-  /**
    * @brief Get the EBLevelGrid for a Realm and phase
    * @param[in] a_realm Realm name
    * @param[in] a_phase Phase (gas or solid)

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -3546,23 +3546,6 @@ AmrMesh::getParticleGhostExposure(const std::string& a_realm, const int a_width)
   return m_realms[a_realm]->getParticleGhostExposure(a_width);
 }
 
-const std::vector<int>&
-AmrMesh::getParticleGhostNeighborRanks(const std::string& a_realm, const int a_width) const
-{
-  CH_TIME("AmrMesh::getParticleGhostNeighborRanks(string, int)");
-  if (m_verbosity > 1) {
-    pout() << "AmrMesh::getParticleGhostNeighborRanks(string, int)" << endl;
-  }
-
-  if (!this->queryRealm(a_realm)) {
-    const std::string str = "AmrMesh::getParticleGhostNeighborRanks(string, int) - could not find realm '" + a_realm +
-                            "'";
-    MayDay::Abort(str.c_str());
-  }
-
-  return m_realms[a_realm]->getParticleGhostNeighborRanks(a_width);
-}
-
 const Vector<RefCountedPtr<EBLevelGrid>>&
 AmrMesh::getEBLevelGrid(const std::string& a_realm, const phase::which_phase a_phase) const
 {

--- a/Source/AmrMesh/CD_ParticleGhostMask.H
+++ b/Source/AmrMesh/CD_ParticleGhostMask.H
@@ -177,20 +177,6 @@ public:
   inline bool
   hasTargetBoxes() const noexcept;
 
-  /**
-   * @brief Flag every rank appearing in this table's packed target list.
-   * @details One pass over the packed targets, ignoring which cell each belongs to -- the caller wants
-   * the ranks this box ships to, not the per-cell breakdown. A flag array rather than a deduplicating
-   * container because there is one packed entry per (boundary cell x target) but only a handful of
-   * distinct ranks: this way each entry costs a single store, and the caller collapses the flags once.
-   * Accumulates into the argument (does not clear it), so a caller can union several tables -- e.g.
-   * every box of every level.
-   * @param[in,out] a_isTarget Per-rank flags, indexed by rank and sized to the communicator. Entries
-   * are set to true; existing true entries are left alone.
-   */
-  inline void
-  markTargetRanks(std::vector<bool>& a_isTarget) const noexcept;
-
 protected:
   /**
    * @brief Box that the source cells (and m_start/m_count) live on.

--- a/Source/AmrMesh/CD_ParticleGhostMaskImplem.H
+++ b/Source/AmrMesh/CD_ParticleGhostMaskImplem.H
@@ -139,16 +139,6 @@ ParticleGhostMask::hasTargetBoxes() const noexcept
   return !m_flatBox.empty();
 }
 
-inline void
-ParticleGhostMask::markTargetRanks(std::vector<bool>& a_isTarget) const noexcept
-{
-  for (const LevelTiles::BoxIDs& target : m_flat) {
-    CH_assert(target.second < a_isTarget.size());
-
-    a_isTarget[target.second] = true;
-  }
-}
-
 #include <CD_NamespaceFooter.H>
 
 #endif

--- a/Source/AmrMesh/CD_Realm.H
+++ b/Source/AmrMesh/CD_Realm.H
@@ -543,17 +543,6 @@ public:
   getParticleGhostExposure(const int a_width) const noexcept;
 
   /**
-   * @brief Get the particle ghost neighbor ranks for a registered width.
-   * @details Every rank this rank exchanges particle ghosts with, in either direction, at a_width -- see
-   * m_particleGhostNeighborRanks' own docs. Lets a consumer restrict a would-be all-to-all exchange to
-   * this set instead.
-   * @param[in] a_width Registered ghost width.
-   * @return The neighbor ranks for a_width, in ascending order. Aborts if the width was not registered.
-   */
-  const std::vector<int>&
-  getParticleGhostNeighborRanks(const int a_width) const noexcept;
-
-  /**
    * @brief Get the tiled space
    * @return Level tiles
    */
@@ -702,21 +691,6 @@ protected:
    * would in any case violate ParticleGhostMask::numTargets()' own precondition.
    */
   std::map<int, AMRMask> m_particleGhostExposure;
-
-  /**
-   * @brief Particle ghost neighbor ranks, keyed by ghost width. The union, over every box THIS rank owns
-   * at every level, of the target ranks appearing in that width's same-level/fine-to-coarse/coarse-to-fine
-   * masks -- i.e. every rank this rank exchanges particle ghosts with in EITHER direction, at that width.
-   * @details Built once per regrid alongside the masks themselves (see defineParticleGhostMasks()); no MPI
-   * is needed because it relies only on ghost adjacency being symmetric (if a box grown by the ghost width
-   * reaches a neighbor, the same growth relation reaches back), a property the ghost-fill masks already
-   * depend on. Lets consumers replace an all-to-all exchange with one restricted to actual neighbors.
-   *
-   * Held as a sorted vector rather than a set: it has a handful of entries (the neighbor COUNT saturates
-   * as the communicator grows, so it is not O(numProc)), every consumer wants to walk it in rank order,
-   * and a vector is what they would otherwise copy it into on every exchange.
-   */
-  std::map<int, std::vector<int>> m_particleGhostNeighborRanks;
 
 #ifdef CH_USE_PETSC
   /**

--- a/Source/AmrMesh/CD_Realm.cpp
+++ b/Source/AmrMesh/CD_Realm.cpp
@@ -1103,7 +1103,6 @@ Realm::defineParticleGhostMasks() noexcept
   m_particleGhostMaskFineToCoar.clear();
   m_particleGhostMaskCoarToFine.clear();
   m_particleGhostExposure.clear();
-  m_particleGhostNeighborRanks.clear();
 
   // Particle ghost filling is intentionally NOT supported on periodic domains (a periodic ghost would
   // require wrapping particle copies across the domain). Abort rather than silently mis-fill if a width
@@ -1133,16 +1132,6 @@ Realm::defineParticleGhostMasks() noexcept
     fineToCoar.resize(1 + m_finestLevel);
     coarToFine.resize(1 + m_finestLevel);
     exposure.resize(1 + m_finestLevel);
-
-    // Every rank this rank exchanges ghosts with at this width, in EITHER direction -- see
-    // m_particleGhostNeighborRanks' own docs for why folding in only MY OWN outgoing targets (below)
-    // is enough to also capture incoming ones, no communication required.
-    //
-    // Accumulated as per-rank flags and collapsed once, after every level has contributed. The masks
-    // hold one packed entry per (boundary cell x target) but only a handful of distinct ranks, so a
-    // flag store per entry beats inserting each one into a deduplicating container.
-    std::vector<int>& neighborRanks = m_particleGhostNeighborRanks[ghost];
-    std::vector<bool> isNeighbor(numProc(), false);
 
     for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
       const DisjointBoxLayout& dbl    = m_grids[lvl];
@@ -1193,43 +1182,6 @@ Realm::defineParticleGhostMasks() noexcept
                                         *coarToFine[lvl],
                                         lvl > 0,
                                         lvl < m_finestLevel);
-
-      // Fold this level's just-built masks' OWN (outgoing) target ranks into the running neighbor set.
-      // Ghost adjacency is symmetric (box growth intersection is a symmetric relation), so the ranks
-      // this rank ships TO at a given direction/width are exactly the ranks that ship back at the
-      // complementary direction (same-level ships back via the same mask; a coarse rank's C2F targets
-      // ship back via THEIR OWN F2C mask, and vice versa) -- the union across all three directions,
-      // over every level this rank owns boxes at, is therefore the full bidirectional neighbor set,
-      // with no MPI needed to discover it.
-      const DataIterator& dit  = dbl.dataIterator();
-      const int           nbox = dit.size();
-
-      // Serial (no omp): every box marks flags in the SAME isNeighbor array, and different boxes
-      // routinely share a target rank, so threads would write the same element concurrently. Distinct
-      // elements would not help either -- std::vector<bool> packs bits, so neighbouring ranks share a
-      // word. Per-thread arrays would fix it, but this runs once per regrid and costs one store per
-      // packed target, so there is nothing here worth buying with that memory.
-      for (int mybox = 0; mybox < nbox; mybox++) {
-        const DataIndex& din = dit[mybox];
-
-        (*same[lvl])[din].markTargetRanks(isNeighbor);
-
-        if (lvl > 0) {
-          (*fineToCoar[lvl])[din].markTargetRanks(isNeighbor);
-        }
-        if (lvl < m_finestLevel) {
-          (*coarToFine[lvl])[din].markTargetRanks(isNeighbor);
-        }
-      }
-    }
-
-    // Collapse the flags. Scanning in rank order means the result is sorted by construction, which is
-    // what the point-to-point exchanges want: both sides must walk their shared neighbors in the same
-    // order for the sends and receives to line up.
-    for (int rank = 0; rank < numProc(); rank++) {
-      if (isNeighbor[rank]) {
-        neighborRanks.push_back(rank);
-      }
     }
   }
 }
@@ -1925,21 +1877,6 @@ Realm::getParticleGhostExposure(const int a_width) const noexcept
 
   if (it == m_particleGhostExposure.end()) {
     const std::string msg = "Realm::getParticleGhostExposure -- width = " + std::to_string(a_width) +
-                            " was not registered (call registerParticleGhostMask before regridding)";
-
-    MayDay::Abort(msg.c_str());
-  }
-
-  return it->second;
-}
-
-const std::vector<int>&
-Realm::getParticleGhostNeighborRanks(const int a_width) const noexcept
-{
-  const auto it = m_particleGhostNeighborRanks.find(a_width);
-
-  if (it == m_particleGhostNeighborRanks.end()) {
-    const std::string msg = "Realm::getParticleGhostNeighborRanks -- width = " + std::to_string(a_width) +
                             " was not registered (call registerParticleGhostMask before regridding)";
 
     MayDay::Abort(msg.c_str());


### PR DESCRIPTION
# Summary

Removes the particle ghost neighbour-rank facility. It was added in #685 as an invariant for #679's
point-to-point exchanges to consume; #679 is not being merged, so nothing consumes it.

### Background

`Realm` computed, for each registered particle ghost width, the set of ranks this rank exchanges
particle ghosts with -- the union over every box it owns, at every level, of the target ranks appearing
in that width's same-level / fine-to-coarse / coarse-to-fine masks. It is derivable with no MPI at all,
because ghost adjacency is symmetric, and that is what made it attractive: a rank could discover its
neighbours for free and then talk only to them.

It landed in #685 because it was one of that issue's regrid invariants and had no owner. The intended
consumer was #679, which replaces the full-communicator `MPI_Alltoall`/`Alltoallv` in ghost-fill and in
the mergers' claim/verdict/commit rounds with `Isend`/`Irecv` restricted to that set.

That consumer is not arriving. The all-to-all does not show up in production profiles at 1k ranks, so
the exchange rewrite has no measured benefit to justify its complexity, and #679 is being closed
unmerged. Two supporting measurements, for the record:

- The neighbour count does saturate as the communicator grows -- 3.0 of 3 possible at 4 ranks, 5.7 of 7
  at 8, 5.9 of 15 at 16 -- so the bounded-neighbour premise itself holds.
- But a desktop A/B of the two exchange implementations was inconclusive: run-to-run variance on a
  single build spanned 0.105-0.229 s for the merge exchange timer at 16 ranks, against a branch
  difference of 3-8%.

### Solution

Delete the facility and the work that built it:

- `Realm::m_particleGhostNeighborRanks` and `Realm::getParticleGhostNeighborRanks`
- `AmrMesh::getParticleGhostNeighborRanks`
- `ParticleGhostMask::markTargetRanks`
- in `Realm::defineParticleGhostMasks()`: the per-rank flag array, the per-box marking loop, and the
  collapse pass that turned the flags into a sorted vector

This removes a per-regrid cost nobody was paying for. The marking loop visited every packed target of
all three masks -- one entry per (boundary cell x target) -- on every box of every level, to produce a
result with no reader.

**The boundary-exposure mask that #685 added alongside it stays.** That one has consumers in both merge
families (`mergeKDCarve` and `gatherMergeParticles` both read it instead of re-deriving the three-mask
OR per particle), and it is the item #685 called substantive.

### Side-effects

None intended, and none observed: this is a pure deletion of code with no callers. `kd_carve` and
`nn_pair_tree` reproduce their particle counts exactly on four ranks.

One documentation fix comes along with it. `Particles.rst` pulls the `AMRParticleGhostMask` alias out of
`CD_ParticleGhostMask.H` by absolute line number; deleting `markTargetRanks` shifted the alias, so the
directive is repointed from line 224 to 210. Every line-addressed `literalinclude` into a file this PR
touches (13 of them) was checked by rendering each directive against its own revision and comparing at
the word level; only that one moved, and it now renders what it rendered before.

### Alternative solutions

- **Keep the facility on the chance that a future consumer wants it.** Rejected: it is not free -- it
  costs a full sweep of every mask's packed targets at every regrid -- and the argument for its consumer
  is exactly what failed to hold up. If the point-to-point work is ever revisited, this is ~60 lines to
  reinstate from the history, against a cost paid every regrid until then.
- **Keep it but stop building it unless asked** (build on first request, cache per regrid). Rejected as
  machinery in service of a hypothetical caller.

### PR-review checklist

Mandatory:

- [x] I have run the test suite and made sure that it passed.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information.
- [x] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks.
- [ ] I have run clang-tidy and fixed all reported errors.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
