### PR TITLE
Cut the per-super-particle cost of the whole-patch kd merges

### DIFF
--- a/Source/ItoDiffusion/CD_ItoSolver.cpp
+++ b/Source/ItoDiffusion/CD_ItoSolver.cpp
@@ -21,6 +21,7 @@
 #include <ParmParse.H>
 #include <ParticleIO.H>
 #include <EBCellFactory.H>
+#include <EBISLayout.H>
 
 // Our includes
 #include <CD_ItoSolver.H>
@@ -4687,6 +4688,16 @@ ItoSolver::mergeKDSkinNn(ParticleContainer<ItoMergeParticle>& merge, const Vecto
     return implicitFunction->value(a_pos) < 0.0;
   };
 
+  // See mergeKDImpl() for why the whole-patch kd merges get a per-patch escape hatch from
+  // isPositionValid(), and for why it is the patch grown by one cell that has to be regular.
+  const Vector<EBISLayout>& ebisLayout = m_amr->getEBISLayout(m_realm, m_phase);
+
+  const bool ebGhostCoversHalo = m_amr->getNumberOfEbGhostCells() >= 1;
+
+  auto isPatchRegular = [&ebisLayout, ebGhostCoversHalo](const int a_lvl, const DataIndex& a_din) -> bool {
+    return ebGhostCoversHalo && ebisLayout[a_lvl][a_din].isAllRegular();
+  };
+
   // See mergeNnPairSearch() for the id-allocator rationale.
   constexpr ParticleID rankStride = 1000000000000LL;
   const ParticleID     rankBase   = static_cast<ParticleID>(procID()) * rankStride;
@@ -4748,7 +4759,8 @@ ItoSolver::mergeKDSkinNn(ParticleContainer<ItoMergeParticle>& merge, const Vecto
                                                               kdCombine,
                                                               kdScatter,
                                                               allocateID,
-                                                              isPositionValid);
+                                                              isPositionValid,
+                                                              isPatchRegular);
 
   merge.clearGhostParticles();
 
@@ -4936,6 +4948,24 @@ ItoSolver::mergeKDImpl(ParticleContainer<ItoMergeParticle>& merge,
     return implicitFunction->value(a_pos) < 0.0;
   };
 
+  // Per-patch escape hatch from isPositionValid(). A patch with no cut or covered cell has no solid in
+  // it for a merged particle to land in, so the implicit function -- the expensive term in the commit
+  // loop, evaluated once per super-particle produced -- is skipped there outright rather than evaluated
+  // to a foregone true. Most patches in a discharge geometry are regular, so this removes the large
+  // majority of the evaluations.
+  const Vector<EBISLayout>& ebisLayout = m_amr->getEBISLayout(m_realm, m_phase);
+
+  // isAllRegular() speaks for the EBISBox's whole region, which is the patch grown by AmrMesh.eb_ghost.
+  // The merge asks about the patch grown by ONE cell -- the carve tier can place a particle built from
+  // members that far outside the patch -- so the EBISBox answers the right question only when that
+  // option leaves at least one ghost cell. Checked here rather than assumed: below one, no patch
+  // reports regular and every position is tested exactly as before.
+  const bool ebGhostCoversHalo = m_amr->getNumberOfEbGhostCells() >= 1;
+
+  auto isPatchRegular = [&ebisLayout, ebGhostCoversHalo](const int a_lvl, const DataIndex& a_din) -> bool {
+    return ebGhostCoversHalo && ebisLayout[a_lvl][a_din].isAllRegular();
+  };
+
   // See mergeNnPairSearch() for the id-allocator rationale.
   constexpr ParticleID rankStride = 1000000000000LL;
   const ParticleID     rankBase   = static_cast<ParticleID>(procID()) * rankStride;
@@ -4989,7 +5019,8 @@ ItoSolver::mergeKDImpl(ParticleContainer<ItoMergeParticle>& merge,
                                                              combine,
                                                              scatter,
                                                              allocateID,
-                                                             isPositionValid);
+                                                             isPositionValid,
+                                                             isPatchRegular);
   }
   else {
     ParticleManagement::mergeKDPatch<ItoMergeParticle, Real>(merge,
@@ -5006,7 +5037,8 @@ ItoSolver::mergeKDImpl(ParticleContainer<ItoMergeParticle>& merge,
                                                              combine,
                                                              scatter,
                                                              allocateID,
-                                                             isPositionValid);
+                                                             isPositionValid,
+                                                             isPatchRegular);
   }
 }
 

--- a/Source/Particle/CD_KDParticleMerge.H
+++ b/Source/Particle/CD_KDParticleMerge.H
@@ -184,6 +184,8 @@ kdExchangeByRank(const std::vector<std::vector<T>>& a_sendByRank);
  * @tparam Scatter Callable `(ParticleSoA<P,Traits>&, const MergeParticle<Packed>&) -> void`.
  * @tparam Allocator Callable `() -> ParticleID`, a fresh globally-unique id per committed merge.
  * @tparam PosValid Callable `(const RealVect&) -> bool`; false leaves the group's members untouched.
+ * @tparam PatchRegular Callable `(int a_lvl, const DataIndex& a_din) -> bool`, answering whether that
+ * patch grown by one cell is free of cut and covered cells.
  * @param[in] a_amr AMR mesh -- source of the particle ghost masks and grid layout.
  * @param[in,out] a_particles The real particle container being merged.
  * @param[in,out] a_cellHistogram Caller-owned per-cell scratch (1 component, >= 1 ghost cell, this
@@ -207,6 +209,11 @@ kdExchangeByRank(const std::vector<std::vector<T>>& a_sendByRank);
  * @param[in] a_scatter Per-merged-particle scatter callback.
  * @param[in] a_allocateID Fresh-id allocator.
  * @param[in] a_isPositionValid Position-validity predicate.
+ * @param[in] a_isPatchRegular Per-patch escape hatch for @a a_isPositionValid, asked once per patch.
+ * Where it returns true every position the patch can produce is in the fluid by construction, so the
+ * per-particle predicate -- an implicit-function evaluation, the expensive term in the commit loop --
+ * is skipped outright. It is asked about the patch GROWN BY ONE CELL because the carve's boundary tier
+ * places a particle from members up to one ghost cell outside the patch's own box.
  */
 template <typename P,
           typename Packed,
@@ -215,7 +222,8 @@ template <typename P,
           typename Combine,
           typename Scatter,
           typename Allocator,
-          typename PosValid>
+          typename PosValid,
+          typename PatchRegular>
 inline void
 mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
              EBAMRFAB&                     a_cellHistogram,
@@ -230,7 +238,8 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
              const Combine&                a_combine,
              const Scatter&                a_scatter,
              const Allocator&              a_allocateID,
-             const PosValid&               a_isPositionValid);
+             const PosValid&               a_isPositionValid,
+             const PatchRegular&           a_isPatchRegular);
 
 /**
  * @brief Run one patch-local kd-tree merge over every patch this rank owns.
@@ -256,6 +265,8 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
  * @tparam Scatter Callable `(ParticleSoA<P,Traits>&, const MergeParticle<Packed>&) -> void`.
  * @tparam Allocator Callable `() -> ParticleID`, a fresh globally-unique id per committed merge.
  * @tparam PosValid Callable `(const RealVect&) -> bool`; false leaves the leaf's members untouched.
+ * @tparam PatchRegular Callable `(int a_lvl, const DataIndex& a_din) -> bool`, answering whether that
+ * patch grown by one cell is free of cut and covered cells.
  * @param[in,out] a_particles The real particle container being merged.
  * @param[in,out] a_cellHistogram Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
  * @param[in,out] a_leafQuota Caller-owned per-cell scratch; see mergeKDCarve()'s own docs.
@@ -276,6 +287,11 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
  * @param[in] a_scatter Per-merged-particle scatter callback.
  * @param[in] a_allocateID Fresh-id allocator.
  * @param[in] a_isPositionValid Position-validity predicate.
+ * @param[in] a_isPatchRegular Per-patch escape hatch for @a a_isPositionValid, asked once per patch.
+ * Where it returns true every position the patch can produce is in the fluid by construction, so the
+ * per-particle predicate -- an implicit-function evaluation, the expensive term in the commit loop --
+ * is skipped outright. It is asked about the patch GROWN BY ONE CELL because the carve's boundary tier
+ * places a particle from members up to one ghost cell outside the patch's own box.
  */
 template <typename P,
           typename Packed,
@@ -284,7 +300,8 @@ template <typename P,
           typename Combine,
           typename Scatter,
           typename Allocator,
-          typename PosValid>
+          typename PosValid,
+          typename PatchRegular>
 inline void
 mergeKDPatch(ParticleContainer<P, Traits>& a_particles,
              EBAMRFAB&                     a_cellHistogram,
@@ -299,7 +316,8 @@ mergeKDPatch(ParticleContainer<P, Traits>& a_particles,
              const Combine&                a_combine,
              const Scatter&                a_scatter,
              const Allocator&              a_allocateID,
-             const PosValid&               a_isPositionValid);
+             const PosValid&               a_isPositionValid,
+             const PatchRegular&           a_isPatchRegular);
 
 /**
  * @brief Run the uncontested tier of the kd merge, splitting the input into merged and leftover.
@@ -331,6 +349,8 @@ mergeKDPatch(ParticleContainer<P, Traits>& a_particles,
  * @tparam Scatter Callable `(ParticleSoA<P,Traits>&, const MergeParticle<Packed>&) -> void`.
  * @tparam Allocator Callable `() -> ParticleID`, a fresh globally-unique id per committed merge.
  * @tparam PosValid Callable `(const RealVect&) -> bool`; false leaves the leaf's members untouched.
+ * @tparam PatchRegular Callable `(int a_lvl, const DataIndex& a_din) -> bool`, answering whether that
+ * patch grown by one cell is free of cut and covered cells.
  * @param[in,out] a_particles Particles to reduce. On return holds only what was not committed.
  * @param[in,out] a_interior Receives one super-particle per committed leaf. Must be allocated on the
  * same realm as @a a_particles, since a leaf is written to the patch it was built on.
@@ -353,6 +373,11 @@ mergeKDPatch(ParticleContainer<P, Traits>& a_particles,
  * @param[in] a_scatter Per-merged-particle scatter callback.
  * @param[in] a_allocateID Fresh-id allocator.
  * @param[in] a_isPositionValid Position-validity predicate.
+ * @param[in] a_isPatchRegular Per-patch escape hatch for @a a_isPositionValid, asked once per patch.
+ * Where it returns true every position the patch can produce is in the fluid by construction, so the
+ * per-particle predicate -- an implicit-function evaluation, the expensive term in the commit loop --
+ * is skipped outright. It is asked about the patch GROWN BY ONE CELL because the carve's boundary tier
+ * places a particle from members up to one ghost cell outside the patch's own box.
  */
 template <typename P,
           typename Packed,
@@ -361,7 +386,8 @@ template <typename P,
           typename Combine,
           typename Scatter,
           typename Allocator,
-          typename PosValid>
+          typename PosValid,
+          typename PatchRegular>
 inline void
 mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
                 ParticleContainer<P, Traits>& a_interior,
@@ -377,7 +403,8 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
                 const Combine&                a_combine,
                 const Scatter&                a_scatter,
                 const Allocator&              a_allocateID,
-                const PosValid&               a_isPositionValid);
+                const PosValid&               a_isPositionValid,
+                const PatchRegular&           a_isPatchRegular);
 
 } // namespace ParticleManagement
 

--- a/Source/Particle/CD_KDParticleMergeImplem.H
+++ b/Source/Particle/CD_KDParticleMergeImplem.H
@@ -764,7 +764,9 @@ kdCheckCentroid(const RealVect& a_centroid,
  * @param[in] a_boxLo       Low corner of the leaf's bounding box.
  * @param[in] a_boxHi       High corner of the leaf's bounding box.
  * @param[in] a_weights     The members' weights, parallel to @a a_positions.
- * @param[in] a_positions   The members' positions, parallel to @a a_weights.
+ * @param[in] a_positions   The members' positions, parallel to @a a_weights. Read only by
+ * KDPlacement::Sample, so callers may leave it empty for the other two placements rather than
+ * filling a vector no branch will look at.
  * @return The position to give the merged particle. Always inside [a_boxLo, a_boxHi].
  */
 template <typename Packed>
@@ -782,6 +784,9 @@ kdPlaceMerged(const KDPlacement            a_placement,
     return a_centroid;
   }
   case KDPlacement::Sample: {
+    // This is the one branch that reads a_positions, so it is also the one that needs it filled.
+    CH_assert(a_positions.size() == a_weights.size());
+
     // Inverse-CDF draw over the members' weights: member i is picked with probability w_i / W.
     const Real threshold = Random::getUniformReal01() * a_totalWeight;
 
@@ -821,7 +826,8 @@ template <typename P,
           typename Combine,
           typename Scatter,
           typename Allocator,
-          typename PosValid>
+          typename PosValid,
+          typename PatchRegular>
 inline void
 mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
              EBAMRFAB&                     a_cellHistogram,
@@ -836,7 +842,8 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
              const Combine&                a_combine,
              const Scatter&                a_scatter,
              const Allocator&              a_allocateID,
-             const PosValid&               a_isPositionValid)
+             const PosValid&               a_isPositionValid,
+             const PatchRegular&           a_isPatchRegular)
 {
   using namespace detail;
 
@@ -1014,6 +1021,18 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
   std::vector<KDLeaf>   leaves;
   std::vector<KDMember> members;
 
+  // Commit scratch, hoisted for the same reason and cleared per committed leaf. Declared per leaf
+  // these cost a malloc/free apiece every time a leaf commits, and a leaf commits about as often as
+  // a super-particle is produced -- the busiest count in the whole merge. The interior tier below and
+  // the boundary tier further down are never live at the same time, so both share these.
+  std::vector<Packed>   payloads;
+  std::vector<Real>     weights;
+  std::vector<RealVect> positions;
+
+  // Only KDPlacement::Sample reads the members' positions; filling them for the other placements is a
+  // store per member per leaf that nothing goes on to read.
+  const bool needPositions = (a_placement == KDPlacement::Sample);
+
   // Which cells hold a particle that some other box can also see. Read from the realm, which derives it
   // from the three ghost masks when they are built; see Realm::m_particleGhostExposure.
   const AMRMask& exposure = a_amr.getParticleGhostExposure(realm, 1);
@@ -1037,6 +1056,16 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
       const DataIndex& din = dit[mybox];
 
       ParticleSoA<P, Traits>& leaf = a_particles[lvl][din];
+
+      // Asked once per patch, then short-circuited into every position test below. Where the patch holds
+      // no cut or covered cell there is no solid for a merged particle to land in, and the implicit
+      // function evaluation -- the expensive term in the commit loop, paid once per super-particle -- is
+      // skipped entirely rather than evaluated to a foregone conclusion.
+      const bool patchRegular = a_isPatchRegular(lvl, din);
+
+      const auto positionValid = [&](const RealVect& a_pos) -> bool {
+        return patchRegular || a_isPositionValid(a_pos);
+      };
 
       const BaseFab<bool>& exposureDin = (*exposure[lvl])[din];
 
@@ -1094,7 +1123,7 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
           }
         }
 
-        kdCapCellWeights(combined, cellCounts, cellWeights, a_ppc, a_splitPlacement, probLo, dx, a_isPositionValid);
+        kdCapCellWeights(combined, cellCounts, cellWeights, a_ppc, a_splitPlacement, probLo, dx, positionValid);
       }
 
       buildKDQuotaLeaves(combined, quota, leaves, a_ppc, a_weightMedianCellWidths, dx, probLo, cellCounts);
@@ -1197,15 +1226,19 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
           // boundary-candidate branch below instead (rather than committing) is what lets a real
           // self-claim be raised for that foreign member, so the argmin actually arbitrates it.
           if (bl.hi - bl.lo >= 2) {
-            std::vector<Packed>   payloads;
-            std::vector<Real>     weights;
-            std::vector<RealVect> positions;
-            RealVect              centroid = RealVect::Zero;
-            Real                  totalW   = 0.0;
+            RealVect centroid = RealVect::Zero;
+            Real     totalW   = 0.0;
+
+            payloads.clear();
+            weights.clear();
+            positions.clear();
 
             payloads.reserve(bl.hi - bl.lo);
             weights.reserve(bl.hi - bl.lo);
-            positions.reserve(bl.hi - bl.lo);
+
+            if (needPositions) {
+              positions.reserve(bl.hi - bl.lo);
+            }
 
             for (std::size_t idx = bl.lo; idx < bl.hi; idx++) {
               const MergeParticle<Packed>& p = combined[idx];
@@ -1214,7 +1247,11 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
 
               payloads.push_back(p.payload);
               weights.push_back(p.weight);
-              positions.push_back(p.position);
+
+              if (needPositions) {
+                positions.push_back(p.position);
+              }
+
               centroid += p.weight * p.position;
               totalW += p.weight;
             }
@@ -1226,14 +1263,22 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
             // The placement can move the particle off the centroid, but never out of the leaf's own
             // box, so the EB test below still has something inside the leaf to judge. A placement
             // that lands in the solid falls back to the centroid rather than losing the leaf.
+            //
+            // The fallback is nested inside the first test rather than sequenced after it so that an
+            // accepted position costs ONE predicate call. the predicate evaluates the geometry's
+            // implicit function, which is the expensive term here, and it is paid once per committed
+            // leaf -- i.e. once per super-particle produced.
             RealVect
               placed = kdPlaceMerged<Packed>(a_placement, centroid, totalW, bl.boxLo, bl.boxHi, weights, positions);
 
-            if (!a_isPositionValid(placed)) {
-              placed = centroid;
+            bool placedValid = positionValid(placed);
+
+            if (!placedValid && placed != centroid) {
+              placed      = centroid;
+              placedValid = positionValid(placed);
             }
 
-            if (a_isPositionValid(placed)) {
+            if (placedValid) {
               MergeParticle<Packed> merged;
 
               merged.position  = placed;
@@ -1566,23 +1611,32 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
     bool committed = false;
 
     if (totalSurvivors >= 2) {
-      std::vector<Packed>   payloads;
-      std::vector<Real>     weights;
-      std::vector<RealVect> positions;
-      RealVect              centroid = RealVect::Zero;
-      Real                  totalW   = 0.0;
-      RealVect              surviveBoxLo, surviveBoxHi;
-      bool                  haveSurviveBox = false;
+      RealVect centroid = RealVect::Zero;
+      Real     totalW   = 0.0;
+      RealVect surviveBoxLo, surviveBoxHi;
+      bool     haveSurviveBox = false;
+
+      payloads.clear();
+      weights.clear();
+      positions.clear();
 
       payloads.reserve(totalSurvivors);
       weights.reserve(totalSurvivors);
+
+      if (needPositions) {
+        positions.reserve(totalSurvivors);
+      }
 
       auto accumulate = [&](const ParticleID a_id) {
         const MergeParticle<Packed>& p = findParticle(a_id);
 
         payloads.push_back(p.payload);
         weights.push_back(p.weight);
-        positions.push_back(p.position);
+
+        if (needPositions) {
+          positions.push_back(p.position);
+        }
+
         centroid += p.weight * p.position;
         totalW += p.weight;
 
@@ -1611,16 +1665,26 @@ mergeKDCarve(ParticleContainer<P, Traits>& a_particles,
 
       kdCheckCentroid(centroid, totalW, surviveBoxLo, surviveBoxHi);
 
-      // Same placement rule as the interior tier -- the box here is the surviving members' own, since
-      // the carve may have taken some of the leaf's original members away.
+      // Same placement rule as the interior tier, fallback nested for the same reason -- one predicate
+      // call whenever the placed position is accepted. The box here is the surviving members' own,
+      // since the carve may have taken some of the leaf's original members away.
       RealVect
         placed = kdPlaceMerged<Packed>(a_placement, centroid, totalW, surviveBoxLo, surviveBoxHi, weights, positions);
 
-      if (!a_isPositionValid(placed)) {
-        placed = centroid;
+      // Same per-patch escape hatch as the interior tier, asked of the patch this box belongs to. This
+      // tier is the reason a_isPatchRegular is defined over the patch GROWN BY ONE CELL: surviveBox is
+      // built from surviving members that may be foreign, and a foreign member sits up to one ghost
+      // cell outside box.patchIdx's own box.
+      const PatchWork& boxPatch = patchWork[box.patchIdx];
+
+      bool placedValid = a_isPatchRegular(boxPatch.level, boxPatch.din) || a_isPositionValid(placed);
+
+      if (!placedValid && placed != centroid) {
+        placed      = centroid;
+        placedValid = a_isPositionValid(placed);
       }
 
-      if (a_isPositionValid(placed)) {
+      if (placedValid) {
         committed = true;
 
         MergeParticle<Packed> merged;
@@ -1778,7 +1842,8 @@ template <typename P,
           typename Combine,
           typename Scatter,
           typename Allocator,
-          typename PosValid>
+          typename PosValid,
+          typename PatchRegular>
 inline void
 mergeKDPatch(ParticleContainer<P, Traits>& a_particles,
              EBAMRFAB&                     a_cellHistogram,
@@ -1793,7 +1858,8 @@ mergeKDPatch(ParticleContainer<P, Traits>& a_particles,
              const Combine&                a_combine,
              const Scatter&                a_scatter,
              const Allocator&              a_allocateID,
-             const PosValid&               a_isPositionValid)
+             const PosValid&               a_isPositionValid,
+             const PatchRegular&           a_isPatchRegular)
 {
   // The patch-local merge is the ghost-free case of mergeKDInterior() writing back into its own
   // container, so it delegates rather than repeating the body.
@@ -1817,7 +1883,8 @@ mergeKDPatch(ParticleContainer<P, Traits>& a_particles,
                                      a_combine,
                                      a_scatter,
                                      a_allocateID,
-                                     a_isPositionValid);
+                                     a_isPositionValid,
+                                     a_isPatchRegular);
 }
 
 template <typename P,
@@ -1827,7 +1894,8 @@ template <typename P,
           typename Combine,
           typename Scatter,
           typename Allocator,
-          typename PosValid>
+          typename PosValid,
+          typename PatchRegular>
 inline void
 mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
                 ParticleContainer<P, Traits>& a_interior,
@@ -1843,7 +1911,8 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
                 const Combine&                a_combine,
                 const Scatter&                a_scatter,
                 const Allocator&              a_allocateID,
-                const PosValid&               a_isPositionValid)
+                const PosValid&               a_isPositionValid,
+                const PatchRegular&           a_isPatchRegular)
 {
   using namespace detail;
 
@@ -1877,6 +1946,17 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
   // earlier patches instead of starting from nothing.
   std::vector<KDLeaf> leaves;
 
+  // Commit scratch, hoisted for the same reason and cleared per committed leaf. Declared per leaf
+  // these cost a malloc/free apiece every time a leaf commits, and a leaf commits about as often as
+  // a super-particle is produced -- the busiest count in the whole merge.
+  std::vector<Packed>   payloads;
+  std::vector<Real>     weights;
+  std::vector<RealVect> positions;
+
+  // Only KDPlacement::Sample reads the members' positions; filling them for the other placements is a
+  // store per member per leaf that nothing goes on to read.
+  const bool needPositions = (a_placement == KDPlacement::Sample);
+
   for (int lvl = 0; lvl <= finestLevel; lvl++) {
     const DisjointBoxLayout& dbl = a_amr.getGrids(realm)[lvl];
     const DataIterator&      dit = dbl.dataIterator();
@@ -1891,6 +1971,16 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
       const DataIndex& din = dit[mybox];
 
       ParticleSoA<P, Traits>& leaf = a_particles[lvl][din];
+
+      // Asked once per patch, then short-circuited into every position test below. Where the patch holds
+      // no cut or covered cell there is no solid for a merged particle to land in, and the implicit
+      // function evaluation -- the expensive term in the commit loop, paid once per super-particle -- is
+      // skipped entirely rather than evaluated to a foregone conclusion.
+      const bool patchRegular = a_isPatchRegular(lvl, din);
+
+      const auto positionValid = [&](const RealVect& a_pos) -> bool {
+        return patchRegular || a_isPositionValid(a_pos);
+      };
 
       // Ghosts ARE gathered, unlike mergeKDPatch(). They are never merged here, but they must take
       // part in the partition: a ghost is what marks the leaf it lands in as contested, and the
@@ -1941,7 +2031,7 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
           }
         }
 
-        kdCapCellWeights(combined, cellCounts, cellWeights, a_ppc, a_splitPlacement, probLo, dx, a_isPositionValid);
+        kdCapCellWeights(combined, cellCounts, cellWeights, a_ppc, a_splitPlacement, probLo, dx, positionValid);
       }
 
       buildKDQuotaLeaves(combined, quota, leaves, a_ppc, a_weightMedianCellWidths, dx, probLo, cellCounts);
@@ -1979,15 +2069,19 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
           continue;
         }
 
-        std::vector<Packed>   payloads;
-        std::vector<Real>     weights;
-        std::vector<RealVect> positions;
-        RealVect              centroid = RealVect::Zero;
-        Real                  totalW   = 0.0;
+        RealVect centroid = RealVect::Zero;
+        Real     totalW   = 0.0;
+
+        payloads.clear();
+        weights.clear();
+        positions.clear();
 
         payloads.reserve(bl.hi - bl.lo);
         weights.reserve(bl.hi - bl.lo);
-        positions.reserve(bl.hi - bl.lo);
+
+        if (needPositions) {
+          positions.reserve(bl.hi - bl.lo);
+        }
 
         for (std::size_t idx = bl.lo; idx < bl.hi; idx++) {
           const MergeParticle<Packed>& p = combined[idx];
@@ -1998,7 +2092,11 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
 
           payloads.push_back(p.payload);
           weights.push_back(p.weight);
-          positions.push_back(p.position);
+
+          if (needPositions) {
+            positions.push_back(p.position);
+          }
+
           centroid += p.weight * p.position;
           totalW += p.weight;
         }
@@ -2007,14 +2105,23 @@ mergeKDInterior(ParticleContainer<P, Traits>& a_particles,
 
         kdCheckCentroid(centroid, totalW, bl.boxLo, bl.boxHi);
 
+        // A placement that lands in the solid falls back to the centroid rather than losing the leaf.
+        // The fallback is nested inside the first test rather than sequenced after it so that an
+        // accepted position costs ONE predicate call. the predicate evaluates the geometry's
+        // implicit function, which is the expensive term here, and it is paid once per committed leaf
+        // -- i.e. once per super-particle produced.
         RealVect placed = kdPlaceMerged<Packed>(a_placement, centroid, totalW, bl.boxLo, bl.boxHi, weights, positions);
 
-        if (!a_isPositionValid(placed)) {
-          placed = centroid;
-        }
+        if (!positionValid(placed)) {
+          if (placed == centroid) {
+            continue;
+          }
 
-        if (!a_isPositionValid(placed)) {
-          continue;
+          placed = centroid;
+
+          if (!positionValid(placed)) {
+            continue;
+          }
         }
 
         MergeParticle<Packed> merged;


### PR DESCRIPTION
# Summary

Cuts the per-super-particle cost of the whole-patch kd merges (`kd_patch`, `kd_amr`). No intended
change in results.

### Background

`mergeKDCarve()`/`mergeKDInterior()` commit a leaf once per super-particle produced, which makes the
commit loop the busiest loop in the merge. Three things it did per committed leaf were avoidable:

1. **The EB position test ran twice.** `kdPlaceMerged()` returns the centroid unchanged under
   `kd_placement = centroid` (the default), so the centroid fallback was a no-op that re-tested a point
   the previous line had already tested. Both calls evaluate the geometry's implicit function, which is
   the expensive term in this loop.
2. **A patch with no cut or covered cell was tested anyway.** There is no solid in such a patch for a
   merged particle to land in, so the implicit function could only ever return true there.
3. **`payloads`/`weights`/`positions` were declared inside the leaf loop,** costing a malloc/free apiece
   every time a leaf committed. `positions` was also filled unconditionally despite being read only by
   `kd_placement = sample`.

### Solution

Nest the centroid fallback inside the first validity test, so an accepted position costs one predicate
call instead of two.

Add an `isPatchRegular` callback to `mergeKDCarve()`/`mergeKDPatch()`/`mergeKDInterior()`, asked once per
patch and short-circuited into every position test. The merge knows the patch but not the phase; the
solver knows the phase but not which patch a point predicate is being asked about, so a per-patch
callback is the minimal thing that joins them. `ItoSolver` answers it from the realm's `EBISLayout`,
whose `isAllRegular()` is a cached flag on the `EBGraph`.

The callback is defined over the patch **grown by one cell**, because the carve's boundary tier places a
particle built from members up to one ghost cell outside the patch. `EBISBox::isAllRegular()` speaks for
the patch grown by `AmrMesh.eb_ghost`, so the caller confirms that option reaches at least one cell
rather than assuming it; below one, no patch reports regular and every position is tested as before.

Hoist the commit scratch next to the existing `leaves`/`members` scratch and `clear()` it per leaf, so
capacity carries across leaves and patches. Fill `positions` only for `kd_placement = sample`;
`kdPlaceMerged()` now documents that it may be empty otherwise and asserts the pairing in the branch
that reads it. The carve boundary tier was also missing the `positions.reserve()` its interior tier had.

### Side-effects

**API.** `mergeKDCarve()`, `mergeKDPatch()` and `mergeKDInterior()` take one more template parameter
(`PatchRegular`) and one more argument (`a_isPatchRegular`). All three call sites in `ItoSolver` are
updated: two in `mergeKDImpl()` and one in `mergeKDSkinNn()`. No new types, structs, containers or maps
are introduced — `PatchRegular` is a template parameter, and the callback is a lambda at each call site.

**Bit-identity.** The fallback nesting and the scratch hoisting are bit-identical by construction: the
same values are accumulated in the same order, the predicate is pure so dropping a redundant call has no
side effect, and RNG draws are untouched (`Random::getUniformReal01()` appears only in `kdPlaceMerged()`
and `kdSplitDisplace()`, both invoked unconditionally before any validity test).

Skipping the predicate on regular patches is bit-identical **iff** EBIS regularity agrees with the sign
of the implicit function — the assumption the EB discretization already rests on. It would diverge only
for a solid feature small enough that EBIS resolves no irregular cell for it, in which case a leaf that
was previously rejected now commits. That would not be a subtle difference: the newly committed leaf also
consumes an `a_allocateID()`, shifting every subsequent id on the rank and changing particle population
and ordering, so a benchmark comparison would show it loudly.

**Testing status.** This branch compiles clean (`Exec/Examples/ItoKMC/AirBasic`, DIM=2, MPI, HDF5,
OPT=HIGH, no warnings in the touched files). The regression suite has **not** been run and no benchmark
comparison has been made, so the bit-identity argument above is static reasoning only.

**Unrelated finding, not addressed here.** `kd_partition = weight` maps to a crossover of
`Real::max()`, which makes `kdSplitWeightMedian()` — a full `std::sort` — run at every node of the tree
rather than only at sub-cell-width nodes, taking `buildKDQuotaLeaves()` from O(N log N) to O(N log²N).
`kd_partition = count` and `hybrid` are unaffected. A weighted selection would remove it; that is a
separate change.

### Alternative solutions

**Bake regularity into `isPositionValid` in the solver.** Rejected: the predicate is a point function and
cannot tell which patch it is being called from, so it would have to re-derive the patch from the
position — work the merge algorithm has already done.

**Give `ItoSolver` a private `isPatchAllRegular()` member** instead of repeating the small lambda in
`mergeKDImpl()` and `mergeKDSkinNn()`. Rejected in favour of the existing house pattern of a short
cross-reference comment (as `mergeNnPairSearch()`'s id-allocator rationale already does), which adds no
new class surface.

**Hoist the `patchRegular` branch out of the commit loop** by specializing the loop. Rejected: it is a
perfectly predicted branch on a loop-invariant bool, and duplicating the commit loop to remove it is not
worth the divergence risk.

**Replace `std::sort` in `kdSplitWeightMedian()` with a weighted selection.** Out of scope here; see the
note under Side-effects.

### PR-review checklist

Mandatory:

- [ ] I have run the test suite and made sure that it passed.
- [ ] I have run CheckDocs.py and fixed potentially broken literalincludes.
- [ ] I have added all relevant user documentation to Sphinx.
- [ ] I have added all relevant APIs to the doxygen documentation.
- [ ] I have added appropriate labels to this PR.
- [ ] I have added/revised proper licensing and copyright information.
- [ ] I have run a PR review using `@claude review`.

Optional:

- [ ] I have run valgrind to make sure that this PR does not cause memory leaks. 
- [ ] I have run clang-tidy and fixed all reported errors.
- [ ] I have made sure that this PR does not change benchmark files (unless it is intended to do so).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jtr7vNPRQMyVgCY2QZFKMJ
