### PR TITLE
Cut the unconditional AMR-wide work out of the ItoKMC reaction advance

### DIFF
--- a/Physics/ItoKMC/CD_ItoKMCStepper.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepper.H
@@ -1601,9 +1601,16 @@ protected:
 
   /**
    * @brief Coarsen data for CDR solvers
+   * @details Always averages the densities and source terms down the hierarchy -- the coarse valid cells
+   * are read before anything re-averages them. The ghost-cell interpolation is optional because it has no
+   * reader on the reaction-advance path: the next consumers of the density ghost cells are
+   * CdrSolver::computeDivF/computeDivD, both of which interpolate the ghost cells themselves, and the
+   * source-term ghost cells are never read at all (getSource()'s consumers -- plotting and
+   * ItoKMCBackgroundEvaluator -- are valid-cell only, and the plot path fills its own ghost cells).
+   * @param[in] a_interpGhosts Whether to interpolate the ghost cells after averaging.
    */
   virtual void
-  coarsenCDRSolvers() noexcept;
+  coarsenCDRSolvers(const bool a_interpGhosts) noexcept;
 
   /**
    * @brief Resolve particle injection at EBs.

--- a/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
+++ b/Physics/ItoKMC/CD_ItoKMCStepperImplem.H
@@ -61,24 +61,35 @@ binLeafToCells(std::vector<ParticleSoA<P, Traits>>& a_cells,
 }
 
 // Rebuild a_leaf from the per-cell scratch vector (concatenate all cells, then swap into the leaf).
+// The cells are written back in Fortran cell order, so the rebuilt leaf is cell-sorted by construction
+// and adopts the CSR mapping rather than letting the next sortByCell() rediscover it.
 template <typename P, typename Traits>
 inline void
-rebuildLeafFromCells(ParticleSoA<P, Traits>& a_leaf, const std::vector<ParticleSoA<P, Traits>>& a_cells) noexcept
+rebuildLeafFromCells(ParticleSoA<P, Traits>&                    a_leaf,
+                     const std::vector<ParticleSoA<P, Traits>>& a_cells,
+                     const Box&                                 a_box,
+                     const Real                                 a_dx,
+                     const RealVect&                            a_probLo) noexcept
 {
-  ParticleSoA<P, Traits> rebuilt;
+  CH_assert(a_cells.size() == static_cast<std::size_t>(a_box.numPts()));
 
-  // Pre-reserve the known total so the append loop allocates once instead of growing
-  // geometrically (O(log N) reallocations) on every reaction-kernel step.
-  std::size_t total = 0;
-  for (const ParticleSoA<P, Traits>& cell : a_cells) {
-    total += cell.size();
+  // Prefix-sum the per-cell counts into the CSR start offsets. This also gives the known total, so the
+  // append loop below allocates once instead of growing geometrically (O(log N) reallocations) on every
+  // reaction-kernel step.
+  std::vector<std::size_t> cellStart(a_cells.size() + 1, 0);
+  for (std::size_t c = 0; c < a_cells.size(); c++) {
+    cellStart[c + 1] = cellStart[c] + a_cells[c].size();
   }
-  rebuilt.reserve(total);
+
+  ParticleSoA<P, Traits> rebuilt;
+  rebuilt.reserve(cellStart.back());
 
   for (const ParticleSoA<P, Traits>& cell : a_cells) {
     rebuilt.append(cell);
   }
+
   a_leaf.swap(rebuilt);
+  a_leaf.adoptCellSort(a_box, a_dx * RealVect::Unit, a_probLo, std::move(cellStart));
 }
 
 } // namespace
@@ -4035,7 +4046,30 @@ ItoKMCStepper<I, C, R, F>::advanceReactionNetwork(const EBAMRCellData& a_electri
   // the photoionization products are created in reconcileParticles and  deposited them on the particle realm, but
   // the resulting products need to end up on in the correct data component in m_fluidCdrPPC.
   CH_START(t5);
+
+  // Species whose product container is empty on EVERY rank deposit identically zero, so the whole block
+  // below -- a halo deposition (which alone is ~3L-1 synchronizing stages), a cross-realm copy, and two
+  // hierarchy-wide passes -- adds nothing to m_fluidCdrPPC. Many plasma models route photoionization to
+  // Ito species rather than CDR species, in which case that is every species on every time step.
+  //
+  // The test must be global because the work being skipped is collective: every rank has to reach the
+  // same verdict for every species. One Allreduce over the whole vector answers it for all of them, and
+  // the local counts it reduces are free (the containers track their own size). Skipping leaves stale
+  // data in m_particleScratch1/m_fluidScratch1, which is harmless -- both are fully overwritten by their
+  // next user.
+  Vector<long long int> numPhotoiProducts(m_cdrPhotoiProducts.size(), 0LL);
+
   for (int i = 0; i < m_cdrPhotoiProducts.size(); i++) {
+    numPhotoiProducts[i] = static_cast<long long int>(m_cdrPhotoiProducts[i]->getNumberOfValidParticlesLocal());
+  }
+
+  ParallelOps::sum(numPhotoiProducts);
+
+  for (int i = 0; i < m_cdrPhotoiProducts.size(); i++) {
+    if (numPhotoiProducts[i] == 0LL) {
+      continue;
+    }
+
     m_cdrPhotoiProducts[i]->organizeParticlesByPatch();
 
     m_amr->depositWeight(m_particleScratch1,
@@ -4640,7 +4674,7 @@ ItoKMCStepper<I, C, R, F>::reconcileParticles(const EBCellFAB& a_newParticlesPer
 
     ParticleContainer<ItoParticle>& solverParticles = solverIt()->getParticles(ItoSolver::WhichContainer::Bulk);
 
-    rebuildLeafFromCells(solverParticles[a_level][a_din], itoCells[idx]);
+    rebuildLeafFromCells(solverParticles[a_level][a_din], itoCells[idx], a_box, a_dx, probLo);
   }
 
   for (auto solverIt = m_rte->iterator(); solverIt.ok(); ++solverIt) {
@@ -4648,14 +4682,14 @@ ItoKMCStepper<I, C, R, F>::reconcileParticles(const EBCellFAB& a_newParticlesPer
 
     ParticleContainer<Photon>& solverSourcePhotons = solverIt()->getSourcePhotons();
 
-    rebuildLeafFromCells(solverSourcePhotons[a_level][a_din], sourcePhotonCells[idx]);
+    rebuildLeafFromCells(solverSourcePhotons[a_level][a_din], sourcePhotonCells[idx], a_box, a_dx, probLo);
   }
 
   // Rebuild the CDR photoionization-product leaves from the mutated per-cell scratch.
   for (auto solverIt = m_cdr->iterator(); solverIt.ok(); ++solverIt) {
     const int idx = solverIt.index();
 
-    rebuildLeafFromCells((*m_cdrPhotoiProducts[idx])[a_level][a_din], cdrCells[idx]);
+    rebuildLeafFromCells((*m_cdrPhotoiProducts[idx])[a_level][a_din], cdrCells[idx], a_box, a_dx, probLo);
   }
 }
 
@@ -4787,7 +4821,9 @@ ItoKMCStepper<I, C, R, F>::reconcileCdrDensities(const EBAMRCellData& a_newParti
       }
     }
 
-    this->coarsenCDRSolvers();
+    // No ghost interpolation: nothing reads the density or source-term ghost cells between here and the
+    // next transport step, which fills them itself. See coarsenCDRSolvers().
+    this->coarsenCDRSolvers(false);
   }
 }
 
@@ -4868,7 +4904,7 @@ ItoKMCStepper<I, C, R, F>::reconcileCdrDensities(const EBCellFAB& a_newParticles
 
 template <typename I, typename C, typename R, typename F>
 void
-ItoKMCStepper<I, C, R, F>::coarsenCDRSolvers() noexcept
+ItoKMCStepper<I, C, R, F>::coarsenCDRSolvers(const bool a_interpGhosts) noexcept
 {
   CH_TIME("ItoKMCStepper::coarsenCDRSolvers");
   if (m_verbosity > 5) {
@@ -4884,8 +4920,10 @@ ItoKMCStepper<I, C, R, F>::coarsenCDRSolvers() noexcept
     this->m_amr->conservativeAverage(phi, phi.getRealm(), this->m_plasmaPhase);
     this->m_amr->conservativeAverage(src, src.getRealm(), this->m_plasmaPhase);
 
-    this->m_amr->interpGhostPwl(phi, phi.getRealm(), this->m_plasmaPhase);
-    this->m_amr->interpGhostPwl(src, src.getRealm(), this->m_plasmaPhase);
+    if (a_interpGhosts) {
+      this->m_amr->interpGhostPwl(phi, phi.getRealm(), this->m_plasmaPhase);
+      this->m_amr->interpGhostPwl(src, src.getRealm(), this->m_plasmaPhase);
+    }
 
     DataOps::setCoveredValue(phi, this->m_amr->getCoveredCells(phi.getRealm(), this->m_plasmaPhase), 0.0);
     DataOps::setCoveredValue(src, this->m_amr->getCoveredCells(src.getRealm(), this->m_plasmaPhase), 0.0);
@@ -5175,11 +5213,11 @@ ItoKMCStepper<I, C, R, F>::fillSecondaryEmissionEB(
       // Primaries are read-only (the physics interface takes them by const reference), so they are not written.
       for (auto it = m_ito->iterator(); it.ok(); ++it) {
         const int idx = it.index();
-        rebuildLeafFromCells((*a_secondaryParticles[idx])[lvl][din], secondaryItoCells[idx]);
+        rebuildLeafFromCells((*a_secondaryParticles[idx])[lvl][din], secondaryItoCells[idx], box, dx, probLo);
       }
       for (auto it = m_rte->iterator(); it.ok(); ++it) {
         const int idx = it.index();
-        rebuildLeafFromCells((*a_secondaryPhotons[idx])[lvl][din], secondaryPhotonCells[idx]);
+        rebuildLeafFromCells((*a_secondaryPhotons[idx])[lvl][din], secondaryPhotonCells[idx], box, dx, probLo);
       }
     }
   }

--- a/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
+++ b/Physics/ItoKMC/TimeSteppers/ItoKMCGodunovStepper/CD_ItoKMCGodunovStepperImplem.H
@@ -1893,7 +1893,7 @@ ItoKMCGodunovStepper<I, C, R, F>::stepEulerMaruyamaCDR(const Real a_dt) noexcept
     DataOps::floor(phi, 0.0, this->m_amr->getVofIterator(this->m_fluidRealm, this->m_plasmaPhase));
   }
 
-  this->coarsenCDRSolvers();
+  this->coarsenCDRSolvers(true);
 }
 
 #ifdef CH_USE_HDF5

--- a/Source/AmrMesh/CD_AmrMeshImplem.H
+++ b/Source/AmrMesh/CD_AmrMeshImplem.H
@@ -122,14 +122,17 @@ AmrMesh::copyData(LevelData<T>&       a_dst,
       CH_assert(a_src.ghostVect() == m_numGhostCells * IntVect::Unit);
     }
 
-    Copier copier;
+    // Point at the cached Copier rather than copy-assigning it: Copier::operator= pool-allocates a fresh
+    // MotionItem for every entry in all three motion plans, which on this (very hot, generic) path is a
+    // per-level allocation loop paid on every cross-realm copy. copyTo() only ever reads it.
+    const Copier* copier = nullptr;
 
     if (a_fromRegion == CopyStrategy::Valid) {
       if (a_toRegion == CopyStrategy::Valid) {
-        copier = m_validToValidRealmCopiers.at(id)[a_level];
+        copier = &m_validToValidRealmCopiers.at(id)[a_level];
       }
       else if (a_toRegion == CopyStrategy::ValidGhost) {
-        copier = m_validToValidGhostRealmCopiers.at(id)[a_level];
+        copier = &m_validToValidGhostRealmCopiers.at(id)[a_level];
       }
       else {
         MayDay::Abort("AmrMesh::copyData - logic bust 1");
@@ -137,10 +140,10 @@ AmrMesh::copyData(LevelData<T>&       a_dst,
     }
     else if (a_fromRegion == CopyStrategy::ValidGhost) {
       if (a_toRegion == CopyStrategy::Valid) {
-        copier = m_validGhostToValidRealmCopiers.at(id)[a_level];
+        copier = &m_validGhostToValidRealmCopiers.at(id)[a_level];
       }
       else if (a_toRegion == CopyStrategy::ValidGhost) {
-        copier = m_validGhostToValidGhostRealmCopiers.at(id)[a_level];
+        copier = &m_validGhostToValidGhostRealmCopiers.at(id)[a_level];
       }
       else {
         MayDay::Abort("AmrMesh::copyData - logic bust 2");
@@ -150,7 +153,7 @@ AmrMesh::copyData(LevelData<T>&       a_dst,
       MayDay::Abort("AmrMesh::copyData - logic bust 3");
     }
 
-    a_src.copyTo(a_srcComps, a_dst, a_dstComps, copier);
+    a_src.copyTo(a_srcComps, a_dst, a_dstComps, *copier);
   }
   else {
     a_src.localCopyTo(a_srcComps, a_dst, a_dstComps);

--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <array>
 #include <unordered_set>
+#include <vector>
 
 // Chombo includes
 #include <CH_Timer.H>
@@ -3948,6 +3949,12 @@ ItoSolver::extractIntoMergeContainer(const WhichContainer a_container, ParticleC
 
   m_amr->allocate(a_merge, m_realm);
 
+  // Cell-sort metadata of the source container, so a leaf that is already cell-sorted can hand its CSR
+  // mapping straight to its reduced copy (see below). These are the same values organizeParticlesByCell()
+  // sorts against, so an adopted mapping is indistinguishable from a re-derived one.
+  const Vector<RealVect> particleDx     = particles.getDx();
+  const RealVect         particleProbLo = particles.getProbLo();
+
   // Extract into the SAME patch (positions unchanged => ownership unchanged => no remap needed).
   for (int lvl = 0; lvl <= m_amr->getFinestLevel(); lvl++) {
     const DisjointBoxLayout& dbl  = m_amr->getGrids(m_realm)[lvl];
@@ -3960,6 +3967,17 @@ ItoSolver::extractIntoMergeContainer(const WhichContainer a_container, ParticleC
       ParticleSoA<ItoParticle>& itoLeaf = particles[lvl][din];
 
       ParticleSoA<ItoMergeParticle>& mergeLeaf = a_merge[lvl][din];
+
+      // The copy below preserves the particle order exactly, so a cell-sorted source hands its CSR
+      // mapping to the reduced copy rather than making the cell-based merges re-derive it with a full
+      // counting sort (applyCellMerger() cell-sorts a_merge before it can index the per-cell ranges).
+      // Snapshot the offsets before the loop -- itoLeaf is cleared at the end of this iteration.
+      const bool               adoptSort = itoLeaf.isSortedAgainst(dbl[din], particleDx[lvl], particleProbLo);
+      std::vector<std::size_t> cellStart;
+
+      if (adoptSort) {
+        cellStart = itoLeaf.cellOffsets();
+      }
 
       // Exact, not geometric: growTo() doubles from 16, so a leaf built by repeated append() carries up
       // to 2x overshoot, while the final count is known here and reserve() sets the capacity exactly.
@@ -3976,6 +3994,10 @@ ItoSolver::extractIntoMergeContainer(const WhichContainer a_container, ParticleC
         // particle that merely passes through. rankID is left alone -- nothing in-tree reads it on an
         // ItoParticle, and it is already -1 after any merge.
         mergeLeaf.particleID(mergeLeaf.size() - 1) = itoLeaf.particleID(i);
+      }
+
+      if (adoptSort && mergeLeaf.size() == itoLeaf.size()) {
+        mergeLeaf.adoptCellSort(dbl[din], particleDx[lvl], particleProbLo, std::move(cellStart));
       }
 
       // Release this patch's ItoParticle arena as soon as its reduced copy exists, rather than clearing

--- a/Source/Particle/CD_ParticleSoA.H
+++ b/Source/Particle/CD_ParticleSoA.H
@@ -905,13 +905,20 @@ public:
   }
 
   /**
-   * @brief Drop all particles (keeps the arena; invalidates the cell sort).
+   * @brief Drop all particles (keeps the arena; invalidates the cell sort unless there was nothing to drop).
+   * @details An already-empty container's CSR mapping is all-zero regardless of the cells it was built
+   * against, so dropping nothing cannot invalidate it. Keeping the flag in that case is what lets a
+   * repeatedly-cleared container (e.g. the ItoKMC photoionization products, cleared and re-sorted every
+   * time step) take sortByCell()'s early-out instead of paying an O(cells) offset rebuild per step.
    */
   void
   clear() noexcept
   {
-    m_size   = 0;
-    m_sorted = false;
+    if (m_size > 0) {
+      m_sorted = false;
+    }
+
+    m_size = 0;
   }
 
   /**
@@ -1566,6 +1573,53 @@ public:
     for (std::size_t i = range.first; i < range.second; i++) {
       a_out.appendParticle(*this, i);
     }
+  }
+
+  /**
+   * @brief The raw CSR start offsets (valid after sortByCell(); a_box.numPts()+1 entries).
+   * @details Exposed so that a caller which is about to reproduce this container's particle order in
+   * another container can hand the mapping straight to adoptCellSort() instead of re-deriving it with a
+   * counting sort. Use the cellStart()/cellRange() accessors for ordinary per-cell indexing.
+   * @return The CSR start offsets.
+   */
+  const std::vector<std::size_t>&
+  cellOffsets() const noexcept
+  {
+    CH_assert(m_sorted);
+
+    return m_cellStart;
+  }
+
+  /**
+   * @brief Declare the container cell-sorted against (a_box, a_dx, a_probLo) with a caller-supplied CSR.
+   * @details For callers that lay the particles out in Fortran cell order themselves and therefore
+   * already know the mapping -- concatenating per-cell scratch containers back into a leaf, or copying a
+   * sorted leaf particle-for-particle into a container with a different payload. sortByCell() would
+   * rediscover exactly this mapping at the cost of a key pass, a prefix sum and a full column permute;
+   * adopting it costs a move. The caller owns the precondition that every particle really does lie in the
+   * cell its offsets claim -- it is checked by the same debug-mode verifier that guards sortByCell()'s
+   * early-out, and is compiled out in optimized builds.
+   * @param[in] a_box       Patch box defining the cells.
+   * @param[in] a_dx        Grid spacing per direction.
+   * @param[in] a_probLo    Physical coordinate of the lower domain corner.
+   * @param[in] a_cellStart CSR start offsets: a_box.numPts()+1 non-decreasing entries, ending at size().
+   */
+  void
+  adoptCellSort(const Box&               a_box,
+                const RealVect&          a_dx,
+                const RealVect&          a_probLo,
+                std::vector<std::size_t> a_cellStart) noexcept
+  {
+    CH_assert(a_cellStart.size() == static_cast<std::size_t>(a_box.numPts()) + 1);
+    CH_assert(a_cellStart.back() == m_size);
+
+    m_cellStart  = std::move(a_cellStart);
+    m_sortBox    = a_box;
+    m_sortDx     = a_dx;
+    m_sortProbLo = a_probLo;
+    m_sorted     = true;
+
+    CH_assert(this->checkCellSort(a_box, a_dx, a_probLo));
   }
 
   ///@}


### PR DESCRIPTION
# Summary

`ItoKMCStepper::advanceReactionNetwork` spent almost none of its time on chemistry: the KMC kernels were ~8% of the call while `reconcileCdrDensities` and the photoionization deposit preceding it were ~75%, because both performed AMR-wide, communication-bound work unconditionally. This PR makes that work conditional on there being something to do, and stops three separate places from rediscovering information they already had.

Closes #715 

### Background

Coarse `CD_Timer` instrumentation of `ItoKMCGodunovStepper::advance` on ~470 ranks gave this split of one reaction advance (see #715 for the full table and its caveats):

| Event | Loc. (s) | Loc. (%) |
|---|---|---|
| Compute PPC | 0.0037 | 0.63 |
| Copy PPC back | 0.0001 | 0.02 |
| KMC kernels | 0.0474 | 8.12 |
| Reconcile particles | 0.0925 | 15.84 |
| **Reconcile CDR** | **0.4399** | **75.38** |

Part of the 0.44 s is load-imbalance absorption rather than work — `Reconcile CDR` is the first region after two badly imbalanced compute phases and is full of collectives — so the number is an upper bound. Separating wait from work needs timed barriers and is not attempted here.

### Solution

**Skip the photoionization deposit for CDR species with no products.** The photoionization products are *point particles*: `ItoKMCPhysics::reconcilePhotoionization` appends one per target species at the absorbed photon's position, and only afterwards are they deposited on the mesh and added into `m_fluidCdrPPC`. `m_cdrPhotoiProducts` is sized `numCdrSpecies` unconditionally, so a container exists for every CDR solver whether or not any photo-reaction can ever populate it. An empty container deposits identically zero, so the whole block — a `CoarseFineDeposition::Halo` deposit (roughly `3L-1` synchronizing stages per species), a cross-realm `copyData`, and hierarchy-wide `volumeScale`/`incr` — adds nothing. The test is a single `ParallelOps::sum` over the whole species vector, because the work being skipped is collective and every rank must reach the same verdict. It is a per-species, per-step runtime question, not an inspection of the reaction set: it covers both a species no photo-reaction targets and a step in which no photon was absorbed into that channel.

**Make the ghost-cell interpolation in `coarsenCDRSolvers()` optional.** The function is called at least twice per time step and ran four hierarchy sweeps per CDR solver. Two of them have no reader on the reaction path: the next consumers of the density ghost cells are `CdrSolver::computeDivF`/`computeDivD`, both documented as interpolating ghost cells themselves, and the source-term ghost cells are never read at all (`getSource()`'s consumers — plotting and `ItoKMCBackgroundEvaluator` — are valid-cell only, and the plot path fills its own). Both `conservativeAverage` calls are kept: `computeCdrConductivity` reads coarse valid cells before anything re-averages them. The transport-step call keeps its current behaviour.

**Stop rediscovering cell sorts that are already known.** Three linked changes:

- `ParticleSoA::clear()` no longer invalidates the sort when there was nothing to drop. An already-empty leaf's CSR is all-zero regardless of the cells it was built against, so `sortByCell()` was falling through its early-out and rebuilding `nCells+1` offsets per patch, per level, per species, per step on containers that are empty by construction.
- `rebuildLeafFromCells` writes the per-cell scratch back in Fortran cell order, so the rebuilt leaf *is* cell-sorted; it now prefix-sums the per-cell counts it already walks and adopts the mapping instead of swapping in an unsorted container.
- `ItoSolver::extractIntoMergeContainer` copies particles in index order, so the reduced `ItoMergeParticle` leaf has the same CSR as its `ItoParticle` source. Carrying it across lets `applyCellMerger`'s `organizeParticlesByCell()` take its early-out, removing a full counting sort plus column permute per species, per patch, per merge step. All four cell-based merge methods route through `applyCellMerger`.

**Stop deep-copying the `Copier` in `AmrMesh::copyData`.** `Copier::operator=` pool-allocates a fresh `MotionItem` for every entry in all three motion plans, so the cached copier was rebuilt on every cross-realm copy. Holding a `const Copier*` and dereferencing at the `copyTo` is free and sits on a hot generic path used across the code base.

### Side-effects

- **`ItoKMCStepper::coarsenCDRSolvers()` changes signature** to `coarsenCDRSolvers(const bool a_interpGhosts)`. It is `virtual`; there are no in-tree overrides, but this is a compile-visible break for any downstream subclass that overrides it.
- **`ParticleSoA` gains two methods**, `adoptCellSort()` (3 uses) and `cellOffsets()` (1 use). No new types or containers are introduced: the early-out uses the existing `Vector<long long int>` with the existing `ParallelOps::sum` overload, and `adoptCellSort()` writes the CSR fields `sortByCell()` already maintains rather than adding a parallel representation. `adoptCellSort()` asserts the adopted mapping against `checkCellSort()`, the same debug-mode verifier that guards `sortByCell()`'s own early-out, so a caller that lays particles out inconsistently fails loudly in a `DEBUG` build instead of silently mis-binning them.
- Skipping the deposit leaves stale data in `m_particleScratch1`/`m_fluidScratch1`. Nothing reads them — both are fully overwritten by their next user.
- The expected gain is in MPI-synchronizing stages rather than FLOPs, and the photoionization early-out only pays off for models that route photoionization to Ito species (or to a subset of the CDR species). No performance measurement at scale is included in this PR; the numbers above are the pre-change profile only.

### Alternative solutions 

- **Precompute which CDR species can ever receive photoionization products**, from the reaction set at define time, instead of testing the containers each step. Rejected: it would miss the transient case (a species that can receive products but received none this step), it would need invalidating whenever the physics is redefined, and the runtime test costs one `Allreduce` of a vector already sized by the species count.
- **Drop the two `interpGhostPwl` calls from `coarsenCDRSolvers()` outright** rather than making them conditional. Rejected: the transport-step caller is not covered by the same reasoning, and a flag keeps that path bit-for-bit unchanged.
- **Move `conservativeAverage(src)` to the plot path**, since the source term matters only for output fidelity. Not done here — it is a behavioural question about what a checkpoint should contain, not a redundancy.
- **Make `sortByCell()` cheap for empty containers** instead of preserving the sorted-empty state through `clear()`. Rejected: the all-zero CSR still has to be materialized for the right cell count, so the O(cells) fill remains; keeping the state is what actually removes it.
- **Leave `rebuildLeafFromCells` unsorted and only fix `clear()`**, as originally sketched in #715. This does not work: the rebuild swaps in a container whose sort flag is already false and whose offsets have been swapped away entirely, so the flag is false by the time `clear()` sees it and the next sort reallocates rather than merely refilling.

### PR-review checklist

Mandatory:

- [x] I have run the test suite and made sure that it passed.
- [x] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [x] I have added all relevant user documentation to Sphinx.
- [x] I have added all relevant APIs to the doxygen documentation.
- [x] I have added appropriate labels to this PR.
- [x] I have added/revised proper licensing and copyright information.
- [x] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [ ] I have run clang-tidy and fixed all reported errors.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).

---

**Verification performed while preparing this PR** (recorded here for the reviewer; the checklist above is left for the author):

- `Exec/Tests/ItoKMC/JSON`, 20 steps, clean-built both sides, at **2 and 4 ranks**: `h5diff -c` reports zero differences on all ten plot files. The change is exactly neutral in floating-point terms — an empty deposit adds identically zero and the dropped sweeps only touch unread ghost cells — so dataset-identical output is the right bar rather than a tolerance. This test exercises both branches of the early-out: its only photoionization is `Y + (O2) -> e + O2+`, so the CDR species `O2+` deposits while the CDR species `N2+` is skipped every step.
- Built with `DEBUG=TRUE OPT=TRUE`, so `CH_assert` is live (it is compiled out under `OPT=HIGH`): `adoptCellSort()`'s `checkCellSort()` assertion held for every rebuild site and for the merge-container adopt.
- 3-D MPI `OPT=HIGH` builds clean and runs 5 steps on 4 ranks with no NaNs.
- `pre-commit` passes clang-format, reuse, codespell, cppcheck and the doxygen hook. No `.. literalinclude::` directive references any of the touched files, so the shifted line numbers are inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
