### PR TITLE
Finish phase B: pipeline the AMR-wide exchange, and revert the arrival-order unpack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,13 +166,51 @@ Output goes to `pout.<rank>` files and HDF5 plot/checkpoint files in `plt/`, `ch
 
 ### Regression tests
 
-Each test directory contains `regression2d.inputs` and/or `regression3d.inputs`. These are
-the canonical reference inputs. Running with these inputs and checking that the simulation
-completes without assertion failures or NaNs is the baseline regression check.
+Each test directory contains `regression2d.inputs` and/or `regression3d.inputs`. These are the
+canonical reference inputs. Running with these inputs and checking that the simulation completes
+without assertion failures or NaNs is the baseline regression check.
 
-There is no automated regression-comparison framework in the repository yet; correctness is
-verified by visual inspection of the output or by comparison against reference solutions in
-the Sphinx documentation.
+`Exec/Tests/tests.py` automates this across the whole suite, including an exact HDF5 comparison
+(`h5diff`, no tolerance) against benchmark files. The suites are described by the `*.ini` files
+alongside it, one section per test.
+
+Benchmark files are **not** checked in — `.gitignore` excludes `*.hdf5`. They are generated with
+`--benchmark`, which writes `<benchmark>.step*.<dim>d.hdf5` into the test's `plt/` directory. So the
+workflow for a change that should not alter results is: generate benchmarks from the *pre*-change
+tree, apply the change, then compare.
+
+```bash
+# from Exec/Tests, on the pre-change tree
+python3 tests.py --compile --benchmark --silent -mpi true -hdf true -opt HIGH -debug false -dim 2 -cores 12
+
+# apply the change, rebuild, then
+python3 tests.py --compile --compare   --silent -mpi true -hdf true -opt HIGH -debug false -dim 2 -cores 12
+```
+
+Run `-dim 2` and `-dim 3` separately; `-dim` selects tests by the `dim` key in the `.ini`, and the
+two dimensions have different test sets.
+
+Pitfalls that are easy to miss and make a run look green when it is not:
+
+- **Comparison only happens if you pass `--compare`.** Without it the suite builds and runs every
+  test and diffs nothing.
+- **`-cores` sets both `make -j` and `mpirun -np`.** The rank count feeds the domain decomposition,
+  so the benchmark run and the comparison run must use the same value or everything differs for
+  unrelated reasons.
+- **A test that fails to compile is silently not compared**, and is reported the same way as a test
+  that had nothing to compare. Transient compile failures do occur. Audit coverage from the benchmark
+  files on disk rather than from the log, and retry failures individually.
+- **`--silent` sends compile stdout and stderr to `/dev/null`**, so a compile failure yields one line
+  and no diagnostic. Drop it when retrying a failure.
+- **A handful of tests emit no HDF5 output at all** and can never contribute to a comparison
+  (`Utilities/LookupTable` declares `output = invalid`). They still serve as crash checks.
+- **After any Chombo submodule change, `make pristine` before rebuilding.** An incremental build
+  leaves objects compiled against the old headers, and if the change touched a class layout the
+  resulting mismatch produces crashes that look like logic bugs.
+
+Correctness beyond bit-for-bit comparison — for changes that are *meant* to alter results — is still
+verified by inspecting the output or comparing against reference solutions in the Sphinx
+documentation.
 
 ### CI tests
 

--- a/Exec/Tests/tests.py
+++ b/Exec/Tests/tests.py
@@ -440,9 +440,15 @@ for test in config.sections():
                                         else:
                                             compare_code = subprocess.call(compare_command, shell=True)
 
-                                            if compare_code != 0:
-                                                print("\t FILES '" + regFile +  "' AND '" + benFile + "' DO NOT MATCH - REGRESSION TEST FAILED")
-                                            else:
-                                                print("\t Benchmark test succeeded for files " + regFile +  " and " + str(benFile))
+                                        # The result must be acted on whether or not --silent was passed. It used to be
+                                        # examined only in the else branch above, so under --silent a mismatch produced
+                                        # no output at all -- and ret_code was never set either way, so the suite exited
+                                        # 0 on a failed comparison. A regression harness that cannot fail is worse than
+                                        # no harness, because it is trusted.
+                                        if compare_code != 0:
+                                            ret_code = 1
+                                            print("\t FILES '" + regFile +  "' AND '" + benFile + "' DO NOT MATCH - REGRESSION TEST FAILED")
+                                        elif not args.silent:
+                                            print("\t Benchmark test succeeded for files " + regFile +  " and " + str(benFile))
 
 exit(ret_code)

--- a/Source/AmrMesh/CD_EBAMRDataImplem.H
+++ b/Source/AmrMesh/CD_EBAMRDataImplem.H
@@ -105,9 +105,48 @@ template <typename T>
 void
 EBAMRData<T>::exchange() noexcept
 {
-  for (int lvl = 0; lvl < m_data.size(); lvl++) {
-    m_data[lvl]->exchange();
+  CH_TIMERS("EBAMRData<T>::exchange()");
+  CH_TIMER("EBAMRData<T>::exchange()::post", t1);
+  CH_TIMER("EBAMRData<T>::exchange()::local", t2);
+  CH_TIMER("EBAMRData<T>::exchange()::wait", t3);
+
+  // Pipeline the hierarchy instead of running one complete MPI round per level. Every level's messages go onto
+  // the wire first, then the on-rank copies run while they are in flight, and only then does anything wait. The
+  // exposed cost is the slowest single level rather than the sum over levels, and no level's messages are held
+  // back by the on-rank work of the levels below it.
+  //
+  // This is safe because the send and receive buffers, and the MPI requests, live on the Copier -- and each
+  // level's LevelData owns its own exchange Copier. The levels therefore never alias one another's buffers.
+  // Message matching is unchanged as well: every rank still posts its levels in the same order, so MPI's
+  // non-overtaking guarantee pairs sends with receives exactly as it does when the levels run one at a time.
+  //
+  // The IntVect::Zero test is the one LevelData::exchange() makes for itself. A level with no ghost cells has
+  // nothing to exchange, so it must be skipped here rather than handed to exchangePost().
+  const int numLevels = m_data.size();
+
+  CH_START(t1);
+  for (int lvl = 0; lvl < numLevels; lvl++) {
+    if (m_data[lvl]->ghostVect() != IntVect::Zero) {
+      m_data[lvl]->exchangePost(m_data[lvl]->exchangeCopier());
+    }
   }
+  CH_STOP(t1);
+
+  CH_START(t2);
+  for (int lvl = 0; lvl < numLevels; lvl++) {
+    if (m_data[lvl]->ghostVect() != IntVect::Zero) {
+      m_data[lvl]->exchangeLocal(m_data[lvl]->exchangeCopier());
+    }
+  }
+  CH_STOP(t2);
+
+  CH_START(t3);
+  for (int lvl = 0; lvl < numLevels; lvl++) {
+    if (m_data[lvl]->ghostVect() != IntVect::Zero) {
+      m_data[lvl]->exchangeEnd();
+    }
+  }
+  CH_STOP(t3);
 }
 
 template <typename T>

--- a/Source/Driver/CD_Driver.cpp
+++ b/Source/Driver/CD_Driver.cpp
@@ -24,6 +24,7 @@
 #include <EBAMRIO.H>
 #include <EBAMRDataOps.H>
 #include <ParmParse.H>
+#include <SPMD.H>
 
 // Our includes
 #include <CD_Driver.H>
@@ -964,6 +965,12 @@ Driver::run(const Real a_startTime, const Real a_endTime, const int a_maxSteps)
     pout() << "==================================" << endl;
 
     MemoryReport::getMaxMinMemoryUsage();
+
+    // Chombo tracks the largest message it actually posted, but nothing ever printed it. Report it
+    // alongside the memory usage: it is the only way to tell whether a run comes anywhere near
+    // CH_MAX_MPI_MESSAGE_SIZE, above which a single peer's message is split across several MPI
+    // requests. A max send or receive size equal to the limit means that splitting has occurred.
+    reportMPIStats();
   }
 }
 


### PR DESCRIPTION
Completes phase B of #710, and repairs a regression that phase B put on `main`.

# Summary

### Background

`EBAMRData<T>::exchange()` walked the hierarchy calling `LevelData::exchange()` per level, so an AMR-wide exchange serialised into one complete MPI round per level. Because each level is load-balanced independently, a rank's slowest neighbour differs per level and the exposed cost is `Σ_ℓ skew_ℓ` where it could be `max_ℓ skew_ℓ`.

Phase B is defined in #710 as *reordering existing MPI calls, results still bit-identical*. Three of its four pieces are already on `main`: **B0** (cache the exchange `Copier`), **B3** (unpack receives before waiting on sends), and **B2** (unpack each peer as its message lands). This PR adds **B1**, and reverts **B2**.

### Solution

**B1 — pipeline the AMR exchange.** Three loops over the hierarchy instead of one: post every level, then run every level's on-rank copies while those messages are in flight, then wait. Posting and copying level-by-level would leave the finest level posting last *and* latest — behind every other level's local work — and it is also the level with the most data to send. Separating the loops puts its messages on the wire first.

Safe because each level's `LevelData` owns its own exchange `Copier`, and the buffers and MPI requests live on the `Copier`, so levels cannot alias one another; and every rank still posts its levels in the same order, so MPI's non-overtaking guarantee pairs sends with receives exactly as before.

**Reverts B2 (Chombo #28), which is a live regression on `main`.** It unpacked each peer's message as it landed, which reorders the writes into the destination — arrival order instead of `m_toMe` order, which is sorted by `(procID, toRegion)` and identical on every rank and every run. Unpack order is observable:

- `ListBox<T>::linearIn` **appends** particles to a list (`ListBoxI.H:449`), so unpack order *is* the particle order in each destination box, and every order-dependent particle algorithm downstream sees a different list.
- `LDaddOp::linearIn` **accumulates** (`argR += *buffer`), and floating-point addition is not associative.

Measured: **51 of 162 file comparisons differed across 21 tests** — every BrownianWalker particle test, both AdvectionDiffusion tests in 3-D, and ItoKMC/JSON3d. Bisection over Chombo #25/#26/#27/#28 put all of it on #28: byte-identical at `f87edbf`, failing at `00f7268`, same benchmarks and same caller commit.

Guarding on `LDOperator::threadSafe()` was tried and does not work — it catches `LDaddOp`, which overrides it to `false`, but not the particle path, whose operator reports `true`. Forcing the in-order unpack while keeping the rest of #28 makes all 21 tests pass, which isolates the cause to the reordering rather than the request-array layout #28 also changed. The premise is what is unsound: unpacking as messages land *is* reordering, so no predicate reconciles it with an order-sensitive `linearIn`. It also sat in `BoxLayoutData<T>`, the single unpack path for every `T`, which is how a change aimed at the AMR ghost exchange reached particle transport.

Chombo `master` carries the revert as `9bc4b45`; this bumps the submodule to it. `00f7268` is untouched and still resolvable, so the pin already in history via #717 continues to check out.

**Makes `tests.py` able to fail.** The h5diff exit code was examined only inside the non-silent branch:

```python
if args.silent:
    compare_code = subprocess.call(cmd, stdout=DEVNULL, stderr=DEVNULL)
else:
    compare_code = subprocess.call(cmd)
    if compare_code != 0:
        print(... DO NOT MATCH ...)
```

Under `--silent` a mismatch produced no output, and `ret_code` was never set in the comparison block in **either** mode, so the suite exited 0 on a failed comparison. Every `--compare` run with `--silent` was structurally incapable of reporting a difference — which is why B2 merged with a clean bill and why this regression sat on `main`. The result is now acted on regardless of `--silent`, and sets the exit status.

**Also:** `reportMPIStats()` at the end of `Driver::run`. Chombo tracked `CH_MaxMPISendSize`/`CH_MaxMPIRecvSize` on every post and nothing ever printed them. First numbers from it: largest message is 7 kB in 2-D, 27 kB in 3-D, against a 30 MiB `CH_MAX_MPI_MESSAGE_SIZE`. And a `CLAUDE.md` §2 correction — it claimed no automated regression-comparison framework exists; `tests.py` is one.

### Side-effects

- **Verification.** Benchmarks generated from a clean build of `main` with Chombo at `8707945` (no phase B), compared against this branch. 12 MPI ranks, `OPT=HIGH`, `h5diff` exact, exclusive build tree, patched harness:

| | tests | comparisons | mismatches |
|---|---|---|---|
| 2-D | 49/49 | 81 | **0** |
| 3-D | 43/43 | 81 | **0** |

  Zero compile failures, and `Benchmark file(s) not found` never fired. Since B0+B3 alone were separately confirmed at 162/162, the clean result here attributes to B1.

- **B1 is byte-identical.** An earlier report that it broke 3-D was wrong: that comparison had B2 present and a build tree being written concurrently by another session. Both causes are removed here.
- `reportMPIStats()` adds three lines of `pout` per run. `CLAUDE.md` and `tests.py` changes do not affect results.
- **Still no measurement.** #710's M0 is dropped — it needs 10k+ cores. Phase B rests on bit-identity plus the argument that exposed cost becomes the slowest level rather than the sum over levels.

### Alternative solutions

- **`exchangeBegin()` per level, then `exchangeEnd()` per level** — two loops, no need for the `exchangePost`/`exchangeLocal` split. Correct, but puts the finest level's posts behind every other level's on-rank copies.
- **Repairing B2 rather than reverting it.** Rejected: its premise is reordering, and the ordering constraint is not expressible with the predicates Chombo has. Re-siting it in the caller — or scoping it as #710 scopes C1, to `preAllocatable() < 2`, which excludes `ListBox` — would be a new design, not a patch. Its ceiling is the cost of unpacking (microseconds of memcpy at the measured payload sizes), whereas C1 removes `2L-2` blocking waits and `Σ_ℓ N_ℓ − |∪_ℓ N_ℓ|` messages.
- **Force-pushing Chombo `master` to drop B2.** Rejected: `main` pins `00f7268` through merged #717, so removing it from all branches would leave a submodule that cannot be checked out.
- **Splitting the revert into its own PR.** Reasonable, but the harness fix, the revert, and B1's verification are one incident, and separating them would land the revert without the reason it was needed.

### PR-review checklist

Mandatory:

- [x] I have run the test suite and made sure that it passed.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information.
- [x] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [ ] I have run clang-tidy and fixed all reported errors.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).
