### PR TITLE
Bump Chombo: stop rebuilding the exchange Copier on every exchange, and reorder the exchange waits

### DIFF
--- a/Exec/Tests/tests.py
+++ b/Exec/Tests/tests.py
@@ -19,12 +19,12 @@ if sys.version_info < MIN_PYTHON:
 # --------------------------------------------------
 parser = argparse.ArgumentParser()
 
-parser.add_argument('--compile',   help="Compile executables.",           action='store_true')
-parser.add_argument('--silent',    help="Turn off unnecessary output.",   action='store_true')
-parser.add_argument('--clean',     help="Do a clean compile.",            action='store_true')
-parser.add_argument('--benchmark', help="Generate benchmark files only.", action='store_true')
-parser.add_argument('--no_exec',   help="Do not run executables.",        action='store_true')
-parser.add_argument('--compare',   help="Turn off HDF5 comparisons",      action='store_true')
+parser.add_argument('--compile',   help="Compile executables.",                          action='store_true')
+parser.add_argument('--silent',    help="Turn off unnecessary output.",                  action='store_true')
+parser.add_argument('--clean',     help="Do a clean compile.",                           action='store_true')
+parser.add_argument('--benchmark', help="Generate benchmark files only.",                action='store_true')
+parser.add_argument('--no_exec',   help="Do not run executables.",                       action='store_true')
+parser.add_argument('--compare',   help="Compare output against benchmarks (h5diff).",   action='store_true')
 parser.add_argument('-mpi',        help="Use MPI or not",         type=str, default=None,  required=False)
 parser.add_argument('-petsc',      help="Compile with PETSC",     type=str, default=None,  required=False)
 parser.add_argument('-hdf',        help="Use HDF5 or not",        type=str, default=None,  required=False)


### PR DESCRIPTION
Phase B of #710, part 1 of 2. This bumps the Chombo submodule; the caller that uses the new API (B1) follows in a separate PR.

# Summary

### Background

`EBAMRData<T>::exchange()` runs one complete MPI round per AMR level, which is what #710 is about. Working through phase B — *reorder existing MPI calls, results still bit-identical* — turned up a Chombo bug that is independent of the reordering and probably worth more than it.

`Copier::exchangeDefine()` opens with `clear()`, which sets `m_isDefined = false`, and never sets it back. Every other `define()` in the class sets it on the way out. So `isDefined()` is permanently **false** for an exchange `Copier`, and `LevelData::exchange()`'s lazy guard

```cpp
if (!m_exchangeCopier.isDefined())
  m_exchangeCopier.exchangeDefine(m_disjointBoxLayout, m_ghost);
```

fires on **every single call**: `clear()` returns every `MotionItem` to the static pool, a `NeighborIterator` walk over every local box rebuilds them, then a sort — for a schedule that was already sitting there and cannot have gone stale. `LevelData::define()` already calls `m_exchangeCopier.clear()` before re-pointing the layout, so the invalidation side was always correct. Only the flag was missing.

That is per exchange, per level, everywhere in the code base.

It is also what makes handing the Copier out to a caller unsafe, which is why the API split (#26) cannot land ahead of it: `exchangeCopier()` returns a reference to the schedule, and a second call re-entered `exchangeDefine`, freeing the `MotionItem`s that in-flight `CopierBuffer::bufEntry::item` pointers still referenced. The symptom was a SIGSEGV in `BaseEBCellFAB<double>::linearIn` under `unpackReceivesToMe`.

### Solution

Bumps `Submodules/Chombo-3.3` from `8707945` to `f87edbf`, picking up three PRs against `chombo-discharge/Chombo-3.3`, merged in the required order:

| Chombo PR | Change | Reach |
|---|---|---|
| [#25](https://github.com/chombo-discharge/Chombo-3.3/pull/25) | `exchangeDefine` sets `m_isDefined` | every `LevelData::exchange()` |
| [#26](https://github.com/chombo-discharge/Chombo-3.3/pull/26) | split `exchangeBegin` into `exchangePost`/`exchangeLocal`, add `exchangeCopier()` | pure addition, no current caller |
| [#27](https://github.com/chombo-discharge/Chombo-3.3/pull/27) | `makeItSoEnd` unpacks receives before waiting on sends | every `copyTo` and every `exchange` |

#27's argument: `writeSendDataFromMeIntoBuffers` has already copied the outgoing data into the Copier's send buffer, so unpacking cannot disturb a send that is still in flight, and the send-side `MPI_Waitall` comes off the critical path. By the time the receives have landed the sends have almost always drained anyway.

#26 is inert here — nothing in chombo-discharge calls the new entry points yet. It is included because B1 needs it and because splitting the bump into three would mean three clean rebuilds of Chombo for no benefit.

Also fixes an inverted help string in `Exec/Tests/tests.py`. `--compare` reads *"Turn off HDF5 comparisons"*, but the code is `elif not args.benchmark and args.compare:` — comparisons run only when the flag is **passed**. Without it the suite builds and runs every test and diffs nothing, which is indistinguishable from a clean pass. That flag is load-bearing for the verification below, so it is fixed here rather than separately.

### Side-effects

- **This is the PR that changes behaviour, not the B1 caller that follows it.** #25 and #27 affect every exchange and every `copyTo` in the code base. B1 is one file and provably bit-identical.
- **Results are expected to be bit-identical, with no tolerance to fall back on.** None of the three changes reassociates a floating-point operation, so any `h5diff` hit is a real defect — a stale cached copier — rather than numerical noise. That makes the check clean pass/fail.
- The failure mode #25 could in principle introduce is a stale schedule: a path that changes a `LevelData`'s layout or ghost vector without going through `define()`. None exists — `m_disjointBoxLayout` and `m_ghost` are set only in the constructor and `define()`, and `define()` clears the copier first.
- `LevelData::define()` skips building the exchange copier for periodic domains. chombo-discharge does not use periodic BCs, so that branch is never taken and the copier is always built by `define()` — which makes #25 purely *stop rebuilding what `define()` already built*.
- No measurement yet. #710's M0 is still open, and nothing here should be merged on a performance claim.

**Verification status: in progress at the time of opening.** Benchmarks were generated from a clean build of the pre-bump tree (`f44e5968` + Chombo `8707945`), 12 MPI ranks, `OPT=HIGH`; 2-D is complete (44 of 49 tests — the other five emit no HDF5 output at all), 3-D is running. The comparison pass against this bump follows. Earlier, the same bit-identity check was done by hand on `AdvectionDiffusion/Godunov` `regression2d` at 4 ranks: all 21 plot files identical under `h5diff` against a pristine pre-change build.

Two traps worth recording for anyone reproducing this:

- `make pristine` between the two builds, never an incremental one. Chombo headers change across the bump, and an incremental rebuild leaves a large fraction of objects stale — after touching `LevelData.H`, only 324 of 526 objects rebuilt, and the resulting vtable mismatch produced segfaults that looked exactly like logic bugs.
- `-cores` sets both `make -j` and `mpirun -np`, and the rank count feeds the domain decomposition, so the benchmark run and the comparison run must use the same value.

### Alternative solutions

- **Bumping only #25, or only #25 and #27, leaving the API split for the B1 PR.** Rejected: each bump costs a full clean rebuild of Chombo, and #26 is inert without a caller, so there is nothing to be gained by separating it.
- **Folding B1 into this PR.** Rejected deliberately. The risk profiles are opposite — this PR changes behaviour globally and is unmeasured, B1 is one file and bit-identical — so keeping them apart means a regression identifies itself without bisection.
- **Making comparison the default in `tests.py` instead of fixing the help text.** The flag name and the code already agree; only the docstring was wrong. Flipping the default would change the workflow for anyone scripting the suite, which is a separate call.

### PR-review checklist

Mandatory:

- [ ] I have run the test suite and made sure that it passed.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information.
- [x] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [ ] I have run clang-tidy and fixed all reported errors.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
