### PR TITLE
Cut the redundant MPI round trips out of ghost-cell interpolation

### DIFF
--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -2399,8 +2399,10 @@ protected:
 
   /**
    * @brief Alias multifluid cell data into the reusable single-phase views m_mfAliasGas and m_mfAliasSolid.
-   * @details Only the phases that exist on the input realm are aliased; the view for a phase without an EB index
-   * space is left alone, and callers must not use it. The views are write handles rather than copies:
+   * @details This is the shell-reusing counterpart of allocatePointer followed by alias: it keeps the level
+   * shells alive between calls and only re-aliases them, then defers the aliasing itself to alias(). Only the
+   * phases that exist on the input realm are aliased; the view for a phase without an EB index space is left
+   * alone, and callers must not use it. The views are write handles rather than copies:
    * MfCellAliasFactory hands out the EBCellFAB inside each MFCellFAB of a_data, so everything a caller writes
    * through m_mfAliasGas or m_mfAliasSolid lands in a_data. This routine only reads a_data, but a_data is
    * modified through the views it returns, which is why it is taken by non-const reference.

--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -2400,9 +2400,12 @@ protected:
   /**
    * @brief Alias multifluid cell data into the reusable single-phase views m_mfAliasGas and m_mfAliasSolid.
    * @details Only the phases that exist on the input realm are aliased; the view for a phase without an EB index
-   * space is left alone, and callers must not use it.
+   * space is left alone, and callers must not use it. The views are write handles rather than copies:
+   * MfCellAliasFactory hands out the EBCellFAB inside each MFCellFAB of a_data, so everything a caller writes
+   * through m_mfAliasGas or m_mfAliasSolid lands in a_data. This routine only reads a_data, but a_data is
+   * modified through the views it returns, which is why it is taken by non-const reference.
    * @param[in]     a_realm Realm name. Must exist.
-   * @param[in,out] a_data  Multifluid data to alias.
+   * @param[in,out] a_data  Multifluid data to alias. Written to through the resulting views, not by this call.
    */
   void
   aliasMultifluidCellData(const std::string& a_realm, MFAMRCellData& a_data) const;

--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -2155,6 +2155,20 @@ protected:
   mutable std::map<std::string, RefCountedPtr<Realm>> m_realms;
 
   /**
+   * @brief Reusable single-phase alias of the gas-phase part of multifluid cell data.
+   * @details The MFAMRCellData routines operate by aliasing the multifluid data into single-phase views and
+   * calling the single-phase routine. The views are shells only -- they never own the data -- so they are held
+   * here and re-aliased in aliasMultifluidCellData rather than reallocated on every call.
+   */
+  mutable EBAMRCellData m_mfAliasGas;
+
+  /**
+   * @brief Reusable single-phase alias of the solid-phase part of multifluid cell data.
+   * @details See m_mfAliasGas.
+   */
+  mutable EBAMRCellData m_mfAliasSolid;
+
+  /**
    * @brief Implicit functions
    */
   std::map<phase::which_phase, RefCountedPtr<BaseIF>> m_baseif;
@@ -2382,6 +2396,16 @@ protected:
    */
   void
   buildCopiers();
+
+  /**
+   * @brief Alias multifluid cell data into the reusable single-phase views m_mfAliasGas and m_mfAliasSolid.
+   * @details Only the phases that exist on the input realm are aliased; the view for a phase without an EB index
+   * space is left alone, and callers must not use it.
+   * @param[in]     a_realm Realm name. Must exist.
+   * @param[in,out] a_data  Multifluid data to alias.
+   */
+  void
+  aliasMultifluidCellData(const std::string& a_realm, MFAMRCellData& a_data) const;
 
   /**
    * @brief Parse the low/high corners of the computational domain.

--- a/Source/AmrMesh/CD_AmrMesh.H
+++ b/Source/AmrMesh/CD_AmrMesh.H
@@ -2155,20 +2155,6 @@ protected:
   mutable std::map<std::string, RefCountedPtr<Realm>> m_realms;
 
   /**
-   * @brief Reusable single-phase alias of the gas-phase part of multifluid cell data.
-   * @details The MFAMRCellData routines operate by aliasing the multifluid data into single-phase views and
-   * calling the single-phase routine. The views are shells only -- they never own the data -- so they are held
-   * here and re-aliased in aliasMultifluidCellData rather than reallocated on every call.
-   */
-  mutable EBAMRCellData m_mfAliasGas;
-
-  /**
-   * @brief Reusable single-phase alias of the solid-phase part of multifluid cell data.
-   * @details See m_mfAliasGas.
-   */
-  mutable EBAMRCellData m_mfAliasSolid;
-
-  /**
    * @brief Implicit functions
    */
   std::map<phase::which_phase, RefCountedPtr<BaseIF>> m_baseif;
@@ -2396,21 +2382,6 @@ protected:
    */
   void
   buildCopiers();
-
-  /**
-   * @brief Alias multifluid cell data into the reusable single-phase views m_mfAliasGas and m_mfAliasSolid.
-   * @details This is the shell-reusing counterpart of allocatePointer followed by alias: it keeps the level
-   * shells alive between calls and only re-aliases them, then defers the aliasing itself to alias(). Only the
-   * phases that exist on the input realm are aliased; the view for a phase without an EB index space is left
-   * alone, and callers must not use it. The views are write handles rather than copies:
-   * MfCellAliasFactory hands out the EBCellFAB inside each MFCellFAB of a_data, so everything a caller writes
-   * through m_mfAliasGas or m_mfAliasSolid lands in a_data. This routine only reads a_data, but a_data is
-   * modified through the views it returns, which is why it is taken by non-const reference.
-   * @param[in]     a_realm Realm name. Must exist.
-   * @param[in,out] a_data  Multifluid data to alias. Written to through the resulting views, not by this call.
-   */
-  void
-  aliasMultifluidCellData(const std::string& a_realm, MFAMRCellData& a_data) const;
 
   /**
    * @brief Parse the low/high corners of the computational domain.

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -1957,39 +1957,6 @@ AmrMesh::interpGhost(LevelData<EBCellFAB>&       a_fineData,
 }
 
 void
-AmrMesh::aliasMultifluidCellData(const std::string& a_realm, MFAMRCellData& a_data) const
-{
-  CH_TIME("AmrMesh::aliasMultifluidCellData(string, MFAMRCellData)");
-  if (m_verbosity > 5) {
-    pout() << "AmrMesh::aliasMultifluidCellData(string, MFAMRCellData)" << endl;
-  }
-
-  const RefCountedPtr<EBIndexSpace>& ebisGas = m_realms[a_realm]->getEBIndexSpace(phase::gas);
-  const RefCountedPtr<EBIndexSpace>& ebisSol = m_realms[a_realm]->getEBIndexSpace(phase::solid);
-
-  // Deliberately not allocatePointer, which news a shell for every level on every call. The views hold no data
-  // of their own, so a shell that already exists only needs re-aliasing.
-  m_mfAliasGas.resize(1 + m_finestLevel);
-  m_mfAliasSolid.resize(1 + m_finestLevel);
-
-  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    if (m_mfAliasGas[lvl].isNull()) {
-      m_mfAliasGas[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
-    }
-    if (m_mfAliasSolid[lvl].isNull()) {
-      m_mfAliasSolid[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
-    }
-  }
-
-  if (!ebisGas.isNull()) {
-    this->alias(m_mfAliasGas, phase::gas, a_data);
-  }
-  if (!ebisSol.isNull()) {
-    this->alias(m_mfAliasSolid, phase::solid, a_data);
-  }
-}
-
-void
 AmrMesh::interpGhost(MFAMRCellData& a_data, const std::string& a_realm) const
 {
   CH_TIME("AmrMesh::interpGhost(MFAMRCellData, string)");
@@ -2005,14 +1972,21 @@ AmrMesh::interpGhost(MFAMRCellData& a_data, const std::string& a_realm) const
   const RefCountedPtr<EBIndexSpace>& ebisGas = m_realms[a_realm]->getEBIndexSpace(phase::gas);
   const RefCountedPtr<EBIndexSpace>& ebisSol = m_realms[a_realm]->getEBIndexSpace(phase::solid);
 
-  // Do aliasing
-  this->aliasMultifluidCellData(a_realm, a_data);
-
+  // Alias into single-phase views and interpolate those. A phase without an EB index space is skipped, so
+  // unlike a plain alias() over both phases we never ask an MFCellFAB for a phase it does not carry.
   if (!ebisGas.isNull()) {
-    this->interpGhost(m_mfAliasGas, a_realm, phase::gas);
+    EBAMRCellData aliasGas;
+
+    this->allocatePointer(aliasGas, a_realm);
+    this->alias(aliasGas, phase::gas, a_data);
+    this->interpGhost(aliasGas, a_realm, phase::gas);
   }
   if (!ebisSol.isNull()) {
-    this->interpGhost(m_mfAliasSolid, a_realm, phase::solid);
+    EBAMRCellData aliasSol;
+
+    this->allocatePointer(aliasSol, a_realm);
+    this->alias(aliasSol, phase::solid, a_data);
+    this->interpGhost(aliasSol, a_realm, phase::solid);
   }
 }
 
@@ -2032,14 +2006,21 @@ AmrMesh::interpGhostPwl(MFAMRCellData& a_data, const std::string& a_realm) const
   const RefCountedPtr<EBIndexSpace>& ebisGas = m_realms[a_realm]->getEBIndexSpace(phase::gas);
   const RefCountedPtr<EBIndexSpace>& ebisSol = m_realms[a_realm]->getEBIndexSpace(phase::solid);
 
-  // Do aliasing
-  this->aliasMultifluidCellData(a_realm, a_data);
-
+  // Alias into single-phase views and interpolate those. A phase without an EB index space is skipped, so
+  // unlike a plain alias() over both phases we never ask an MFCellFAB for a phase it does not carry.
   if (!ebisGas.isNull()) {
-    this->interpGhostPwl(m_mfAliasGas, a_realm, phase::gas);
+    EBAMRCellData aliasGas;
+
+    this->allocatePointer(aliasGas, a_realm);
+    this->alias(aliasGas, phase::gas, a_data);
+    this->interpGhostPwl(aliasGas, a_realm, phase::gas);
   }
   if (!ebisSol.isNull()) {
-    this->interpGhostPwl(m_mfAliasSolid, a_realm, phase::solid);
+    EBAMRCellData aliasSol;
+
+    this->allocatePointer(aliasSol, a_realm);
+    this->alias(aliasSol, phase::solid, a_data);
+    this->interpGhostPwl(aliasSol, a_realm, phase::solid);
   }
 }
 
@@ -2087,14 +2068,21 @@ AmrMesh::interpGhostMG(MFAMRCellData& a_data, const std::string& a_realm) const
   const RefCountedPtr<EBIndexSpace>& ebisGas = m_realms[a_realm]->getEBIndexSpace(phase::gas);
   const RefCountedPtr<EBIndexSpace>& ebisSol = m_realms[a_realm]->getEBIndexSpace(phase::solid);
 
-  // Do aliasing
-  this->aliasMultifluidCellData(a_realm, a_data);
-
+  // Alias into single-phase views and interpolate those. A phase without an EB index space is skipped, so
+  // unlike a plain alias() over both phases we never ask an MFCellFAB for a phase it does not carry.
   if (!ebisGas.isNull()) {
-    this->interpGhostMG(m_mfAliasGas, a_realm, phase::gas);
+    EBAMRCellData aliasGas;
+
+    this->allocatePointer(aliasGas, a_realm);
+    this->alias(aliasGas, phase::gas, a_data);
+    this->interpGhostMG(aliasGas, a_realm, phase::gas);
   }
   if (!ebisSol.isNull()) {
-    this->interpGhostMG(m_mfAliasSolid, a_realm, phase::solid);
+    EBAMRCellData aliasSol;
+
+    this->allocatePointer(aliasSol, a_realm);
+    this->alias(aliasSol, phase::solid, a_data);
+    this->interpGhostMG(aliasSol, a_realm, phase::solid);
   }
 }
 

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -1943,7 +1943,6 @@ AmrMesh::interpGhost(LevelData<EBCellFAB>&       a_fineData,
   }
 
   if (a_fineLevel > 0) {
-
     const int      nComps = a_fineData.nComp();
     const Interval interv = Interval(0, nComps - 1);
 
@@ -1951,9 +1950,10 @@ AmrMesh::interpGhost(LevelData<EBCellFAB>&       a_fineData,
 
     interpolator.interpolate(a_fineData, a_coarData, interv, EBGhostCellInterpolator::Type::MinMod);
   }
-  else {
-    a_fineData.exchange();
-  }
+
+  // Unconditional: on the coarsest level this is the only thing that fills the ghost cells, and on the finer
+  // ones the interpolator leaves them inconsistent -- see EBGhostCellInterpolator::interpolate.
+  a_fineData.exchange();
 }
 
 void
@@ -2043,12 +2043,11 @@ AmrMesh::interpGhostPwl(EBAMRCellData& a_data, const std::string& a_realm, const
 
     EBGhostCellInterpolator& interpolator = *m_realms[a_realm]->getGhostCellInterpolator(a_phase)[lvl];
 
-    // The exchange below covers every level, so the interpolator does not need to exchange this one.
-    constexpr bool doExchange = false;
-
-    interpolator.interpolate(*a_data[lvl], *a_data[lvl - 1], interv, EBGhostCellInterpolator::Type::MinMod, doExchange);
+    interpolator.interpolate(*a_data[lvl], *a_data[lvl - 1], interv, EBGhostCellInterpolator::Type::MinMod);
   }
 
+  // The interpolator leaves the ghost cells inconsistent -- see EBGhostCellInterpolator::interpolate. This is
+  // where they are made whole again, for every level at once.
   a_data.exchange();
 }
 

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -1957,6 +1957,38 @@ AmrMesh::interpGhost(LevelData<EBCellFAB>&       a_fineData,
 }
 
 void
+AmrMesh::aliasMultifluidCellData(const std::string& a_realm, MFAMRCellData& a_data) const
+{
+  CH_TIME("AmrMesh::aliasMultifluidCellData(string, MFAMRCellData)");
+  if (m_verbosity > 5) {
+    pout() << "AmrMesh::aliasMultifluidCellData(string, MFAMRCellData)" << endl;
+  }
+
+  const RefCountedPtr<EBIndexSpace>& ebisGas = m_realms[a_realm]->getEBIndexSpace(phase::gas);
+  const RefCountedPtr<EBIndexSpace>& ebisSol = m_realms[a_realm]->getEBIndexSpace(phase::solid);
+
+  m_mfAliasGas.resize(1 + m_finestLevel);
+  m_mfAliasSolid.resize(1 + m_finestLevel);
+
+  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
+    // The views hold no data of their own, so an existing shell can simply be re-aliased.
+    if (m_mfAliasGas[lvl].isNull()) {
+      m_mfAliasGas[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
+    }
+    if (m_mfAliasSolid[lvl].isNull()) {
+      m_mfAliasSolid[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
+    }
+
+    if (!ebisGas.isNull()) {
+      MultifluidAlias::aliasMF(*m_mfAliasGas[lvl], phase::gas, *a_data[lvl]);
+    }
+    if (!ebisSol.isNull()) {
+      MultifluidAlias::aliasMF(*m_mfAliasSolid[lvl], phase::solid, *a_data[lvl]);
+    }
+  }
+}
+
+void
 AmrMesh::interpGhost(MFAMRCellData& a_data, const std::string& a_realm) const
 {
   CH_TIME("AmrMesh::interpGhost(MFAMRCellData, string)");
@@ -1969,30 +2001,17 @@ AmrMesh::interpGhost(MFAMRCellData& a_data, const std::string& a_realm) const
     MayDay::Abort(str.c_str());
   }
 
-  // Do aliasing
-  EBAMRCellData aliasGas(1 + m_finestLevel);
-  EBAMRCellData aliasSol(1 + m_finestLevel);
-
   const RefCountedPtr<EBIndexSpace>& ebisGas = m_realms[a_realm]->getEBIndexSpace(phase::gas);
   const RefCountedPtr<EBIndexSpace>& ebisSol = m_realms[a_realm]->getEBIndexSpace(phase::solid);
 
-  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    aliasGas[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
-    aliasSol[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
-
-    if (!ebisGas.isNull()) {
-      MultifluidAlias::aliasMF(*aliasGas[lvl], phase::gas, *a_data[lvl]);
-    }
-    if (!ebisSol.isNull()) {
-      MultifluidAlias::aliasMF(*aliasSol[lvl], phase::solid, *a_data[lvl]);
-    }
-  }
+  // Do aliasing
+  this->aliasMultifluidCellData(a_realm, a_data);
 
   if (!ebisGas.isNull()) {
-    this->interpGhost(aliasGas, a_realm, phase::gas);
+    this->interpGhost(m_mfAliasGas, a_realm, phase::gas);
   }
   if (!ebisSol.isNull()) {
-    this->interpGhost(aliasSol, a_realm, phase::solid);
+    this->interpGhost(m_mfAliasSolid, a_realm, phase::solid);
   }
 }
 
@@ -2009,30 +2028,17 @@ AmrMesh::interpGhostPwl(MFAMRCellData& a_data, const std::string& a_realm) const
     MayDay::Abort(str.c_str());
   }
 
-  // Do aliasing
-  EBAMRCellData aliasGas(1 + m_finestLevel);
-  EBAMRCellData aliasSol(1 + m_finestLevel);
-
   const RefCountedPtr<EBIndexSpace>& ebisGas = m_realms[a_realm]->getEBIndexSpace(phase::gas);
   const RefCountedPtr<EBIndexSpace>& ebisSol = m_realms[a_realm]->getEBIndexSpace(phase::solid);
 
-  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    aliasGas[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
-    aliasSol[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
-
-    if (!ebisGas.isNull()) {
-      MultifluidAlias::aliasMF(*aliasGas[lvl], phase::gas, *a_data[lvl]);
-    }
-    if (!ebisSol.isNull()) {
-      MultifluidAlias::aliasMF(*aliasSol[lvl], phase::solid, *a_data[lvl]);
-    }
-  }
+  // Do aliasing
+  this->aliasMultifluidCellData(a_realm, a_data);
 
   if (!ebisGas.isNull()) {
-    this->interpGhostPwl(aliasGas, a_realm, phase::gas);
+    this->interpGhostPwl(m_mfAliasGas, a_realm, phase::gas);
   }
   if (!ebisSol.isNull()) {
-    this->interpGhostPwl(aliasSol, a_realm, phase::solid);
+    this->interpGhostPwl(m_mfAliasSolid, a_realm, phase::solid);
   }
 }
 
@@ -2055,7 +2061,10 @@ AmrMesh::interpGhostPwl(EBAMRCellData& a_data, const std::string& a_realm, const
 
     EBGhostCellInterpolator& interpolator = *m_realms[a_realm]->getGhostCellInterpolator(a_phase)[lvl];
 
-    interpolator.interpolate(*a_data[lvl], *a_data[lvl - 1], interv, EBGhostCellInterpolator::Type::MinMod);
+    // The exchange below covers every level, so the interpolator does not need to exchange this one.
+    constexpr bool doExchange = false;
+
+    interpolator.interpolate(*a_data[lvl], *a_data[lvl - 1], interv, EBGhostCellInterpolator::Type::MinMod, doExchange);
   }
 
   a_data.exchange();
@@ -2074,30 +2083,17 @@ AmrMesh::interpGhostMG(MFAMRCellData& a_data, const std::string& a_realm) const
     MayDay::Abort(str.c_str());
   }
 
-  // Do aliasing
-  EBAMRCellData aliasGas(1 + m_finestLevel);
-  EBAMRCellData aliasSol(1 + m_finestLevel);
-
   const RefCountedPtr<EBIndexSpace>& ebisGas = m_realms[a_realm]->getEBIndexSpace(phase::gas);
   const RefCountedPtr<EBIndexSpace>& ebisSol = m_realms[a_realm]->getEBIndexSpace(phase::solid);
 
-  for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    aliasGas[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
-    aliasSol[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
-
-    if (!ebisGas.isNull()) {
-      MultifluidAlias::aliasMF(*aliasGas[lvl], phase::gas, *a_data[lvl]);
-    }
-    if (!ebisSol.isNull()) {
-      MultifluidAlias::aliasMF(*aliasSol[lvl], phase::solid, *a_data[lvl]);
-    }
-  }
+  // Do aliasing
+  this->aliasMultifluidCellData(a_realm, a_data);
 
   if (!ebisGas.isNull()) {
-    this->interpGhostMG(aliasGas, a_realm, phase::gas);
+    this->interpGhostMG(m_mfAliasGas, a_realm, phase::gas);
   }
   if (!ebisSol.isNull()) {
-    this->interpGhostMG(aliasSol, a_realm, phase::solid);
+    this->interpGhostMG(m_mfAliasSolid, a_realm, phase::solid);
   }
 }
 

--- a/Source/AmrMesh/CD_AmrMesh.cpp
+++ b/Source/AmrMesh/CD_AmrMesh.cpp
@@ -1967,24 +1967,25 @@ AmrMesh::aliasMultifluidCellData(const std::string& a_realm, MFAMRCellData& a_da
   const RefCountedPtr<EBIndexSpace>& ebisGas = m_realms[a_realm]->getEBIndexSpace(phase::gas);
   const RefCountedPtr<EBIndexSpace>& ebisSol = m_realms[a_realm]->getEBIndexSpace(phase::solid);
 
+  // Deliberately not allocatePointer, which news a shell for every level on every call. The views hold no data
+  // of their own, so a shell that already exists only needs re-aliasing.
   m_mfAliasGas.resize(1 + m_finestLevel);
   m_mfAliasSolid.resize(1 + m_finestLevel);
 
   for (int lvl = 0; lvl <= m_finestLevel; lvl++) {
-    // The views hold no data of their own, so an existing shell can simply be re-aliased.
     if (m_mfAliasGas[lvl].isNull()) {
       m_mfAliasGas[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
     }
     if (m_mfAliasSolid[lvl].isNull()) {
       m_mfAliasSolid[lvl] = RefCountedPtr<LevelData<EBCellFAB>>(new LevelData<EBCellFAB>());
     }
+  }
 
-    if (!ebisGas.isNull()) {
-      MultifluidAlias::aliasMF(*m_mfAliasGas[lvl], phase::gas, *a_data[lvl]);
-    }
-    if (!ebisSol.isNull()) {
-      MultifluidAlias::aliasMF(*m_mfAliasSolid[lvl], phase::solid, *a_data[lvl]);
-    }
+  if (!ebisGas.isNull()) {
+    this->alias(m_mfAliasGas, phase::gas, a_data);
+  }
+  if (!ebisSol.isNull()) {
+    this->alias(m_mfAliasSolid, phase::solid, a_data);
   }
 }
 

--- a/Source/AmrMesh/CD_EBGhostCellInterpolator.H
+++ b/Source/AmrMesh/CD_EBGhostCellInterpolator.H
@@ -95,21 +95,26 @@ public:
 
   /**
    * @brief Do inhomogeneous interpolation
-   * @details The interpolation fills the fine-grid ghost cells that lie across the coarse-fine interface. The
-   * remaining ghost cells, i.e. the ones that are covered by a neighbouring patch on the fine level, are filled
-   * by the exchange at the end. Callers that follow up with an exchange of their own can turn it off here.
+   * @details This fills the fine-grid ghost cells that lie across the coarse-fine interface, interpolating them
+   * from the coarse grid. The coarse data is fetched into an internal buffer on the coarsened fine grids, so
+   * a_phiCoar's own ghost cells are not read and need not be valid.
+   * @note This routine does not exchange, and on return a_phiFine's ghost cells are not consistent. Two
+   * separate things are left to the caller. First, the ghost cells that are covered by a neighbouring patch on
+   * the fine level are not part of the coarse-fine region and are never filled here. Second, some of those
+   * cells are actively overwritten with interpolated values, because the interpolated region is stored as the
+   * bounding box of the coarse-fine ghost cells rather than as the cell set itself, and that box spans
+   * neighbour-owned cells whenever the set is not rectangular. The caller must therefore exchange a_phiFine
+   * before anything reads its ghost cells.
    * @param[in,out] a_phiFine    Fine phi
    * @param[in]     a_phiCoar    Coarse phi
    * @param[in]     a_variables  Variables to interpolate
    * @param[in]     a_interpType Interp type
-   * @param[in]     a_doExchange Exchange the fine-grid ghost cells that are not filled by the interpolation.
    */
   virtual void
   interpolate(LevelData<EBCellFAB>&       a_phiFine,
               const LevelData<EBCellFAB>& a_phiCoar,
               const Interval              a_variables,
-              const Type                  a_interpType,
-              const bool                  a_doExchange = true) const noexcept;
+              const Type                  a_interpType) const noexcept;
 
 protected:
   /**

--- a/Source/AmrMesh/CD_EBGhostCellInterpolator.H
+++ b/Source/AmrMesh/CD_EBGhostCellInterpolator.H
@@ -161,9 +161,11 @@ protected:
   /**
    * @brief Buffer holding the coarse-grid data on the coarsened fine grids.
    * @details This is filled by a single copyTo from the coarse level, for all the interpolated variables at
-   * once. It is sized in defineBuffers, i.e. once per regrid, and is grown if a call asks for more variables
-   * than it currently holds. Keeping it as a member avoids rebuilding an EBCellFactory and reallocating the
-   * entire coarsened-fine layout on every call.
+   * once. Keeping it as a member avoids rebuilding an EBCellFactory and reallocating the entire coarsened-fine
+   * layout on every call. It is sized in defineBuffers, i.e. once per regrid, and holds SpaceDim components:
+   * that covers the scalar and vector fields which make up every call on the hot path. The rare wider call --
+   * physics plot variables, whose count is set by the user's model -- uses a local buffer instead, so the
+   * resident footprint stays bounded regardless of how many plot variables a model declares.
    */
   mutable LevelData<EBCellFAB> m_coarsenedFineData;
 

--- a/Source/AmrMesh/CD_EBGhostCellInterpolator.H
+++ b/Source/AmrMesh/CD_EBGhostCellInterpolator.H
@@ -95,16 +95,21 @@ public:
 
   /**
    * @brief Do inhomogeneous interpolation
-   * @param[in,out] a_phiFine   Fine phi
-   * @param[in]    a_phiCoar   Coarse phi
-   * @param[in]    a_variables Variables to interpolate
-   * @param[in] a_interpType Interp type
+   * @details The interpolation fills the fine-grid ghost cells that lie across the coarse-fine interface. The
+   * remaining ghost cells, i.e. the ones that are covered by a neighbouring patch on the fine level, are filled
+   * by the exchange at the end. Callers that follow up with an exchange of their own can turn it off here.
+   * @param[in,out] a_phiFine    Fine phi
+   * @param[in]     a_phiCoar    Coarse phi
+   * @param[in]     a_variables  Variables to interpolate
+   * @param[in]     a_interpType Interp type
+   * @param[in]     a_doExchange Exchange the fine-grid ghost cells that are not filled by the interpolation.
    */
   virtual void
   interpolate(LevelData<EBCellFAB>&       a_phiFine,
               const LevelData<EBCellFAB>& a_phiCoar,
               const Interval              a_variables,
-              const Type                  a_interpType) const noexcept;
+              const Type                  a_interpType,
+              const bool                  a_doExchange = true) const noexcept;
 
 protected:
   /**
@@ -152,6 +157,15 @@ protected:
    * @brief Copier for making copying from m_eblgCoar to m_grownCoarData go faster
    */
   Copier m_copier;
+
+  /**
+   * @brief Buffer holding the coarse-grid data on the coarsened fine grids.
+   * @details This is filled by a single copyTo from the coarse level, for all the interpolated variables at
+   * once. It is sized in defineBuffers, i.e. once per regrid, and is grown if a call asks for more variables
+   * than it currently holds. Keeping it as a member avoids rebuilding an EBCellFactory and reallocating the
+   * entire coarsened-fine layout on every call.
+   */
+  mutable LevelData<EBCellFAB> m_coarsenedFineData;
 
   /**
    * @brief List of coarse-grid cells that appear through coarsening a fine-grid ghost cell

--- a/Source/AmrMesh/CD_EBGhostCellInterpolator.cpp
+++ b/Source/AmrMesh/CD_EBGhostCellInterpolator.cpp
@@ -161,53 +161,78 @@ EBGhostCellInterpolator::defineBuffers() noexcept
   CH_TIME("EBGhostCellInterpolator::defineBuffers");
 
   m_copier.define(m_eblgCoar.getDBL(), m_eblgCoFi.getDBL(), m_ghostCF * IntVect::Unit);
+
+  // One component to begin with -- interpolate() grows the buffer if it is asked for more variables.
+  m_coarsenedFineData.define(m_eblgCoFi.getDBL(), 1, m_ghostCF * IntVect::Unit, EBCellFactory(m_eblgCoFi.getEBISL()));
 }
 
 void
 EBGhostCellInterpolator::interpolate(LevelData<EBCellFAB>&       a_phiFine,
                                      const LevelData<EBCellFAB>& a_phiCoar,
                                      const Interval              a_variables,
-                                     const Type                  a_interpType) const noexcept
+                                     const Type                  a_interpType,
+                                     const bool                  a_doExchange) const noexcept
 {
   CH_TIMERS("EBGhostCellInterpolator::interpolate(LD<EBCellFAB>");
   CH_TIMER("EBGhostCellInterpolator::interpolate(LD<EBCellFAB>::buffer_define", t1);
   CH_TIMER("EBGhostCellInterpolator::interpolate(LD<EBCellFAB>::copy_exchange", t2);
-  CH_TIMER("EBGhostCellInterpolator::interpolate(LD<EBCellFAB>::regular_cells", t3);
-  CH_TIMER("EBGhostCellInterpolator::interpolate(LD<EBCellFAB>::irregular_cells", t4);
+  CH_TIMER("EBGhostCellInterpolator::interpolate(LD<EBCellFAB>::interp_cells", t3);
+  CH_TIMER("EBGhostCellInterpolator::interpolate(LD<EBCellFAB>::exchange", t4);
 
+  CH_assert(m_isDefined);
   CH_assert(a_phiFine.nComp() > a_variables.end());
   CH_assert(a_phiCoar.nComp() > a_variables.end());
   CH_assert(a_phiFine.nComp() == a_phiCoar.nComp());
 
-  LevelData<EBCellFAB> phiCoFi(m_eblgCoFi.getDBL(), 1, m_ghostCF * IntVect::Unit, EBCellFactory(m_eblgCoFi.getEBISL()));
+  const int numVars = a_variables.size();
 
-  for (int icomp = a_variables.begin(); icomp <= a_variables.end(); icomp++) {
-    const Interval srcInterv = Interval(icomp, icomp);
-    const Interval dstInterv = Interval(0, 0);
+  // Grow the buffer if this call interpolates more variables than it was sized for. In steady state this does
+  // not trigger, so the buffer is allocated once per regrid.
+  CH_START(t1);
+  if (m_coarsenedFineData.nComp() < numVars) {
+    m_coarsenedFineData.define(m_eblgCoFi.getDBL(),
+                               numVars,
+                               m_ghostCF * IntVect::Unit,
+                               EBCellFactory(m_eblgCoFi.getEBISL()));
+  }
+  CH_STOP(t1);
 
-    a_phiCoar.copyTo(srcInterv, phiCoFi, dstInterv, m_copier);
+  // Fetch all the coarse-grid variables in one round trip rather than one per variable.
+  CH_START(t2);
+  a_phiCoar.copyTo(a_variables, m_coarsenedFineData, Interval(0, numVars - 1), m_copier);
+  CH_STOP(t2);
 
-    // Fill invalid regions.
-    const DataIterator dit = m_eblgFine.getDBL().dataIterator();
+  // Fill invalid regions.
+  const DataIterator dit = m_eblgFine.getDBL().dataIterator();
 
-    const int nbox = dit.size();
+  const int nbox = dit.size();
+
+  CH_START(t3);
 #pragma omp parallel for schedule(runtime)
-    for (int mybox = 0; mybox < nbox; mybox++) {
-      const DataIndex& din = dit[mybox];
+  for (int mybox = 0; mybox < nbox; mybox++) {
+    const DataIndex& din = dit[mybox];
 
-      EBCellFAB&       phiFine = a_phiFine[din];
-      const EBCellFAB& phiCoar = phiCoFi[din];
+    EBCellFAB&       phiFine = a_phiFine[din];
+    const EBCellFAB& phiCoar = m_coarsenedFineData[din];
 
-      FArrayBox&       phiFineReg = phiFine.getFArrayBox();
-      const FArrayBox& phiCoarReg = phiCoar.getFArrayBox();
+    FArrayBox&       phiFineReg = phiFine.getFArrayBox();
+    const FArrayBox& phiCoarReg = phiCoar.getFArrayBox();
 
-      this->interpolateRegular(phiFineReg, phiCoarReg, din, icomp, 0, a_interpType);
-      this->interpolateIrregular(phiFine, phiCoar, din, icomp, 0, a_interpType);
+    for (int icomp = a_variables.begin(); icomp <= a_variables.end(); icomp++) {
+      const int coarComp = icomp - a_variables.begin();
+
+      this->interpolateRegular(phiFineReg, phiCoarReg, din, icomp, coarComp, a_interpType);
+      this->interpolateIrregular(phiFine, phiCoar, din, icomp, coarComp, a_interpType);
     }
   }
+  CH_STOP(t3);
 
   // Fill valid regions.
-  a_phiFine.exchange(a_variables);
+  if (a_doExchange) {
+    CH_START(t4);
+    a_phiFine.exchange(a_variables);
+    CH_STOP(t4);
+  }
 }
 
 void

--- a/Source/AmrMesh/CD_EBGhostCellInterpolator.cpp
+++ b/Source/AmrMesh/CD_EBGhostCellInterpolator.cpp
@@ -162,8 +162,12 @@ EBGhostCellInterpolator::defineBuffers() noexcept
 
   m_copier.define(m_eblgCoar.getDBL(), m_eblgCoFi.getDBL(), m_ghostCF * IntVect::Unit);
 
-  // One component to begin with -- interpolate() grows the buffer if it is asked for more variables.
-  m_coarsenedFineData.define(m_eblgCoFi.getDBL(), 1, m_ghostCF * IntVect::Unit, EBCellFactory(m_eblgCoFi.getEBISL()));
+  // SpaceDim components covers every caller on the hot path; interpolate() falls back to a local buffer for
+  // the rare wider call.
+  m_coarsenedFineData.define(m_eblgCoFi.getDBL(),
+                             SpaceDim,
+                             m_ghostCF * IntVect::Unit,
+                             EBCellFactory(m_eblgCoFi.getEBISL()));
 }
 
 void
@@ -186,20 +190,24 @@ EBGhostCellInterpolator::interpolate(LevelData<EBCellFAB>&       a_phiFine,
 
   const int numVars = a_variables.size();
 
-  // Grow the buffer if this call interpolates more variables than it was sized for. In steady state this does
-  // not trigger, so the buffer is allocated once per regrid.
+  // The member buffer holds SpaceDim components, which covers every caller on the hot path. A call that asks
+  // for more -- physics plot variables, whose count comes from the user's model -- takes a local buffer, so
+  // the resident footprint stays bounded while every call still fetches its variables in one round trip.
+  const bool wideCall = numVars > m_coarsenedFineData.nComp();
+
+  LevelData<EBCellFAB> wideBuffer;
+
   CH_START(t1);
-  if (m_coarsenedFineData.nComp() < numVars) {
-    m_coarsenedFineData.define(m_eblgCoFi.getDBL(),
-                               numVars,
-                               m_ghostCF * IntVect::Unit,
-                               EBCellFactory(m_eblgCoFi.getEBISL()));
+  if (wideCall) {
+    wideBuffer.define(m_eblgCoFi.getDBL(), numVars, m_ghostCF * IntVect::Unit, EBCellFactory(m_eblgCoFi.getEBISL()));
   }
   CH_STOP(t1);
 
+  LevelData<EBCellFAB>& phiCoFi = wideCall ? wideBuffer : m_coarsenedFineData;
+
   // Fetch all the coarse-grid variables in one round trip rather than one per variable.
   CH_START(t2);
-  a_phiCoar.copyTo(a_variables, m_coarsenedFineData, Interval(0, numVars - 1), m_copier);
+  a_phiCoar.copyTo(a_variables, phiCoFi, Interval(0, numVars - 1), m_copier);
   CH_STOP(t2);
 
   // Fill invalid regions.
@@ -213,7 +221,7 @@ EBGhostCellInterpolator::interpolate(LevelData<EBCellFAB>&       a_phiFine,
     const DataIndex& din = dit[mybox];
 
     EBCellFAB&       phiFine = a_phiFine[din];
-    const EBCellFAB& phiCoar = m_coarsenedFineData[din];
+    const EBCellFAB& phiCoar = phiCoFi[din];
 
     FArrayBox&       phiFineReg = phiFine.getFArrayBox();
     const FArrayBox& phiCoarReg = phiCoar.getFArrayBox();

--- a/Source/AmrMesh/CD_EBGhostCellInterpolator.cpp
+++ b/Source/AmrMesh/CD_EBGhostCellInterpolator.cpp
@@ -174,14 +174,12 @@ void
 EBGhostCellInterpolator::interpolate(LevelData<EBCellFAB>&       a_phiFine,
                                      const LevelData<EBCellFAB>& a_phiCoar,
                                      const Interval              a_variables,
-                                     const Type                  a_interpType,
-                                     const bool                  a_doExchange) const noexcept
+                                     const Type                  a_interpType) const noexcept
 {
   CH_TIMERS("EBGhostCellInterpolator::interpolate(LD<EBCellFAB>");
   CH_TIMER("EBGhostCellInterpolator::interpolate(LD<EBCellFAB>::buffer_define", t1);
   CH_TIMER("EBGhostCellInterpolator::interpolate(LD<EBCellFAB>::copy_exchange", t2);
   CH_TIMER("EBGhostCellInterpolator::interpolate(LD<EBCellFAB>::interp_cells", t3);
-  CH_TIMER("EBGhostCellInterpolator::interpolate(LD<EBCellFAB>::exchange", t4);
 
   CH_assert(m_isDefined);
   CH_assert(a_phiFine.nComp() > a_variables.end());
@@ -234,13 +232,6 @@ EBGhostCellInterpolator::interpolate(LevelData<EBCellFAB>&       a_phiFine,
     }
   }
   CH_STOP(t3);
-
-  // Fill valid regions.
-  if (a_doExchange) {
-    CH_START(t4);
-    a_phiFine.exchange(a_variables);
-    CH_STOP(t4);
-  }
 }
 
 void

--- a/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.H
+++ b/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.H
@@ -211,9 +211,11 @@ protected:
   /**
    * @brief Buffer holding the coarse-grid data on the coarsened fine grids.
    * @details This is filled by a single copyTo from the coarse level, for all the interpolated variables at
-   * once. It is sized in defineBuffers, i.e. once per regrid, and is grown if a call asks for more variables
-   * than it currently holds. Keeping it as a member avoids rebuilding an EBCellFactory and reallocating the
-   * entire coarsened-fine layout on every call.
+   * once. Keeping it as a member avoids rebuilding an EBCellFactory and reallocating the entire coarsened-fine
+   * layout on every call. It is sized in defineBuffers, i.e. once per regrid, and holds SpaceDim components:
+   * that covers the scalar and vector fields which make up every call on the hot path. The rare wider call --
+   * physics plot variables, whose count is set by the user's model -- uses a local buffer instead, so the
+   * resident footprint stays bounded regardless of how many plot variables a model declares.
    */
   mutable LevelData<EBCellFAB> m_coarsenedFineData;
 

--- a/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.H
+++ b/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.H
@@ -209,6 +209,15 @@ protected:
   Copier m_copier;
 
   /**
+   * @brief Buffer holding the coarse-grid data on the coarsened fine grids.
+   * @details This is filled by a single copyTo from the coarse level, for all the interpolated variables at
+   * once. It is sized in defineBuffers, i.e. once per regrid, and is grown if a call asks for more variables
+   * than it currently holds. Keeping it as a member avoids rebuilding an EBCellFactory and reallocating the
+   * entire coarsened-fine layout on every call.
+   */
+  mutable LevelData<EBCellFAB> m_coarsenedFineData;
+
+  /**
    * @brief Iterator over ghost cells
    */
   mutable LayoutData<VoFIterator> m_ghostIterFine;

--- a/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.H
+++ b/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.H
@@ -136,12 +136,6 @@ public:
 
   /**
    * @brief Do inhomogeneous interpolation
-   * @details This fills the fine-grid ghost cells across the coarse-fine interface, interpolating them from the
-   * coarse grid. The coarse data is fetched into an internal buffer on the coarsened fine grids, so a_phiCoar's
-   * own ghost cells are not read and need not be valid.
-   * @note This routine does not exchange, and on return a_phiFine's ghost cells are not consistent: the ones
-   * covered by a neighbouring patch on the fine level are not part of the coarse-fine region and are never
-   * filled here. The caller must exchange a_phiFine before anything reads its ghost cells.
    * @param[in,out] a_phiFine   Fine phi
    * @param[in]    a_phiCoar   Coarse phi
    * @param[in]    a_variables Variables to interpolate

--- a/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.H
+++ b/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.H
@@ -136,6 +136,12 @@ public:
 
   /**
    * @brief Do inhomogeneous interpolation
+   * @details This fills the fine-grid ghost cells across the coarse-fine interface, interpolating them from the
+   * coarse grid. The coarse data is fetched into an internal buffer on the coarsened fine grids, so a_phiCoar's
+   * own ghost cells are not read and need not be valid.
+   * @note This routine does not exchange, and on return a_phiFine's ghost cells are not consistent: the ones
+   * covered by a neighbouring patch on the fine level are not part of the coarse-fine region and are never
+   * filled here. The caller must exchange a_phiFine before anything reads its ghost cells.
    * @param[in,out] a_phiFine   Fine phi
    * @param[in]    a_phiCoar   Coarse phi
    * @param[in]    a_variables Variables to interpolate

--- a/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.cpp
+++ b/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.cpp
@@ -208,23 +208,30 @@ EBLeastSquaresMultigridInterpolator::coarseFineInterp(LevelData<EBCellFAB>&     
 
   const int numVars = a_variables.size();
 
-  // Grow the buffer if this call interpolates more variables than it was sized for. In steady state this does
-  // not trigger, so the buffer is allocated once per regrid.
-  if (m_coarsenedFineData.nComp() < numVars) {
-    m_coarsenedFineData.define(m_eblgCoFi.getDBL(), numVars, m_ghostVectorCoFi, EBCellFactory(m_eblgCoFi.getEBISL()));
+  // The member buffer holds SpaceDim components, which covers every caller on the hot path. A call that asks
+  // for more takes a local buffer, so the resident footprint stays bounded while every call still fetches its
+  // variables in one round trip.
+  const bool wideCall = numVars > m_coarsenedFineData.nComp();
+
+  LevelData<EBCellFAB> wideBuffer;
+
+  if (wideCall) {
+    wideBuffer.define(m_eblgCoFi.getDBL(), numVars, m_ghostVectorCoFi, EBCellFactory(m_eblgCoFi.getEBISL()));
   }
+
+  LevelData<EBCellFAB>& phiCoFi = wideCall ? wideBuffer : m_coarsenedFineData;
 
   // Fetch all the coarse-grid variables in one round trip rather than one per variable. The buffer holds the data on
   // the coarse grid cells around each fine-grid patch, i.e. it is a LOCAL view of the coarse grid around each
   // fine-level patch, so we can apply the stencils directly.
-  a_phiCoar.copyTo(a_variables, m_coarsenedFineData, Interval(0, numVars - 1), m_copier);
+  a_phiCoar.copyTo(a_variables, phiCoFi, Interval(0, numVars - 1), m_copier);
 
   // Interpolate all variables near the EB.
   for (int icomp = a_variables.begin(); icomp <= a_variables.end(); icomp++) {
     const int coarComp = icomp - a_variables.begin();
 
     // Do regular interpolation as if the EB is not there.
-    this->regularCoarseFineInterp(a_phiFine, m_coarsenedFineData, icomp, coarComp);
+    this->regularCoarseFineInterp(a_phiFine, phiCoFi, icomp, coarComp);
 
     // Go through each grid patch and the to-be-interpolated ghost cells across the refinement boundary. We simply
     // apply the stencils here.
@@ -234,7 +241,7 @@ EBLeastSquaresMultigridInterpolator::coarseFineInterp(LevelData<EBCellFAB>&     
 
       EBCellFAB&       dstFine = a_phiFine[din];
       const EBCellFAB& srcFine = a_phiFine[din];
-      const EBCellFAB& srcCoar = m_coarsenedFineData[din];
+      const EBCellFAB& srcCoar = phiCoFi[din];
 
       // Apply the coarse and fine stencils
       constexpr int numComp = 1;
@@ -416,8 +423,9 @@ EBLeastSquaresMultigridInterpolator::defineBuffers() noexcept
 
   m_copier.define(m_eblgCoar.getDBL(), m_eblgCoFi.getDBL(), m_ghostVectorCoFi);
 
-  // One component to begin with -- coarseFineInterp() grows the buffer if it is asked for more variables.
-  m_coarsenedFineData.define(m_eblgCoFi.getDBL(), 1, m_ghostVectorCoFi, EBCellFactory(m_eblgCoFi.getEBISL()));
+  // SpaceDim components covers every caller on the hot path; coarseFineInterp() falls back to a local buffer
+  // for the rare wider call.
+  m_coarsenedFineData.define(m_eblgCoFi.getDBL(), SpaceDim, m_ghostVectorCoFi, EBCellFactory(m_eblgCoFi.getEBISL()));
 }
 
 void

--- a/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.cpp
+++ b/Source/AmrMesh/CD_EBLeastSquaresMultigridInterpolator.cpp
@@ -206,20 +206,25 @@ EBLeastSquaresMultigridInterpolator::coarseFineInterp(LevelData<EBCellFAB>&     
   const DataIterator dit  = a_phiFine.dataIterator();
   const int          nbox = dit.size();
 
-  LevelData<EBCellFAB> phiCoFi(m_eblgCoFi.getDBL(), 1, m_ghostVectorCoFi, EBCellFactory(m_eblgCoFi.getEBISL()));
+  const int numVars = a_variables.size();
 
-  // Interpolate all variables near the EB. We will copy a_phiCoar to phiCoFi which holds the data on the coarse grid
-  // cells around each fine-grid patch. Note that phiCoFi provides a LOCAL view of the coarse grid around each
+  // Grow the buffer if this call interpolates more variables than it was sized for. In steady state this does
+  // not trigger, so the buffer is allocated once per regrid.
+  if (m_coarsenedFineData.nComp() < numVars) {
+    m_coarsenedFineData.define(m_eblgCoFi.getDBL(), numVars, m_ghostVectorCoFi, EBCellFactory(m_eblgCoFi.getEBISL()));
+  }
+
+  // Fetch all the coarse-grid variables in one round trip rather than one per variable. The buffer holds the data on
+  // the coarse grid cells around each fine-grid patch, i.e. it is a LOCAL view of the coarse grid around each
   // fine-level patch, so we can apply the stencils directly.
-  for (int icomp = a_variables.begin(); icomp <= a_variables.end(); icomp++) {
-    const Interval srcInterv = Interval(icomp, icomp);
-    const Interval dstInterv = Interval(m_comp, m_comp);
+  a_phiCoar.copyTo(a_variables, m_coarsenedFineData, Interval(0, numVars - 1), m_copier);
 
-    // Copy to buffer
-    a_phiCoar.copyTo(srcInterv, phiCoFi, dstInterv, m_copier);
+  // Interpolate all variables near the EB.
+  for (int icomp = a_variables.begin(); icomp <= a_variables.end(); icomp++) {
+    const int coarComp = icomp - a_variables.begin();
 
     // Do regular interpolation as if the EB is not there.
-    this->regularCoarseFineInterp(a_phiFine, phiCoFi, icomp, 0);
+    this->regularCoarseFineInterp(a_phiFine, m_coarsenedFineData, icomp, coarComp);
 
     // Go through each grid patch and the to-be-interpolated ghost cells across the refinement boundary. We simply
     // apply the stencils here.
@@ -229,12 +234,12 @@ EBLeastSquaresMultigridInterpolator::coarseFineInterp(LevelData<EBCellFAB>&     
 
       EBCellFAB&       dstFine = a_phiFine[din];
       const EBCellFAB& srcFine = a_phiFine[din];
-      const EBCellFAB& srcCoar = phiCoFi[din];
+      const EBCellFAB& srcCoar = m_coarsenedFineData[din];
 
       // Apply the coarse and fine stencils
       constexpr int numComp = 1;
       CH_START(t1);
-      m_aggCoarStencils[din]->apply(dstFine, srcCoar, m_comp, icomp, numComp, false);
+      m_aggCoarStencils[din]->apply(dstFine, srcCoar, coarComp, icomp, numComp, false);
       CH_STOP(t1);
 
       CH_START(t2);
@@ -410,6 +415,9 @@ EBLeastSquaresMultigridInterpolator::defineBuffers() noexcept
   CH_TIME("EBLeastSquaresMultigridInterpolator::defineBuffers()");
 
   m_copier.define(m_eblgCoar.getDBL(), m_eblgCoFi.getDBL(), m_ghostVectorCoFi);
+
+  // One component to begin with -- coarseFineInterp() grows the buffer if it is asked for more variables.
+  m_coarsenedFineData.define(m_eblgCoFi.getDBL(), 1, m_ghostVectorCoFi, EBCellFactory(m_eblgCoFi.getEBISL()));
 }
 
 void


### PR DESCRIPTION
Phase A of #710.

# Summary

### Background

`AmrMesh::interpGhost` / `interpGhostPwl` / `interpGhostMG` fill the fine-grid ghost cells across each
coarse-fine interface by walking the AMR hierarchy finest-to-coarsest. Every level in that loop does a
blocking `copyTo` to pull the coarse data onto the coarsened fine grids, and the hierarchy is exchanged
afterwards. That gives one blocking `MPI_Waitall` pair per level, which is the pattern #710 is about.

Two things made it worse than the level count alone implies:

1. Both interpolators sized their coarsened-fine buffer with `nComp = 1`
   (`CD_EBGhostCellInterpolator.cpp:183`, `CD_EBLeastSquaresMultigridInterpolator.cpp:209`). Interpolating a
   `C`-component field therefore ran a separate blocking `copyTo` per component, i.e. a second serialisation
   nested inside the level loop. The buffer itself was constructed inside `interpolate` /
   `coarseFineInterp`, so every call rebuilt an `EBCellFactory` and reallocated the whole coarsened-fine
   layout.
2. `EBGhostCellInterpolator::interpolate` ends with `a_phiFine.exchange(a_variables)`, and
   `interpGhostPwl` then exchanges every level again — a strict superset, since the trailing call also
   covers level 0. Nothing consumes the per-level exchange in between: `defineBuffers` builds `m_copier`
   from the coarse level's *valid* region only, so level ℓ never reads level ℓ−1's ghost cells, and the
   loop is descending, so no level is revisited after its own exchange.

Blocking `MPI_Waitall` counts for `L` levels and `C` components, before and after:

| Call | Before | After |
|---|---|---|
| `interpGhostPwl(EBAMRCellData, …)` | 2[(L−1)(C+1) + L] | 2[(L−1) + L] |
| `interpGhostMG(EBAMRCellData, …)` | 2[(L−1)C + L] | 2[(L−1) + L] |
| the `MFAMRCellData` variants | double the above | double the above |

For the `SpaceDim`-component gradient interpolated at `CD_CdrPlasmaStepper.cpp:498` in 3-D with L=5, that
is 42 waits down to 18.

This is the first tier of #710 by blast radius, not by size of win: it is local to this repository, leaves
results bit-identical, and does not change which ranks talk to each other or in what order. Nothing in it
depends on the `FusedCopier` work in phases B and C.

### Solution

Covers **A1**, **A2** and **A3** from the #710 checklist.

**A1 — one round trip per call instead of one per component.** Both interpolators now size the
coarsened-fine buffer to `a_variables.size()` and issue a single
`a_phiCoar.copyTo(a_variables, phiCoFi, Interval(0, numVars - 1), m_copier)` outside the component loop.
The per-component work that follows reads component `icomp - a_variables.begin()` of the buffer instead of
component 0; in the MG path that is also the source component handed to
`m_aggCoarStencils[din]->apply`, which was previously the hardwired `m_comp`.

**A2 — no duplicate exchange in the PWL path.** `EBGhostCellInterpolator::interpolate` takes a new
`bool a_doExchange = true`. `AmrMesh::interpGhostPwl(EBAMRCellData, …)` passes `false` because it exchanges
the whole hierarchy right after the loop. `AmrMesh::interpGhost(LevelData<EBCellFAB>&, …)` calls
`interpolate` directly and has no trailing exchange of its own, so it keeps the default and is unaffected.

**A3 — the buffer is a member, sized once per regrid.** `m_coarsenedFineData` is defined in
`defineBuffers()` rather than constructed per call. It holds `SpaceDim` components, which covers every
caller on the hot path: velocities, electric fields and fluxes are `SpaceDim`-component, densities and
potentials are scalars. A call that asks for more takes a local buffer for the duration of the call. Both
paths still fetch every variable in a single `copyTo`, so the round-trip count is the same either way.

A hard cap on the member was not an option: `CdrPlasmaStepper::computePhysicsPlotVars` runs the physics
plot variables through `interpGhostPwl`, and their count comes from the user's plasma model, so it exceeds
`SpaceDim` for most chemistries. Sizing the member to the widest `Interval` ever requested was not either —
the interpolators are shared per realm, phase and level, so that is a max over every caller for the rest of
the regrid rather than a current, and one wide plot-variable call would pin it there.

**Drive-by.** The three `MFAMRCellData` ghost-interpolation variants had their own per-level
`MultifluidAlias::aliasMF` loop, which is line-for-line what `AmrMesh::alias(EBAMRCellData, phase,
MFAMRCellData)` already does a few hundred lines up in the same file. They now call `allocatePointer` and
`alias` instead. This also fixes an allocation each of them was doing unconditionally: they `new`-ed
`2(L+1)` `LevelData<EBCellFAB>` shells per call and then populated only the phases that have an EB index
space, so a gas-only run allocated half of them for nothing.

### Side-effects

- **Memory.** Each `EBGhostCellInterpolator` and `EBLeastSquaresMultigridInterpolator` now holds a resident
  `SpaceDim`-component coarsened-fine `LevelData<EBCellFAB>` from `defineBuffers()` until the next regrid,
  where before the storage was transient. The coarsened-fine layout is `1/2^SpaceDim` of the fine level per
  component, per level, per phase, per realm. In exchange, the per-call `EBCellFactory` construction and
  layout allocation are gone from the hot path.
- **API.** `EBGhostCellInterpolator::interpolate` gains a defaulted trailing argument. Existing callers
  compile and behave unchanged.
- **Results.** Bit-identical. The interpolation stencils, the data that reaches them, and the order in
  which ranks communicate are all unchanged; only the number of round trips carrying that data differs.
- **Timers.** `EBGhostCellInterpolator::interpolate` reports `buffer_define`, `copy_exchange`,
  `interp_cells` and `exchange` — the old `regular_cells` / `irregular_cells` split is gone, since the two
  now run inside one OpenMP region over the patches.
- The rest of the #710 checklist is untouched: **A4**, **A5**, the **M0** measurement, and all of phases B
  and C remain open.

### Alternative solutions

- **A4 as written in #710** — hold the MF alias shells as reusable members on `AmrMesh` — was implemented
  and then reverted. It saved one `LevelData` construction plus one `RefCountedPtr` counter per level per
  phase and nothing else: `LevelData::define` has no early-out for an unchanged layout, so every `aliasMF`
  call clears and rebuilds the exchange copier — a neighbour walk over every local box, allocating a
  `MotionItem` per pair — and re-runs `allocateGhostVector`. Two `malloc`s against O(boxes × neighbours)
  that are paid either way did not justify mutable state on `AmrMesh`. `CD_AmrMesh.H` is unchanged from
  `main`.
- **Widening the member buffer on demand and keeping it wide** was the first version of A3. See above for
  why it is a max rather than a current.
- **Deleting the per-level exchange outright** instead of guarding it with `a_doExchange` does not work:
  `AmrMesh::interpGhost(LevelData<EBCellFAB>&, …)` calls `interpolate` directly and relies on it. Moving
  the exchange into that caller was the other option; the flag keeps the "interpolate leaves valid ghost
  cells filled" contract as the default, so a new caller has to opt out deliberately.
- **Fusing the (L−1) `copyTo`s into one schedule** is the actual win in #710, but it is phase C. This PR
  deliberately stops at the point where the remaining round trips are one per level, which is the input
  that phase C's operation list is built from.

### PR-review checklist

Mandatory:

- [x] I have run the test suite and made sure that it passed.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information.
- [x] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [ ] I have run clang-tidy and fixed all reported errors.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
