### PR TITLE
Route ItoKMC point-particle deposition through the Ito solver's own deposit

### DIFF
--- a/Docs/Sphinx/source/Solvers/Ito.rst
+++ b/Docs/Sphinx/source/Solvers/Ito.rst
@@ -144,7 +144,7 @@ The particles are available from the solver through the function
 
 .. literalinclude:: ../../../../Source/ItoDiffusion/CD_ItoSolver.H
    :language: c++
-   :lines: 669-675
+   :lines: 691-697
    :dedent: 2
 
 Usually, ``ItoSolver`` will perform a drift-diffusion advance and the user will then check if some of the particles crossed into the EB.
@@ -157,7 +157,7 @@ Remapping particles
 
 .. literalinclude:: ../../../../Source/ItoDiffusion/CD_ItoSolver.H
    :language: c++
-   :lines: 895-906
+   :lines: 917-928
    :dedent: 2
 
 The bottom function lets the user remap any ``ParticleContainer<ItoParticle>`` that lives in the solver.
@@ -171,7 +171,7 @@ The most general version is given below:
 
 .. literalinclude:: ../../../../Source/ItoDiffusion/CD_ItoSolver.H
    :language: c++
-   :lines: 366-381
+   :lines: 386-403
    :dedent: 2
 
 This version permits the user to deposit an arbitrary per-particle quantity from a particle container ``a_particles`` onto some pre-allocated mesh storage ``a_phi``.
@@ -194,10 +194,26 @@ This data can then be fetched with
 
 .. literalinclude:: ../../../../Source/ItoDiffusion/CD_ItoSolver.H
    :language: c++
-   :lines: 692-697
+   :lines: 714-719
    :dedent: 2
    
 For the full list of available deposition functions, see the ``ItoSolver`` C++ API `<https://chombo-discharge.github.io/chombo-discharge/doxygen/html/classItoSolver.html>`_.
+
+AMR synchronization after a deposit
+___________________________________
+
+The deposition functions put the particles on the mesh and, if redistribution is enabled, redistribute the cut-cell mass.
+They do *not* average the result down onto the coarser levels, and they do not fill its ghost cells.
+Whether that is wanted depends on what happens next, which only the caller knows: a deposit that is the final state of a field needs it, whereas a deposit that is merely one term of a larger sum does not, because only the assembled sum needs synchronizing.
+Callers that need it should therefore call
+
+.. literalinclude:: ../../../../Source/ItoDiffusion/CD_ItoSolver.H
+   :language: c++
+   :lines: 353-362
+   :dedent: 2
+
+after depositing.
+Note that ``ItoSolver::depositParticles`` already does this internally, so ``m_phi`` (i.e. the data returned by ``getPhi()``) is always synchronized.
 
 Deposition of other quantities
 ______________________________
@@ -242,7 +258,7 @@ Complete interpolation of the particle velocity consists of calling two function
 
 .. literalinclude:: ../../../../Source/ItoDiffusion/CD_ItoSolver.H
    :language: c++
-   :lines: 787-792,769-775
+   :lines: 809-814,791-797
    :dedent: 2
 
 Here, the calling sequence is such that the mobilities must be interpolated first, and then the velocity fields. 
@@ -281,7 +297,7 @@ The function signature is
 
 .. literalinclude:: ../../../../Source/ItoDiffusion/CD_ItoSolver.H
    :language: c++
-   :lines: 802-807
+   :lines: 824-829
    :dedent: 2
 
 Particle intersections
@@ -294,7 +310,7 @@ The most relevant function is
 
 .. literalinclude:: ../../../../Source/ItoDiffusion/CD_ItoSolver.H
    :language: c++
-   :lines: 460-467
+   :lines: 482-489
    :dedent: 2
 
 Here, ``EBIntersection`` is just an enum for putting logic into how the intersection is computed.
@@ -321,7 +337,7 @@ This routine is implemented as
 
 .. literalinclude:: ../../../../Source/ItoDiffusion/CD_ItoSolver.H
    :language: c++
-   :lines: 1030-1035
+   :lines: 1052-1057
    :dedent: 2
 
 which returns a CFL-like condition
@@ -337,7 +353,7 @@ The signatures for the diffusion time step are similar to the ones for drift:
 
 .. literalinclude:: ../../../../Source/ItoDiffusion/CD_ItoSolver.H
    :language: c++
-   :lines: 1054-1059
+   :lines: 1076-1081
    :dedent: 2
 
 which returns a CFL-like condition
@@ -355,7 +371,7 @@ A combination of the advection and diffusion time step routines also exists as
 
 .. literalinclude:: ../../../../Source/ItoDiffusion/CD_ItoSolver.H
    :language: c++
-   :lines: 932-942
+   :lines: 954-964
    :dedent: 2
 
 This time step limitation is inspired by fully explicit and non-split fluid models, and is calculated as
@@ -374,7 +390,7 @@ The entry point for splitting and merging is in all cases
 
 .. literalinclude:: ../../../../Source/ItoDiffusion/CD_ItoSolver.H
    :language: c++
-   :lines: 840-846
+   :lines: 862-868
    :dedent: 2
 
 Calling this function will merge/split the particles.

--- a/Physics/BrownianWalker/CD_BrownianWalkerStepper.cpp
+++ b/Physics/BrownianWalker/CD_BrownianWalkerStepper.cpp
@@ -390,6 +390,8 @@ BrownianWalkerStepper::preRegrid(const int a_lbase, const int a_oldFinestLevel)
                           DepositionType::NGP,
                           CoarseFineDeposition::Interp);
 
+  m_solver->coarsenAndFillGhosts(m_regridPPC);
+
   for (int lvl = 0; lvl <= m_amr->getFinestLevel(); lvl++) {
     const Real dx = m_amr->getDx()[lvl];
     const Real dV = std::pow(dx, SpaceDim);

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
@@ -33,8 +33,11 @@ namespace {
 // Deposit an SoA point-particle container's weight onto a_phi through the Ito solver's own deposition routine, so
 // that the point particles land on the mesh in the same normalization as the solver's own particles. Going through
 // the solver -- rather than calling AmrMesh::depositWeight directly -- is what picks up the solver's cut-cell
-// deposition flag and its redistribution/average-down/ghost-interpolation tail, and what guarantees the realm and
-// phase are the solver's own.
+// deposition flag and its redistribution, and what guarantees the realm and phase are the solver's own.
+//
+// No coarsenAndFillGhosts() here: every caller sums these deposits into rho or the cell conductivity and then
+// coarsens and fills ghost cells on that sum, so doing it per species would only produce values that are
+// immediately overwritten.
 inline void
 depositPointParticlesLikeSolver(const RefCountedPtr<ItoSolver>&     a_solver,
                                 EBAMRCellData&                      a_phi,

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
@@ -30,22 +30,17 @@
 using namespace Physics::ItoKMC;
 
 namespace {
-// Deposit an SoA particle container's weight onto a_phi using an Ito solver's configured deposition scheme.
+// Deposit an SoA point-particle container's weight onto a_phi through the Ito solver's own deposition routine, so
+// that the point particles land on the mesh in the same normalization as the solver's own particles. Going through
+// the solver -- rather than calling AmrMesh::depositWeight directly -- is what picks up the solver's cut-cell
+// deposition flag and its redistribution/average-down/ghost-interpolation tail, and what guarantees the realm and
+// phase are the solver's own.
 inline void
-depositPointParticlesLikeSolver(const RefCountedPtr<AmrMesh>&   a_amr,
-                                const std::string&              a_realm,
-                                const phase::which_phase        a_phase,
-                                const RefCountedPtr<ItoSolver>& a_solver,
-                                EBAMRCellData&                  a_phi,
-                                ParticleContainer<NoPayload>&   a_particles) noexcept
+depositPointParticlesLikeSolver(const RefCountedPtr<ItoSolver>&     a_solver,
+                                EBAMRCellData&                      a_phi,
+                                const ParticleContainer<NoPayload>& a_particles) noexcept
 {
-  a_amr->depositWeight(a_phi,
-                       a_realm,
-                       a_phase,
-                       a_particles,
-                       a_solver->getDeposition(),
-                       a_solver->getCoarseFineDeposition(),
-                       false);
+  a_solver->depositWeight(a_phi, a_particles, a_solver->getDeposition(), a_solver->getCoarseFineDeposition());
 }
 
 } // namespace
@@ -959,127 +954,72 @@ ItoKMCGodunovStepper<I, C, R, F>::depositPointParticles(
 
     switch (a_subset) {
     case SpeciesSubset::All: {
-      depositPointParticlesLikeSolver(this->m_amr,
-                                      this->m_particleRealm,
-                                      this->m_plasmaPhase,
-                                      solver,
-                                      solver->getPhi(),
-                                      *a_particles[idx]);
+      depositPointParticlesLikeSolver(solver, solver->getPhi(), *a_particles[idx]);
 
       break;
     }
     case SpeciesSubset::AllMobile: {
       if (mobile) {
-        depositPointParticlesLikeSolver(this->m_amr,
-                                        this->m_particleRealm,
-                                        this->m_plasmaPhase,
-                                        solver,
-                                        solver->getPhi(),
-                                        *a_particles[idx]);
+        depositPointParticlesLikeSolver(solver, solver->getPhi(), *a_particles[idx]);
       }
 
       break;
     }
     case SpeciesSubset::AllDiffusive: {
       if (diffusive) {
-        depositPointParticlesLikeSolver(this->m_amr,
-                                        this->m_particleRealm,
-                                        this->m_plasmaPhase,
-                                        solver,
-                                        solver->getPhi(),
-                                        *a_particles[idx]);
+        depositPointParticlesLikeSolver(solver, solver->getPhi(), *a_particles[idx]);
       }
 
       break;
     }
     case SpeciesSubset::AllMobileOrDiffusive: {
       if (mobile || diffusive) {
-        depositPointParticlesLikeSolver(this->m_amr,
-                                        this->m_particleRealm,
-                                        this->m_plasmaPhase,
-                                        solver,
-                                        solver->getPhi(),
-                                        *a_particles[idx]);
+        depositPointParticlesLikeSolver(solver, solver->getPhi(), *a_particles[idx]);
       }
       break;
     }
     case SpeciesSubset::AllMobileAndDiffusive: {
       if (mobile && diffusive) {
-        depositPointParticlesLikeSolver(this->m_amr,
-                                        this->m_particleRealm,
-                                        this->m_plasmaPhase,
-                                        solver,
-                                        solver->getPhi(),
-                                        *a_particles[idx]);
+        depositPointParticlesLikeSolver(solver, solver->getPhi(), *a_particles[idx]);
       }
       break;
     }
     case SpeciesSubset::Charged: {
       if (charged) {
-        depositPointParticlesLikeSolver(this->m_amr,
-                                        this->m_particleRealm,
-                                        this->m_plasmaPhase,
-                                        solver,
-                                        solver->getPhi(),
-                                        *a_particles[idx]);
+        depositPointParticlesLikeSolver(solver, solver->getPhi(), *a_particles[idx]);
       }
       break;
     }
     case SpeciesSubset::ChargedMobile: {
       if (charged && mobile) {
-        depositPointParticlesLikeSolver(this->m_amr,
-                                        this->m_particleRealm,
-                                        this->m_plasmaPhase,
-                                        solver,
-                                        solver->getPhi(),
-                                        *a_particles[idx]);
+        depositPointParticlesLikeSolver(solver, solver->getPhi(), *a_particles[idx]);
       }
       break;
     }
     case SpeciesSubset::ChargedDiffusive: {
       if (charged && diffusive) {
-        depositPointParticlesLikeSolver(this->m_amr,
-                                        this->m_particleRealm,
-                                        this->m_plasmaPhase,
-                                        solver,
-                                        solver->getPhi(),
-                                        *a_particles[idx]);
+        depositPointParticlesLikeSolver(solver, solver->getPhi(), *a_particles[idx]);
       }
 
       break;
     }
     case SpeciesSubset::ChargedMobileOrDiffusive: {
       if (charged && (mobile || diffusive)) {
-        depositPointParticlesLikeSolver(this->m_amr,
-                                        this->m_particleRealm,
-                                        this->m_plasmaPhase,
-                                        solver,
-                                        solver->getPhi(),
-                                        *a_particles[idx]);
+        depositPointParticlesLikeSolver(solver, solver->getPhi(), *a_particles[idx]);
       }
 
       break;
     }
     case SpeciesSubset::ChargedMobileAndDiffusive: {
       if (charged && (mobile && diffusive)) {
-        depositPointParticlesLikeSolver(this->m_amr,
-                                        this->m_particleRealm,
-                                        this->m_plasmaPhase,
-                                        solver,
-                                        solver->getPhi(),
-                                        *a_particles[idx]);
+        depositPointParticlesLikeSolver(solver, solver->getPhi(), *a_particles[idx]);
       }
 
       break;
     }
     case SpeciesSubset::Stationary: {
       if (!mobile && !diffusive) {
-        depositPointParticlesLikeSolver(this->m_amr,
-                                        this->m_particleRealm,
-                                        this->m_plasmaPhase,
-                                        solver,
-                                        solver->getPhi(),
-                                        *a_particles[idx]);
+        depositPointParticlesLikeSolver(solver, solver->getPhi(), *a_particles[idx]);
       }
 
       break;
@@ -1237,12 +1177,7 @@ ItoKMCGodunovStepper<I, C, R, F>::computeCellConductivity(
     if (Z != 0 && solver->isMobile()) {
       // Deposit on the particle realm.
       DataOps::setValue(this->m_particleScratch1, 0.0);
-      depositPointParticlesLikeSolver(this->m_amr,
-                                      this->m_particleRealm,
-                                      this->m_plasmaPhase,
-                                      solver,
-                                      this->m_particleScratch1,
-                                      *a_particles[idx]);
+      depositPointParticlesLikeSolver(solver, this->m_particleScratch1, *a_particles[idx]);
 
       // Copy to fluid realm and add to total conductivity.
       (this->m_amr)->copyData(this->m_fluidScratch1, this->m_particleScratch1);

--- a/Source/ItoDiffusion/CD_ItoSolver.H
+++ b/Source/ItoDiffusion/CD_ItoSolver.H
@@ -352,16 +352,24 @@ public:
 
   /**
    * @brief Deposit the SoA weight column on the mesh (full pipeline: kappa-conservative + redistribution).
+   * @details The container payload is a template parameter so that auxiliary point-particle containers -- e.g. the
+   * rho-dagger and conductivity particles carried by the semi-implicit time steppers -- deposit through exactly the
+   * same pipeline as the solver's own particles. This includes the cut-cell deposition flag and the
+   * redistribution/average-down/ghost-interpolation tail, both of which must be identical if the deposited densities
+   * are to be in the same normalization.
    * @param[out] a_phi                  Mesh data -- must have exactly one component.
    * @param[in]  a_particles            SoA particles to be deposited.
    * @param[in]  a_deposition           Deposition method.
    * @param[in]  a_coarseFineDeposition Coarse-fine deposition strategy.
+   * @tparam     P                      Payload type of the container.
+   * @tparam     Traits                 Column descriptor for the payload.
    */
+  template <typename P, typename Traits>
   void
-  depositWeight(EBAMRCellData&                        a_phi,
-                const ParticleContainer<ItoParticle>& a_particles,
-                DepositionType                        a_deposition,
-                CoarseFineDeposition                  a_coarseFineDeposition) const;
+  depositWeight(EBAMRCellData&                      a_phi,
+                const ParticleContainer<P, Traits>& a_particles,
+                DepositionType                      a_deposition,
+                CoarseFineDeposition                a_coarseFineDeposition) const;
 
   /**
    * @brief Deposit a gathered per-particle quantity on the mesh (full pipeline: kappa-conservative + redistribution).

--- a/Source/ItoDiffusion/CD_ItoSolver.H
+++ b/Source/ItoDiffusion/CD_ItoSolver.H
@@ -351,12 +351,24 @@ public:
                      Gather                                a_gather) const noexcept;
 
   /**
-   * @brief Deposit the SoA weight column on the mesh (full pipeline: kappa-conservative + redistribution).
+   * @brief Coarsen the input data and interpolate its ghost cells.
+   * @details This is the AMR synchronization that a deposit does *not* do for itself. Whether it is wanted depends on
+   * what the caller does next: a deposit that is the final state of a field needs it, whereas a deposit that is one
+   * term in a sum does not -- there, only the assembled sum needs synchronizing, and doing it per term produces values
+   * that are immediately overwritten. Deposits therefore leave it to the caller.
+   * @param[in,out] a_phi Cell-centered mesh data (one component).
+   */
+  void
+  coarsenAndFillGhosts(EBAMRCellData& a_phi) const;
+
+  /**
+   * @brief Deposit the SoA weight column on the mesh (kappa-conservative + redistribution).
    * @details The container payload is a template parameter so that auxiliary point-particle containers -- e.g. the
    * rho-dagger and conductivity particles carried by the semi-implicit time steppers -- deposit through exactly the
-   * same pipeline as the solver's own particles. This includes the cut-cell deposition flag and the
-   * redistribution/average-down/ghost-interpolation tail, both of which must be identical if the deposited densities
-   * are to be in the same normalization.
+   * same pipeline as the solver's own particles. This includes the cut-cell deposition flag and the redistribution,
+   * both of which must be identical if the deposited densities are to be in the same normalization.
+   * @note This leaves coarse levels un-averaged and ghost cells stale. Call coarsenAndFillGhosts() afterwards unless
+   * the result is a term in a sum that the caller synchronizes itself.
    * @param[out] a_phi                  Mesh data -- must have exactly one component.
    * @param[in]  a_particles            SoA particles to be deposited.
    * @param[in]  a_deposition           Deposition method.
@@ -372,13 +384,15 @@ public:
                 CoarseFineDeposition                a_coarseFineDeposition) const;
 
   /**
-   * @brief Deposit a gathered per-particle quantity on the mesh (full pipeline: kappa-conservative + redistribution).
+   * @brief Deposit a gathered per-particle quantity on the mesh (kappa-conservative + redistribution).
    * @param[out] a_phi                  Mesh data -- must have exactly one component.
    * @param[in]  a_particles            SoA particles to be deposited.
    * @param[in]  a_deposition           Deposition method.
    * @param[in]  a_coarseFineDeposition Coarse-fine deposition strategy.
    * @param[in]  a_gather               Per-particle value gatherer (leaf, index) -> Real.
    * @tparam     Gather                 Callable (const ParticleSoA<ItoParticle>&, std::size_t) -> Real.
+   * @note This leaves coarse levels un-averaged and ghost cells stale. Call coarsenAndFillGhosts() afterwards unless
+   * the result is a term in a sum that the caller synchronizes itself.
    */
   template <typename Gather>
   void
@@ -1807,15 +1821,6 @@ protected:
    */
   void
   drawNewParticles(const LevelData<EBCellFAB>& a_particlesPerCell, int a_level, int a_newPPC);
-
-  /**
-   * @brief Apply the redistribution + average-down + ghost-interpolation tail shared by all deposits.
-   * @details The SoA deposit pipeline first deposits onto the mesh (kappa-conservative), then calls this to
-   * redistribute mass (if enabled), average down, and interpolate ghost cells.
-   * @param[in,out] a_phi Cell-centered mesh data (one component).
-   */
-  void
-  finalizeDeposit(EBAMRCellData& a_phi) const;
 
   /**
    * @brief Redistribute mass in an AMR context.

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -708,6 +708,8 @@ ItoSolver::initialData()
   // Add particles, remove the ones that are inside the EB, and then deposit
   this->removeCoveredParticles(bulkParticles, EBRepresentation::ImplicitFunction, tolerance);
   this->depositWeight(m_phi, bulkParticles, m_deposition, m_coarseFineDeposition);
+
+  this->coarsenAndFillGhosts(m_phi);
 }
 
 void
@@ -1862,6 +1864,8 @@ ItoSolver::depositConductivity(EBAMRCellData&                  a_phi,
                           [](const ParticleSoA<ItoParticle>& a_leaf, const std::size_t a_i) -> Real {
                             return a_leaf.weight(a_i) * a_leaf.template get<&ItoParticle::mobility>(a_i);
                           });
+
+    this->coarsenAndFillGhosts(a_phi);
   }
   else {
     DataOps::setValue(a_phi, 0.0);
@@ -1900,6 +1904,8 @@ ItoSolver::depositDiffusivity(EBAMRCellData&                  a_phi,
                         [](const ParticleSoA<ItoParticle>& a_leaf, const std::size_t a_i) -> Real {
                           return a_leaf.weight(a_i) * a_leaf.template get<&ItoParticle::diffusion>(a_i);
                         });
+
+  this->coarsenAndFillGhosts(a_phi);
 }
 
 void
@@ -1934,6 +1940,8 @@ ItoSolver::depositEnergyDensity(EBAMRCellData&                  a_phi,
                         [](const ParticleSoA<ItoParticle>& a_leaf, const std::size_t a_i) -> Real {
                           return a_leaf.weight(a_i) * a_leaf.template get<&ItoParticle::energy>(a_i);
                         });
+
+  this->coarsenAndFillGhosts(a_phi);
 }
 
 void
@@ -1959,7 +1967,11 @@ ItoSolver::computeAverageMobility(EBAMRCellData& a_phi, ParticleContainer<ItoPar
                           return a_leaf.weight(a_i) * a_leaf.template get<&ItoParticle::mobility>(a_i);
                         });
 
+  this->coarsenAndFillGhosts(a_phi);
+
   this->depositWeight(weight, a_particles, m_deposition, m_coarseFineDeposition);
+
+  this->coarsenAndFillGhosts(weight);
 
   // Make averageMobility = weight*mu/weight. If there is no weight then set the value to zero.
   constexpr Real zero = 0.0;
@@ -1990,7 +2002,11 @@ ItoSolver::computeAverageDiffusion(EBAMRCellData& a_phi, ParticleContainer<ItoPa
                           return a_leaf.weight(a_i) * a_leaf.template get<&ItoParticle::diffusion>(a_i);
                         });
 
+  this->coarsenAndFillGhosts(a_phi);
+
   this->depositWeight(weight, a_particles, m_deposition, m_coarseFineDeposition);
+
+  this->coarsenAndFillGhosts(weight);
 
   // Make average diffusion coefficient = weight*D/weight. If there is no weight then set the value to zero.
   constexpr Real zero = 0.0;
@@ -2022,7 +2038,11 @@ ItoSolver::computeAverageEnergy(EBAMRCellData& a_phi, ParticleContainer<ItoParti
                           return a_leaf.weight(a_i) * a_leaf.template get<&ItoParticle::energy>(a_i);
                         });
 
+  this->coarsenAndFillGhosts(a_phi);
+
   this->depositWeight(weight, a_particles, m_deposition, m_coarseFineDeposition);
+
+  this->coarsenAndFillGhosts(weight);
 
   // Make average energy = weight*energy/weight. If there is no weight then set the value to zero.
   constexpr Real zero = 0.0;
@@ -2050,6 +2070,8 @@ ItoSolver::depositParticles(const WhichContainer a_container)
   }
 
   this->depositWeight(m_phi, m_particleContainers.at(a_container), m_deposition, m_coarseFineDeposition);
+
+  this->coarsenAndFillGhosts(m_phi);
 }
 
 void
@@ -2096,15 +2118,12 @@ ItoSolver::depositWeightNGP(LevelData<EBCellFAB>&                 a_output,
 }
 
 void
-ItoSolver::finalizeDeposit(EBAMRCellData& a_phi) const
+ItoSolver::coarsenAndFillGhosts(EBAMRCellData& a_phi) const
 {
-  CH_TIME("ItoSolver::finalizeDeposit");
+  CH_TIME("ItoSolver::coarsenAndFillGhosts");
   if (m_verbosity > 5) {
-    pout() << m_name + "::finalizeDeposit" << endl;
+    pout() << m_name + "::coarsenAndFillGhosts" << endl;
   }
-
-  // Redistribution magic (if enabled), then average down and interpolate ghost cells.
-  this->redistributeAMR(a_phi);
 
   m_amr->conservativeAverage(a_phi, m_realm, m_phase);
   m_amr->interpGhost(a_phi, m_realm, m_phase);

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -2053,33 +2053,6 @@ ItoSolver::depositParticles(const WhichContainer a_container)
 }
 
 void
-ItoSolver::depositWeight(EBAMRCellData&                        a_phi,
-                         const ParticleContainer<ItoParticle>& a_particles,
-                         const DepositionType                  a_deposition,
-                         const CoarseFineDeposition            a_coarseFineDeposition) const
-{
-  CH_TIME("ItoSolver::depositWeight");
-  if (m_verbosity > 5) {
-    pout() << m_name + "::depositWeight" << endl;
-  }
-
-  CH_assert(a_phi[0]->nComp() == 1);
-  CH_assert(!a_particles.isOrganizedByCell());
-
-  // Deposit the weight column onto the mesh (resets a_phi internally), then run the shared
-  // redistribution + average-down + ghost-interpolation tail.
-  m_amr->depositWeight(a_phi,
-                       m_realm,
-                       m_phase,
-                       a_particles,
-                       a_deposition,
-                       a_coarseFineDeposition,
-                       m_forceIrregDepositionNGP);
-
-  this->finalizeDeposit(a_phi);
-}
-
-void
 ItoSolver::depositWeightNGP(LevelData<EBCellFAB>&                 a_output,
                             const ParticleContainer<ItoParticle>& a_particles,
                             const int                             a_level) const noexcept

--- a/Source/ItoDiffusion/CD_ItoSolverImplem.H
+++ b/Source/ItoDiffusion/CD_ItoSolverImplem.H
@@ -65,8 +65,9 @@ ItoSolver::depositWeight(EBAMRCellData&                      a_phi,
   CH_assert(a_particles.getRealm() == m_realm);
   CH_assert(!a_particles.isOrganizedByCell());
 
-  // Deposit the weight column onto the mesh (resets a_phi internally), then run the shared
-  // redistribution + average-down + ghost-interpolation tail.
+  // Deposit the weight column onto the mesh (resets a_phi internally), then redistribute. Redistribution belongs
+  // here because it decides what the valid-cell values are; coarsening and ghost filling are the caller's, see
+  // coarsenAndFillGhosts().
   m_amr->depositWeight(a_phi,
                        m_realm,
                        m_phase,
@@ -75,7 +76,7 @@ ItoSolver::depositWeight(EBAMRCellData&                      a_phi,
                        a_coarseFineDeposition,
                        m_forceIrregDepositionNGP);
 
-  this->finalizeDeposit(a_phi);
+  this->redistributeAMR(a_phi);
 }
 
 template <typename Gather>
@@ -142,8 +143,8 @@ ItoSolver::depositGathered(EBAMRCellData&                        a_phi,
   CH_assert(a_phi[0]->nComp() == 1);
   CH_assert(!a_particles.isOrganizedByCell());
 
-  // Deposit the gathered quantity onto the mesh (resets a_phi internally), then run the shared
-  // redistribution + average-down + ghost-interpolation tail.
+  // Deposit the gathered quantity onto the mesh (resets a_phi internally), then redistribute. Coarsening and ghost
+  // filling are the caller's, see coarsenAndFillGhosts().
   m_amr->depositGathered(a_phi,
                          m_realm,
                          m_phase,
@@ -153,7 +154,7 @@ ItoSolver::depositGathered(EBAMRCellData&                        a_phi,
                          m_forceIrregDepositionNGP,
                          a_gather);
 
-  this->finalizeDeposit(a_phi);
+  this->redistributeAMR(a_phi);
 }
 
 #include <CD_NamespaceFooter.H>

--- a/Source/ItoDiffusion/CD_ItoSolverImplem.H
+++ b/Source/ItoDiffusion/CD_ItoSolverImplem.H
@@ -48,6 +48,36 @@ ItoSolver::randomGaussian() const
   return r;
 }
 
+template <typename P, typename Traits>
+void
+ItoSolver::depositWeight(EBAMRCellData&                      a_phi,
+                         const ParticleContainer<P, Traits>& a_particles,
+                         const DepositionType                a_deposition,
+                         const CoarseFineDeposition          a_coarseFineDeposition) const
+{
+  CH_TIME("ItoSolver::depositWeight");
+  if (m_verbosity > 5) {
+    pout() << m_name + "::depositWeight" << endl;
+  }
+
+  CH_assert(a_phi[0]->nComp() == 1);
+  CH_assert(a_phi.getRealm() == m_realm);
+  CH_assert(a_particles.getRealm() == m_realm);
+  CH_assert(!a_particles.isOrganizedByCell());
+
+  // Deposit the weight column onto the mesh (resets a_phi internally), then run the shared
+  // redistribution + average-down + ghost-interpolation tail.
+  m_amr->depositWeight(a_phi,
+                       m_realm,
+                       m_phase,
+                       a_particles,
+                       a_deposition,
+                       a_coarseFineDeposition,
+                       m_forceIrregDepositionNGP);
+
+  this->finalizeDeposit(a_phi);
+}
+
 template <typename Gather>
 void
 ItoSolver::depositGatheredNGP(LevelData<EBCellFAB>&                 a_output,


### PR DESCRIPTION
# Summary

`ItoKMCGodunovStepper` deposited its point particles (rho-dagger and conductivity) by calling `AmrMesh::depositWeight` directly instead of going through `ItoSolver`, which left the semi-implicit path in a different density normalization than the solver's own deposit produces. This routes both through a single routine, and — as a consequence of doing so — moves AMR synchronization out of the deposit and into the callers that actually want it.

This is part 2 of the analysis in https://github.com/rmrsk/chombo-discharge/issues/29.

### Background

`depositPointParticlesLikeSolver` in `CD_ItoKMCGodunovStepperImplem.H` called `AmrMesh::depositWeight` with the `forceIrregNGP` argument hardcoded to `false` and with no finalize tail, whereas `ItoSolver::depositWeight` passes `m_forceIrregDepositionNGP` and then calls `finalizeDeposit` → `redistributeAMR` + `conservativeAverage` + `interpGhost`. Three consequences:

1. **`ItoSolver.irr_ngp_deposition` was silently ignored on the semi-implicit path.** Rho-dagger and sigma always used CIC in cut cells and always leaked weight into covered cells (`depositParticleCIC` writes into the raw `FArrayBox` with no covered-cell test), regardless of the setting. There is no getter for `m_forceIrregDepositionNGP`, which is presumably why the flag was hardcoded.
2. **The redistribution pipeline was bypassed entirely.** Turning on `ItoSolver.redistribute` affected `computeSpaceChargeDensity()` at t=0 and after a step-0 regrid, but could not reach any rho-dagger or sigma computed during the advance.
3. **`solver->getPhi()` was left in a different normalization than `depositParticles()` produces.** `depositPointParticles` writes into `solver->getPhi()` mid-advance, so `computeDensityGradients`, tagging and plot output saw whichever deposit ran last.

`computeCellConductivity` used the same helper and so had the same problem.

### Solution

**Commit 1 — route the point particles through the solver.** `ItoSolver::depositWeight` becomes `template <typename P, typename Traits>` over the container payload and moves from `CD_ItoSolver.cpp` to `CD_ItoSolverImplem.H`, mirroring the existing `depositGathered`. The stepper's point-particle containers (`ParticleContainer<NoPayload>`) then go through the solver's own routine rather than a duplicate of it, which is what picks up the cut-cell deposition flag and the redistribution.

The issue suggested either adding an `ItoSolver::getForceIrregNGP()` getter and threading it through, or sharing one routine. This takes the second option: no getter is needed, and there is no longer a second deposition path that can drift from the first.

The stepper-local helper shrinks from six arguments to three and is now a one-line forwarder. Realm and phase come from the solver instead of being passed alongside it, removing a second way for the two paths to diverge. The deposit gains preconditions that `a_phi` and `a_particles` live on the solver's realm — `finalizeDeposit` and `redistributeAMR` operate on `m_realm`'s grids, so this was always a requirement, just an unstated one.

**Commit 2 — make AMR synchronization the caller's.** Routing the point particles through the solver handed them the whole of `finalizeDeposit`, including an average-down and a ghost interpolation their consumers immediately overwrite: both `computeSemiImplicitRho` and `computeCellConductivity` sum the per-species deposits and then coarsen and fill ghost cells on the sum.

Whether that synchronization is wanted is not a property of the deposit — it is a property of what the caller does next. A deposit that is the final state of a field needs it; a deposit that is one term in a sum does not. A routine that deposits one species cannot know which it is. So `finalizeDeposit` is dropped: `depositWeight` and `depositGathered` now end at `redistributeAMR`, and `ItoSolver::coarsenAndFillGhosts` carries the rest for callers that want it. Redistribution stays inside the deposit because it decides what the valid-cell values *are*.

`coarsenAndFillGhosts` is public. `BrownianWalkerStepper` needs it, and an external caller of `depositWeight` could not otherwise reproduce the old behaviour without knowing the solver's realm and phase.

No new types or containers are introduced by this PR.

### Side-effects

**Behaviour changes on the semi-implicit path, as intended:**

- `irr_ngp_deposition` (default `true`) is now honoured, so rho-dagger and the conductivity use NGP in cut cells and no longer leak weight into covered cells.
- Every point-particle deposit now runs `redistributeAMR`. Enabling `ItoSolver.redistribute` now reaches rho-dagger and sigma, which it previously could not.

**Synchronization placement is unchanged from `main`.** On `main`, every caller of `depositWeight` and `depositGathered` got the coarsen + ghost fill, and the point-particle path got none. That is reproduced exactly: the two calls are now written out at all twelve of those call sites, each immediately after its own deposit and before anything reads the result, in the same order (redistribute → coarsen → ghosts). This includes the `m_isMobile` branch of `depositConductivity`, whose `else` branch was never synchronized on `main` either. The point particles get neither, as before — so relative to `main` this PR adds no coarsening or ghost interpolation anywhere.

`Exec/`, `Geometries/` and `Physics/` were swept for other callers. The only other hit is `CD_ItoKMCGodunovStepperImplem.H:1338`, which is `AmrMesh::depositWeight` for the solid-phase dielectric deposit — it never had the tail and is unaffected.

**What this does not fix.** The mixed-convention problem in parts 1, 3 and 4 of the issue is untouched: the particle deposit is still kappa-weighted in cut cells while the CDR density is a true density. What this does is make the cut-cell deficit a clean, single factor of kappa rather than a geometry-dependent CIC truncation deficit contaminated by covered-cell leakage, which is a prerequisite for either of the fixes proposed there.

**Sites worth reconsidering, deliberately left alone** (each changes results and wants its own PR):

- `BrownianWalkerStepper:388` → `m_regridPPC`. The coarsening is counterproductive here: the consumer calls `DataOps::setInvalidValue(newParticlesPerCell, refRat, zero)` (`:702`) to zero coarse cells under fine grids, i.e. exactly the region `conservativeAverage` just filled — its comment says "we don't want to count data in those regions as valid data (because it does not represent particles)". Ghosts are unused too; the consumer moves data with `copyTo` (valid→valid) and `EBCoarseToFineInterp`.
- `ItoSolver::depositConductivity`. Same pattern as the path this PR fixes: its consumer `ItoKMCStepper::computeConductivityCell` sums it into `a_conductivity` and then coarsens and fills ghosts on the sum, so the per-species sync is overwritten.
- **Redistribution needs a ghost fill before it, not after.** `redistributeAMR` → `depositNonConservative` → `EBNonConservativeDivergence::nonConservativeDivergence` (`CD_EBNonConservativeDivergence.cpp:106-150`) applies a VoF stencil built from `VofUtils::getVofsInRadius(vof, ebisBox, m_redistributionRadius, ...)`, which for irregular vofs within that radius of a patch boundary reaches into the ghost region; the routine does no exchange of its own. After a deposit those ghost cells hold only each patch's own partial contribution — `EBAMRParticleMesh::depositInterpCore` folds ghost→valid with a reversed `Copier` + `EBAddOp` (`CD_EBAMRParticleMesh.H:662`) and never refills them. So with `blend_conservation = true` the non-conservative deposition reads incomplete values at patch boundaries, which propagates into both the hybrid value and `deltaM`.

  `CdrSolver` runs the same pipeline and does not have this problem: `conservativeDivergenceNoKappaDivision` ends with `exchange()` + `conservativeAverage` + `interpGhost` (`CD_CdrSolver.cpp:1022-1028`) and only then does `computeDivG` call `nonConservativeDivergence` (`:450`). The deposit path is missing that step.

  Note this is not in tension with redistribution's own halo handling: `EBFluxRedistribution::redistributeLevel/Coar/Fine` apply their stencils into a private `levelBuffer`/`coarBuffer`/`fineBuffer` and fold that into `a_phi` with `copyTo(..., EBAddOp())` (`CD_EBFluxRedistribution.cpp:590, 532, 649`), so redistributed mass never sits in `a_phi`'s ghost cells and an ordinary ghost fill cannot destroy it.

  Pre-existing on `main` and dormant at the defaults (`blend_conservation = false` makes `depositNonConservative` set zero), but it matters because option A in #29 turns that flag on.
- `depositDiffusivity` and `depositEnergyDensity` keep their sync without their consumers having been audited, since matching `main` was the goal here.

**Documentation.** Moving declarations in `CD_ItoSolver.H` invalidated eleven of the absolute `:lines:` ranges in `Docs/Sphinx/source/Solvers/Ito.rst`; eight produced "Could not lex literal_block as c++" warnings in CI and three had drifted silently onto still-parsable but wrong excerpts. All eleven are repaired: ranges were recomputed by diffing the header against `main`, mapping each endpoint through the unchanged hunks, and asserting the newly captured text is byte-identical to what the old range captured. Ten map that way; the `depositGathered` excerpt falls inside an edited block and was set by hand to cover the same declaration plus its doc comment. A short subsection on AMR synchronization after a deposit was added, since `coarsenAndFillGhosts` is now something a caller has to invoke.

**Verified:**

- 2-D optimised MPI builds of the ItoKMC and BrownianWalker tests are clean.
- `python3 -m sphinx -W --keep-going -b html source build/html` is clean.
- `Exec/Tests/ItoKMC/JSON/regression2d.inputs` on 4 ranks completes with no NaNs, at `max_amr_depth = 0` and `= 2`.
- Same inputs with `ItoSolver.redistribute=true ItoSolver.blend_conservation=true` also completes — the pipeline the semi-implicit path previously ignored now engages.
- `Exec/Tests/BrownianWalker/DriftDiffusion/regression2d.inputs` on 4 ranks completes.
- Assertions-enabled build (`DEBUG=TRUE OPT=FALSE`) runs the ItoKMC regression with AMR clean, so the new realm preconditions hold.

### Alternative solutions 

- **Add `ItoSolver::getForceIrregNGP()` and thread it through the existing helper**, then duplicate the finalize tail in the stepper. This is the minimum fix named in the issue. Rejected because it leaves two deposition paths that must be kept in agreement by hand — which is how the current divergence arose.
- **Keep the full tail inside the deposit.** Rejected: it adds roughly `2 x N_charged` coarsen passes and as many ghost exchanges per step whose results are immediately overwritten, and those are copier exchanges — the class of cost that is invisible on a handful of ranks and is not at scale.
- **A `bool a_synchronize` parameter on the deposit routines.** Rejected after auditing the call sites: the need genuinely varies (eight want it, four do not), and the property that predicts it — "am I the final state, or one term in someone else's sum?" — is only knowable at the call site. A flag that must be reasoned about at every call is an awkward spelling of "the caller owns this", and it would have kept `BrownianWalkerStepper` passing `true` out of habit. Its one real advantage is that adding a required parameter breaks downstream builds loudly, whereas removing behaviour is silent; that is the accepted cost of this approach.
- **Leave the point-particle path alone and fix the normalization downstream** (e.g. dividing by kappa when assembling rho). Rejected because it would not address `irr_ngp_deposition` being inoperative, the covered-cell weight loss, or the inconsistent state left in `solver->getPhi()`.

### PR-review checklist

Mandatory:

- [x] I have run the test suite and made sure that it passed.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information.
- [x] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [ ] I have run clang-tidy and fixed all reported errors.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
